### PR TITLE
Fix configuration for unsupported userAuthentication and strongBox usage

### DIFF
--- a/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet-config/configure-document-key-creation.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet-config/configure-document-key-creation.md
@@ -17,6 +17,13 @@ values are used to create the eu.europa.ec.eudi.wallet.document.CreateDocumentSe
 using [eu.europa.ec.eudi.wallet.document.DocumentExtensions.getDefaultCreateDocumentSettings](../../eu.europa.ec.eudi.wallet.document/-document-extensions/get-default-create-document-settings.md)
 method.
 
+If user authentication is required, the user authentication timeout must be greater than 0.
+
+**Note**: when setting userAuthenticationRequired to true, device must be secured with a PIN,
+pattern or password.
+
+**Note**: when setting useStrongBoxForKeys to true, the device must support the StrongBox.
+
 The default values are:
 
 -
@@ -24,7 +31,7 @@ userAuthenticationRequired: false
 -
 userAuthenticationTimeout: 0
 -
-useStrongBoxForKeys: true
+useStrongBoxForKeys: true if supported by the device
 
 #### Parameters
 

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet/-builder/build.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet/-builder/build.md
@@ -7,12 +7,42 @@ fun [build](build.md)(): [EudiWallet](../index.md)
 
 Build the [EudiWallet](../index.md) instance
 
+The [EudiWallet](../index.md) instance will be created based on the configuration provided in
+the [Builder](index.md) class.
+
+The [EudiWallet](../index.md) instance will be created with the following default implementations if
+not set:
+
+-
+AndroidStorageEngine for storing/retrieving documents
+-
+AndroidKeystoreSecureArea for managing documents' keys
+-
+DocumentManagerImpl for managing documents
+-
+[PresentationManagerImpl](../../../eu.europa.ec.eudi.wallet.presentation/-presentation-manager-impl/index.md)
+for both proximity and remote presentation
+-
+[OpenId4VpManager](../../../eu.europa.ec.eudi.wallet.transfer.openId4vp/-open-id4-vp-manager/index.md)
+for remote presentation
+-
+TransferManagerImpl for proximity presentation
+
+**Note**:
+The [EudiWalletConfig.documentsStorageDir](../../-eudi-wallet-config/documents-storage-dir.md) is
+not set, the default storage directory will be used which is the application's no backup files
+directory.
+
+**Note**:
+The [EudiWalletConfig.userAuthenticationRequired](../../-eudi-wallet-config/user-authentication-required.md)
+is set to true and the device is not secured with a PIN, pattern, or password, the configuration
+will be updated to set the user authentication required to false.
+
+**Note**:
+The [EudiWalletConfig.useStrongBoxForKeys](../../-eudi-wallet-config/use-strong-box-for-keys.md) is
+set to true and the device does not support StrongBox, the configuration will be updated to set the
+use StrongBox for keys to false.
+
 #### Return
 
 [EudiWallet](../index.md)
-
-#### Throws
-
-|                                                                                                                  |                                                                                                                                                                  |
-|------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html) | if [EudiWalletConfig.documentsStorageDir](../../-eudi-wallet-config/documents-storage-dir.md) is not set and and the default DocumentManager is going to be used |

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml,build/reports/jacoco/testReleaseUnitTestCoverage/testReleaseUnitTestCoverage.xml
 systemProp.sonar.projectName=eudi-lib-android-wallet-core
-VERSION_NAME=0.12.0
+VERSION_NAME=0.12.1-SNAPSHOT
 
 SONATYPE_HOST=S01
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/licenses.md
+++ b/licenses.md
@@ -2,7 +2,7 @@
 # EUDI Wallet Core library for Android
 ## Dependency License Report
 
-_2024-11-20 17:38:59 EET_
+_2024-11-22 13:51:07 EET_
 ## Apache License, Version 2.0
 
 **1** **Group:** `androidx.appcompat` **Name:** `appcompat` **Version:** `1.6.1` 

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -106,50 +106,40 @@ android {
 
 dependencies {
 
-    implementation(libs.appcompat)
-
     // EUDI libs
     api(libs.eudi.document.manager)
     api(libs.eudi.iso18013.data.transfer)
-
-    // OpenID4VCI
-    implementation(libs.eudi.lib.jvm.openid4vci.kt)
-    implementation(libs.nimbus.oauth2.oidc.sdk)
-
-    // Siop-Openid4VP library
-    implementation(libs.eudi.lib.jvm.siop.openid4vp.kt) {
-        exclude(group = "org.bouncycastle")
-    }
-
     // Identity android library
     api(libs.google.identity.android) {
         exclude(group = "org.bouncycastle")
     }
 
+    implementation(libs.appcompat)
+    // OpenID4VCI
+    implementation(libs.eudi.lib.jvm.openid4vci.kt)
+    implementation(libs.nimbus.oauth2.oidc.sdk)
+    // Siop-Openid4VP library
+    implementation(libs.eudi.lib.jvm.siop.openid4vp.kt) {
+        exclude(group = "org.bouncycastle")
+    }
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.io.core)
     implementation(libs.kotlinx.io.bytestring)
-
     // CBOR
     implementation(libs.cbor)
-
-    testImplementation(libs.testng)
-
+    implementation(libs.upokecenter.cbor)
+    implementation(libs.cose.java)
     // Ktor Android Engine
-    runtimeOnly(libs.ktor.client.android)
     implementation(libs.ktor.client.logging)
-
     // Bouncy Castle
     implementation(libs.bouncy.castle.prov)
     implementation(libs.bouncy.castle.pkix)
 
-    implementation(libs.upokecenter.cbor)
-    implementation(libs.cose.java)
+    runtimeOnly(libs.ktor.client.android)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.mockk)
     testImplementation(libs.json)
-    testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.biometric.ktx)
 

--- a/wallet-core/src/androidTest/java/eu/europa/ec/eudi/wallet/EudiWalletTest.kt
+++ b/wallet-core/src/androidTest/java/eu/europa/ec/eudi/wallet/EudiWalletTest.kt
@@ -54,8 +54,9 @@ class EudiWalletTest {
     fun testLoadSampleDocuments() {
         walletConfig = EudiWalletConfig()
             .configureDocumentKeyCreation(
-                userAuthenticationRequired = false,
-                useStrongBoxForKeys = false,
+                userAuthenticationRequired = true,
+                userAuthenticationTimeout = 30_000L,
+                useStrongBoxForKeys = true,
             )
 
         val result = wallet.loadMdocSampleDocuments(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -299,11 +299,11 @@ class EudiWalletConfig {
     }
 
     var userAuthenticationRequired: Boolean = false
-        private set
+        internal set // internal for setting the default value from the builder
     var userAuthenticationTimeout: Long = 0L
         private set
     var useStrongBoxForKeys: Boolean = true
-        private set
+        internal set // internal for setting the default value from the builder
 
     /**
      * Configure the document key creation. This allows to configure if user authentication is
@@ -313,10 +313,17 @@ class EudiWalletConfig {
      * using [eu.europa.ec.eudi.wallet.document.DocumentExtensions.getDefaultCreateDocumentSettings]
      * method.
      *
+     * If user authentication is required, the user authentication timeout must be greater than 0.
+     *
+     * **Note**: when setting userAuthenticationRequired to true, device must be secured with a PIN, pattern
+     * or password.
+     *
+     * **Note**: when setting useStrongBoxForKeys to true, the device must support the StrongBox.
+     *
      * The default values are:
      * - userAuthenticationRequired: false
      * - userAuthenticationTimeout: 0
-     * - useStrongBoxForKeys: true
+     * - useStrongBoxForKeys: true if supported by the device
      *
      * @param userAuthenticationRequired whether user authentication is required
      * @param userAuthenticationTimeout the user authentication timeout. If user authentication

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/internal/Extensions.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/internal/Extensions.kt
@@ -1,31 +1,25 @@
 /*
- *  Copyright (c) 2023-2024 European Commission
+ * Copyright (c) 2023-2024 European Commission
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package eu.europa.ec.eudi.wallet.internal
 
-import COSE.OneKey
 import android.content.Context
-import android.content.pm.PackageManager.GET_META_DATA
 import android.os.Build
 import androidx.annotation.RawRes
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.runBlocking
-import org.bouncycastle.util.encoders.Hex
-import java.net.URI
-import java.security.PublicKey
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.concurrent.Executor
@@ -46,39 +40,3 @@ internal fun Context.mainExecutor(): Executor {
         ContextCompat.getMainExecutor(applicationContext)
     }
 }
-
-@JvmSynthetic
-internal fun Context.executeOnMain(block: suspend () -> Unit) {
-    mainExecutor().execute {
-        runBlocking { block() }
-    }
-}
-
-@get:JvmSynthetic
-@get:Suppress("DEPRECATION")
-/**
- * Keep deprecation for Xiaomi compatibility
- */
-internal val Context.openId4VciAuthorizationRedirectUri: URI
-    get() = with(
-        packageManager.getApplicationInfo(packageName, GET_META_DATA).metaData
-    ) {
-        URI.create(
-            getString("openid4vciAuthorizeScheme", "https") + "://"
-                    + getString("openid4vciAuthorizeHost", "localhost")
-                    + getString("openid4vciAuthorizePath", "/authorize")
-        )
-
-    }
-
-@get:JvmSynthetic
-internal val PublicKey.cose: OneKey
-    get() = OneKey(this, null)
-
-@get:JvmSynthetic
-internal val PublicKey.coseBytes: String
-    get() = Hex.toHexString(cose.EncodeToBytes())
-
-@get:JvmSynthetic
-internal val PublicKey.coseDebug: String
-    get() = cose.AsCBOR().ToJSONString()

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderDeviceCapabilitiesTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderDeviceCapabilitiesTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet
+
+import android.content.Context
+import eu.europa.ec.eudi.wallet.logging.Logger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(value = Parameterized::class)
+class EudiWalletBuilderDeviceCapabilitiesTest(
+    private val configUserAuthenticationRequired: Boolean,
+    private val configUseStrongBoxForKeys: Boolean,
+    private val deviceSecureLockScreenSetup: Boolean,
+    private val deviceStrongBoxSupported: Boolean,
+    private val expectedUserAuthenticationRequired: Boolean,
+    private val expectedUseStrongBoxForKeys: Boolean,
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: config(ua={0},sb={1}), device(ua={2},sb={3}), expected(ua={4},sb={5})")
+        fun data() = arrayListOf(
+            arrayOf(true, true, false, false, false, false),
+            arrayOf(true, true, true, false, true, false),
+            arrayOf(true, true, false, true, false, true),
+            arrayOf(true, true, true, true, true, true),
+            arrayOf(false, false, false, false, false, false),
+            arrayOf(false, false, true, false, false, false),
+            arrayOf(false, false, false, true, false, false),
+            arrayOf(false, false, true, true, false, false),
+        )
+    }
+
+    @Test
+    fun `EudiWalletConfig userAuthenticationRequired and useStrongBoxForKeys should be reverted to false if not supported by device`() {
+        val config = EudiWalletConfig()
+            .configureDocumentKeyCreation(
+                userAuthenticationRequired = configUserAuthenticationRequired,
+                userAuthenticationTimeout = 30_000L,
+                useStrongBoxForKeys = configUseStrongBoxForKeys
+            )
+
+        val context: Context = mockk {
+            every { applicationContext } returns this
+        }
+
+        val builder = spyk(
+            EudiWallet.Builder(context, config)
+                .withLogger(Logger { record ->
+                    println(record.message)
+                })
+        ) {
+            every { capabilities } returns mockk {
+                every { secureLockScreenSetup } returns deviceSecureLockScreenSetup
+                every { strongBoxSupported } returns deviceStrongBoxSupported
+            }
+        }
+
+        builder.ensureUserAuthIsSupported()
+        builder.ensureStrongBoxIsSupported()
+
+        assertEquals(expectedUserAuthenticationRequired, config.userAuthenticationRequired)
+        assertEquals(expectedUseStrongBoxForKeys, config.useStrongBoxForKeys)
+
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderParUsageTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderParUsageTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.issue.openid4vci
+
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.Test
+
+@RunWith(value = Parameterized::class)
+class OpenId4VciManagerConfigBuilderParUsageTest(
+    private val parUsage: Int,
+) {
+
+    @Test
+    fun `ConfigBuilder set the parUsage property correctly`() {
+        val builder = OpenId4VciManager.Config.Builder()
+            .withIssuerUrl("https://issuer.example.com")
+            .withClientId("testClientId")
+            .withAuthFlowRedirectionURI("app://redirect")
+            .withParUsage(parUsage)
+
+        val config = builder.build()
+
+        assertEquals(parUsage, config.parUsage)
+    }
+
+    companion object {
+
+        @Parameterized.Parameters(name = "{index}: parUsage={0}")
+        @JvmStatic
+        fun parUsageArgs() = arrayListOf(
+            OpenId4VciManager.Config.ParUsage.IF_SUPPORTED,
+            OpenId4VciManager.Config.ParUsage.REQUIRED,
+            OpenId4VciManager.Config.ParUsage.NEVER
+        )
+    }
+
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderTest.kt
@@ -20,9 +20,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import kotlin.test.Test
 
 
@@ -99,29 +96,5 @@ class OpenId4VciManagerConfigBuilderTest {
         val config = builder.build()
 
         assertTrue(config.useDPoPIfSupported)
-    }
-
-    @ParameterizedTest(name = "parUsage: {0}")
-    @MethodSource("parUsageArgs")
-    fun `ConfigBuilder set the parUsage property correctly`(parUsage: Int) {
-        val builder = OpenId4VciManager.Config.Builder()
-            .withIssuerUrl("https://issuer.example.com")
-            .withClientId("testClientId")
-            .withAuthFlowRedirectionURI("app://redirect")
-            .withParUsage(parUsage)
-
-        val config = builder.build()
-
-        assertEquals(parUsage, config.parUsage)
-    }
-
-    companion object {
-
-        @JvmStatic
-        fun parUsageArgs() = listOf(
-            OpenId4VciManager.Config.ParUsage.IF_SUPPORTED,
-            OpenId4VciManager.Config.ParUsage.REQUIRED,
-            OpenId4VciManager.Config.ParUsage.NEVER
-        ).map { Arguments.of(it) }
     }
 }


### PR DESCRIPTION
Chagnes: 

- Check userAuthenticationRequired and useStrongBoxForKeys when building EudiWallet and unset if either one is not supported 
Closes #97
- removed unused code
