### PR TITLE
Fix DefaultWalletKeyManager thread unsafe initialization.

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/provider/DefaultWalletKeyManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/provider/DefaultWalletKeyManager.kt
@@ -58,6 +58,8 @@ class DefaultWalletKeyManager(
 
     private suspend fun getSecureAreaWalletKeyManager(): SecureAreaWalletKeyManager {
         return secureAreaBased ?: mutex.withLock {
+            // another thread may have initialized secureAreaBased while we were acquiring mutex.
+            secureAreaBased ?.let { return it }
             val storage = AndroidStorage("${context.noBackupFilesDir.path}/wallet-attest.bin")
             val secureArea = AndroidKeystoreSecureArea.create(storage)
 


### PR DESCRIPTION
Because the field wasn't re-checked after acquiring the mutex lock, it's possible that a second thread had already initialized the field concurrently.

Worse, because the field isn't volatile, "concurrently" could have happened an arbitrarily long wall clock time ago, since the current thread isn't guaranteed to see a write to the field until after it acquires mutex.

This commit adds an extra check inside the mutex block in order to prevent this race condition.