### PR TITLE
Fix/update dcapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ file.
 
 ```groovy
 dependencies {
-    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0"
+    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.1"
     // required when using the built-in AndroidKeystoreSecureArea implementation provided by the library
     // for user authentication with biometrics
     implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ android.nonTransitiveRClass=true
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 
-VERSION_NAME=0.26.0
+VERSION_NAME=0.26.1
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/ProcessedDCPAPIRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/ProcessedDCPAPIRequest.kt
@@ -59,7 +59,7 @@ class ProcessedDCPAPIRequest(
     private val logger: Logger? = null,
     val origin: String,
     requestedDocuments: RequestedDocuments
-    ): RequestProcessor.ProcessedRequest.Success(requestedDocuments) {
+): RequestProcessor.ProcessedRequest.Success(requestedDocuments) {
 
     @OptIn(ExperimentalDigitalCredentialApi::class)
     override fun generateResponse(
@@ -122,15 +122,17 @@ class ProcessedDCPAPIRequest(
                 })
             }.EncodeToBytes()
 
-            val responseJson = JSONObject()
-            responseJson.put(RESPONSE, encryptedResponse.toBase64())
-            val response = responseJson.toString()
+            val response = JSONObject()
+            response.put(RESPONSE, encryptedResponse.toBase64())
             logger?.d(TAG, "Response JSON: $response")
 
             return ResponseResult.Success(
                 DCAPIResponse(
                     deviceResponseBytes = deviceResponse.deviceResponseBytes,
-                    intent = createResponseIntent(response),
+                    intent = createResponseIntent(
+                        protocol = protocol,
+                        data = response
+                    ),
                     documentIds = deviceResponse.documentIds
                 )
             )
@@ -146,12 +148,17 @@ class ProcessedDCPAPIRequest(
     }
 
     @OptIn(ExperimentalDigitalCredentialApi::class)
-    private fun createResponseIntent(response: String): Intent {
+    private fun createResponseIntent(protocol: String, data: JSONObject): Intent {
+        val credentialJson = JSONObject().apply {
+            put(PROTOCOL, protocol)
+            put(DATA, data)
+        }
+        logger?.d(TAG, "Credential JSON: $credentialJson")
         val resultData = Intent()
         PendingIntentHandler.setGetCredentialResponse(
             resultData,
             GetCredentialResponse(
-                DigitalCredential(response)
+                DigitalCredential(credentialJson.toString())
             )
         )
         return resultData


### PR DESCRIPTION

Fix: DCAPI add protocol/data envelope to credential response

`createResponseIntent` now builds the {protocol, data: {response}} structure required by the W3C Digital Credentials API, instead of returning the bare {response} payload.