### PR TITLE
SubmitRequest: Fix access to uninitialized lateinit variable.

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
@@ -201,7 +201,7 @@ internal class SubmitRequest(
         val walletAttestationsProvider = checkNotNull(walletAttestationsProvider) {
             "WalletAttestationsProvider is required for attestation based client authentication"
         }
-        lateinit var proofSigner: KeyAttestationSigner
+        var proofSigner: KeyAttestationSigner? = null
         val keyIndex = 0
         val proofsSpecification = ProofsSpecification.JwtProofs.WithKeyAttestation(
             proofSignerProvider = { nonce ->
@@ -216,7 +216,7 @@ internal class SubmitRequest(
             return with(issuer) { request(payload, proofsSpecification) }.getOrThrow()
         } catch (e: Throwable) {
 
-            val isUserAuthRequired = proofSigner.keyLockedException != null
+            val isUserAuthRequired = proofSigner?.keyLockedException != null
             if (isUserAuthRequired) {
                 val keysAndSecureAreas = mapOf(
                     proofSigner.signer.let { it.keyAlias to it.secureArea }


### PR DESCRIPTION
lateinit is read in the catch block, but is not yet initialized on some exception paths. Since isInitialized() is not supported on local lateinit variables, this PR convert it to a nullable type so that we can check for initalization.

Since the BatchProofSigner ctor (obviously) creates a non-null value, it should still be sufficiently clear that null can _only_ arise if the ctor has not yet completed.

Kudos go to @simplekjl for spotting this.