### PR TITLE
fix encoding of mdoc generated nonce in apu

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpResponse.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpResponse.kt
@@ -90,6 +90,6 @@ private fun constructEncryptedParameters(
     msoMdocNonce: String,
 ): EncryptionParameters? {
     return if (alg in JWEAlgorithm.Family.ECDH_ES) {
-        EncryptionParameters.DiffieHellman(apu = Base64URL.from(msoMdocNonce))
+        EncryptionParameters.DiffieHellman(apu = Base64URL.encode(msoMdocNonce))
     } else null
 }


### PR DESCRIPTION

ISO 18013-7 Annex B states:

> The mdoc shall set the apu JWT (JWE) header parameter to the base64url-encoded-with-no-padding value of the mdocGeneratedNonce of the SessionTranscript as defined in B.4.4.

But this library does not follow that requirement. [Previously](https://github.com/eu-digital-identity-wallet/eudi-lib-android-wallet-core/blob/v0.14.0/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/ProcessedOpenId4VpRequest.kt#L78), the value for `msoMdocNonce` had been base64-url-encoded: `Base64URL.encode(msoMdocNonce)`. [Now](https://github.com/eu-digital-identity-wallet/eudi-lib-android-wallet-core/blame/33ae6ba5c28a5416ac20bd9f8a9ed5a42c3205bc/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpResponse.kt#L93) it is not being encoded: `Base64URL.from(msoMdocNonce)`.

This PR fixes that.