### PR TITLE
Migrate DCAPI to AndroidX Credentials Registry

### DIFF
--- a/DIGITAL_CREDENTIAL_API.md
+++ b/DIGITAL_CREDENTIAL_API.md
@@ -9,6 +9,41 @@ according to the [ISO/IEC TS 18013-7:2025](https://www.iso.org/standard/91154.ht
 
 ## Enabling the Digital Credential API
 
+### Add the runtime dependency
+
+To enable DCAPI, add the following dependency to your app:
+
+```groovy
+dependencies {
+    // Required only if DCAPI is enabled
+    implementation "androidx.credentials.registry:registry-provider-play-services:1.0.0-alpha04"
+}
+```
+
+Without this dependency, DCAPI registration fails at runtime
+with the error `"no provider dependencies found - please ensure the desired provider dependencies are added"`.
+
+#### Why you need to add this dependency
+
+DCAPI registration relies on the AndroidX Credentials Registry, and the
+`registry-provider-play-services` artifact is currently the only runtime
+provider available — without it, DCAPI cannot function.
+
+This artifact pulls in Google Play Services (GMS), which is not available
+on every Android device.
+
+For this reason `eudi-lib-android-wallet-core` does **not** bundle the
+provider as a transitive dependency. Each consuming wallet is free to
+decide whether to support DCAPI based on its target distribution:
+
+- **GMS-enabled distributions** (e.g., apps shipped via Google Play): add
+  the dependency to enable DCAPI alongside all other wallet-core features.
+- **Non-GMS distributions** (e.g., **GrapheneOS**, AOSP-based government
+  builds): omit the dependency. DCAPI will not function,
+  but every other wallet-core capability — OpenID4VCI issuance, OpenID4VP
+  remote presentation, BLE/NFC proximity presentation —
+  continues to work normally.
+
 ### Register the Intent
 
 In the application's `AndroidManifest.xml` file define an Activity to listen the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-androidx-credentials-registry-provider = "1.0.0-alpha03"
+androidx-credentials = "1.6.0"
+androidx-credentials-registry = "1.0.0-alpha04"
 appcompat = "1.7.1"
 biometricKtx = "1.2.0-alpha05"
 bouncy-castle = "1.78.1"
@@ -32,7 +33,6 @@ mockito-kotlin = "5.4.0"
 mockk = "1.14.4"
 multipaz = "0.99.0"
 nimbus-sdk = "11.20.1"
-play-services-identity-credentials = "16.0.0-alpha08"
 robolectric = "4.15.1"
 sonarqube = "6.2.0.5505"
 test-core = "1.6.1"
@@ -46,7 +46,8 @@ testng = "7.11.0"
 kover = "0.9.1"
 
 [libraries]
-androidx-credentials-registry-provider = { module = "androidx.credentials.registry:registry-provider", version.ref = "androidx-credentials-registry-provider" }
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidx-credentials" }
+androidx-credentials-registry-provider = { module = "androidx.credentials.registry:registry-provider", version.ref = "androidx-credentials-registry" }
 android-junit = { module = "androidx.test.ext:junit", version.ref = "junit-android" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 biometric-ktx = { group = "androidx.biometric", name = "biometric-ktx", version.ref = "biometricKtx" }
@@ -78,7 +79,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 multipaz-android = { module = "org.multipaz:multipaz-android", version.ref = "multipaz" }
 multipaz-longfellow = { module = "org.multipaz:multipaz-longfellow-android", version.ref = "multipaz" }
 nimbus-oauth2-oidc-sdk = { module = "com.nimbusds:oauth2-oidc-sdk", version.ref = "nimbus-sdk" }
-play-services-identity-credentials = { module = "com.google.android.gms:play-services-identity-credentials", version.ref = "play-services-identity-credentials" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 test-core = { module = "androidx.test:core", version.ref = "test-core" }
 test-coreKtx = { module = "androidx.test:core-ktx", version.ref = "test-core" }

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -137,8 +137,8 @@ dependencies {
     api(libs.eudi.lib.kmp.statium)
 
     // Digital Credential API
+    implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.registry.provider)
-    implementation(libs.play.services.identity.credentials)
 
     implementation(libs.kotlinx.io.core)
     implementation(libs.kotlinx.io.bytestring)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIManager.kt
@@ -20,8 +20,9 @@ package eu.europa.ec.eudi.wallet.dcapi
 import android.content.Intent
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.credentials.GetDigitalCredentialOption
+import androidx.credentials.exceptions.GetCredentialCustomException
+import androidx.credentials.provider.PendingIntentHandler
 import androidx.credentials.provider.ProviderGetCredentialRequest
-import com.google.android.gms.identitycredentials.IntentHelper
 import eu.europa.ec.eudi.iso18013.transfer.TransferEvent
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
@@ -135,10 +136,12 @@ class DCAPIManager(
 class DCAPIException(message: String, cause: Throwable? = null): Exception(message, cause) {
     fun toIntent(): Intent {
         val resultData = Intent()
-        IntentHelper.setGetCredentialException(
+        PendingIntentHandler.setGetCredentialException(
             resultData,
-            cause?.toString() ?: "Unknown Error Type",
-            message
+            GetCredentialCustomException(
+                type = cause?.toString() ?: "Unknown Error Type",
+                errorMessage = message
+            )
         )
         return resultData
     }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRegistration.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRegistration.kt
@@ -18,36 +18,32 @@
 package eu.europa.ec.eudi.wallet.dcapi
 
 import android.content.Context
-import android.graphics.BitmapFactory
-import com.google.android.gms.identitycredentials.IdentityCredentialManager
-import com.google.android.gms.identitycredentials.RegistrationRequest
-import com.upokecenter.cbor.CBORObject
+import androidx.credentials.registry.provider.ClearCredentialRegistryRequest
+import androidx.credentials.registry.provider.RegistryManager
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
-import eu.europa.ec.eudi.wallet.document.format.MsoMdocData
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
-import eu.europa.ec.eudi.wallet.document.metadata.IssuerMetadata
 import eu.europa.ec.eudi.wallet.internal.d
 import eu.europa.ec.eudi.wallet.internal.e
 import eu.europa.ec.eudi.wallet.logging.Logger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.bouncycastle.util.encoders.Hex
-import org.multipaz.cbor.Cbor
-import java.net.HttpURLConnection
-import java.net.URL
 
 /**
- * [DCAPIIsoMdocRegistration] is responsible for registering MSO MDOC credentials for the Digital
- * Credential API (DCAPI).
+ * [DCAPIIsoMdocRegistration] is responsible for registering MSO MDOC credentials for the
+ * Digital Credential API (DCAPI).
  *
- * It retrieves issued documents, converts them to CBOR format, and registers them with
- * the Identity Credential Manager.
+ * It collects all issued mdoc documents from the [DocumentManager] and hands them to an
+ * [IsoMdocRegistry] (a [DigitalCredentialRegistry] subclass implementing the
+ * `org-iso-mdoc` protocol per ISO/IEC TS 18013-7:2025 Annex C) which is then registered
+ * with the system [RegistryManager].
  *
- * @property context The application context used for accessing resources and services.
- * @property documentManager The [DocumentManager] instance used to manage documents.
- * @property logger Optional logger for logging events.
+ * @property context Application context used by [IsoMdocRegistry] to load the
+ *   bundled WASM matcher and resolve app name / locale.
+ * @property documentManager The [DocumentManager] instance used to fetch issued documents.
+ * @property logger Optional logger.
+ * @property ioDispatcher Coroutine dispatcher used for I/O bound work.
  */
 
 class DCAPIIsoMdocRegistration(
@@ -55,147 +51,65 @@ class DCAPIIsoMdocRegistration(
     private val documentManager: DocumentManager,
     private var logger: Logger? = null,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-): DCAPIRegistration {
+) : DCAPIRegistration {
+
+    private val registryManager: RegistryManager by lazy {
+        RegistryManager.create(context)
+    }
 
     override suspend fun registerCredentials() {
-        return withContext(ioDispatcher) {
+        withContext(ioDispatcher) {
             try {
-                val issuedMsoMdocDocuments =
-                    documentManager.getDocuments().filterIsInstance<IssuedDocument>()
-                        .filter { it.format is MsoMdocFormat }
+                val issuedMsoMdocDocuments = documentManager.getDocuments()
+                    .filterIsInstance<IssuedDocument>()
+                    .filter { it.format is MsoMdocFormat }
 
-                val credentials = issuedMsoMdocDocuments.toCBORBytes(context)
-                val client = IdentityCredentialManager.getClient(context)
-                val matcher = context.getMatcher(IDENTITY_CREDENTIAL_MATCHER)
-                client.registerCredentials(
-                    RegistrationRequest(
-                        credentials = credentials,
-                        matcher = matcher,
-                        type = REGISTRATION_TYPE,
-                        requestType = "",
-                        protocolTypes = emptyList(),
-                    )
-                ).addOnSuccessListener {
-                    logger?.d(TAG, "Registration succeeded (old)")
-                }.addOnFailureListener {
-                    logger?.d(TAG, "Registration failed  (old) $it")
+                // clear previously registered credentials
+                registryManager.clearCredentialRegistry(
+                    ClearCredentialRegistryRequest(isDeleteAll = true)
+                )
+
+                if (issuedMsoMdocDocuments.isEmpty()) {
+                    logger?.d(TAG, "No mdoc documents to register; cleared existing registries")
+                    return@withContext
                 }
-                client.registerCredentials(
-                    RegistrationRequest(
-                        credentials = credentials,
-                        matcher = matcher,
-                        type = TYPE_DIGITAL_CREDENTIAL,
-                        requestType = "",
-                        protocolTypes = emptyList(),
-                    )
-                ).addOnSuccessListener {
-                    logger?.d(TAG, "Registration succeeded")
-                }.addOnFailureListener {
-                    logger?.d(TAG, "Registration failed $it")
-                }
+
+                val registry = IsoMdocRegistry(
+                    context = context,
+                    documents = issuedMsoMdocDocuments,
+                    id = REGISTRY_ID,
+                    logger = logger,
+                    ioDispatcher = ioDispatcher
+                )
+
+                registryManager.registerCredentials(registry)
+                logger?.d(TAG, "Registered ${issuedMsoMdocDocuments.size} mdoc credential(s)")
             } catch (e: Exception) {
-                logger?.e(TAG, "Error during registration", e)
+                logger?.e(TAG, "Error during DCAPI registration", e)
             }
         }
     }
 
-    private suspend fun List<IssuedDocument>.toCBORBytes(context: Context): ByteArray {
-        val docsBuilder = CBORObject.NewArray()
-        forEach { document ->
-            val docType = (document.data.format as MsoMdocFormat).docType
-            logger?.d(
-                TAG,
-                "Issued Document with id: ${document.id}, type: $docType is being added as a credential"
-            )
-
-            // Try to get document logo provided by issuer else use an empty byte array
-            val bitmapBytes = document.issuerMetadata?.let {
-                getBitmapBytes(it)
-            } ?: byteArrayOf(0)
-
-            docsBuilder.Add(CBORObject.NewMap().apply {
-                Add(TITLE, document.name)
-                Add(SUBTITLE, context.getAppName())
-                Add(BITMAP, bitmapBytes)
-                Add(MDOC, CBORObject.NewMap().apply {
-                    Add(ID, document.id)
-                    Add(DOC_TYPE, docType)
-                    Add(NAMESPACES, CBORObject.NewMap().apply {
-                        (document.data as MsoMdocData).claims.groupBy { it.nameSpace }
-                            .forEach { (nameSpace, elements) ->
-                                val namespaceBuilder = CBORObject.NewMap()
-                                elements.forEach { element ->
-                                    val displayName = element.issuerMetadata?.display?.find {
-                                        it.locale?.language == context.getLocale().language
-                                    }?.name ?: element.identifier
-                                    val displayedValue =
-                                        if (Cbor.toDiagnostics(element.rawValue).startsWith("h'")) {
-                                            "${element.rawValue.size} bytes"
-                                        } else {
-                                            Cbor.toDiagnostics(element.rawValue)
-                                        }
-                                    val elementBuilder = CBORObject.NewArray().apply {
-                                        Add(displayName)
-                                        Add(displayedValue)
-                                    }
-                                    namespaceBuilder.Add(element.identifier, elementBuilder)
-                                }
-                                Add(nameSpace, namespaceBuilder)
-                            }
-                    })
-                })
-            })
-        }
-        val credentialBytes = docsBuilder.EncodeToBytes()
-        logger?.d(TAG, "Register documents with bytes: ${Hex.toHexString(credentialBytes)}")
-        return credentialBytes
-    }
-
-    private suspend fun getBitmapBytes(issuerMetadata: IssuerMetadata): ByteArray {
-        return try {
-            issuerMetadata.display.find {
-                it.locale?.language == context.getLocale().language
-            }?.logo?.uri?.let { uri ->
-                getLogo(uri.toURL())?.let { logoBytes ->
-                    BitmapFactory.decodeByteArray(logoBytes, 0, logoBytes.size).getIconBytes()
-                }
-            } ?: byteArrayOf(0)
-        } catch (_: Exception) {
-            byteArrayOf(0)
-        }
-    }
-
-    private suspend fun getLogo(url: URL): ByteArray? = withContext(ioDispatcher) {
-        try {
-            (url.openConnection() as? HttpURLConnection)?.run {
-                connectTimeout = 5_000
-                readTimeout = 10_000
-                requestMethod = "GET"
-                doInput = true
-                connect()
-                inputStream.use { it.readBytes() }
+    override suspend fun unregisterCredentials() {
+        withContext(ioDispatcher) {
+            try {
+                registryManager.clearCredentialRegistry(
+                    ClearCredentialRegistryRequest(isDeleteAll = true)
+                )
+                logger?.d(TAG, "Unregistered all credentials")
+            } catch (e: Exception) {
+                logger?.e(TAG, "Error during DCAPI unregistration", e)
             }
-        } catch (e: Exception) {
-            logger?.e(TAG, "Failed to download from URL: $url", e)
-            null
         }
     }
 
     companion object {
         private const val TAG = "DCAPIIsoMdocRegistration"
-        private const val REGISTRATION_TYPE = "com.credman.IdentityCredential"
-        private const val TYPE_DIGITAL_CREDENTIAL = "androidx.credentials.TYPE_DIGITAL_CREDENTIAL"
-        private const val IDENTITY_CREDENTIAL_MATCHER = "identitycredentialmatcher.wasm"
-        private const val TITLE = "title"
-        private const val SUBTITLE = "subtitle"
-        private const val BITMAP = "bitmap"
-        private const val MDOC = "mdoc"
-        private const val ID = "id"
-        private const val DOC_TYPE = "docType"
-        private const val NAMESPACES = "namespaces"
+        private const val REGISTRY_ID = "eudi-mdoc-registry-v1"
     }
 }
 
-fun interface DCAPIRegistration {
+interface DCAPIRegistration {
     suspend fun registerCredentials()
+    suspend fun unregisterCredentials()
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/IsoMdocRegistry.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/IsoMdocRegistry.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024-2025 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.dcapi
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.credentials.registry.provider.digitalcredentials.DigitalCredentialRegistry
+import com.upokecenter.cbor.CBORObject
+import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocData
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.metadata.IssuerMetadata
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.multipaz.cbor.Cbor
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * [DigitalCredentialRegistry] implementation for the `org-iso-mdoc` protocol
+ * (ISO/IEC TS 18013-7:2025 Annex C).
+ *
+ * ```
+ * val registry = IsoMdocRegistry(
+ *     context = context,
+ *     documents = issuedDocuments,
+ *     id = "eudi-mdoc-registry-v1"
+ * )
+ * registryManager.registerCredentials(registry)
+ * ```
+ */
+internal class IsoMdocRegistry private constructor(
+    id: String,
+    credentials: ByteArray,
+    matcher: ByteArray
+) : DigitalCredentialRegistry(id, credentials, matcher) {
+
+    companion object {
+        private const val TAG = "IsoMdocRegistry"
+        private const val DEFAULT_MATCHER_FILE = "identitycredentialmatcher.wasm"
+
+        // Keys consumed by the matcher in the CBOR credentials structure
+        private const val TITLE = "title"
+        private const val SUBTITLE = "subtitle"
+        private const val BITMAP = "bitmap"
+        private const val MDOC = "mdoc"
+        private const val ID = "id"
+        private const val DOC_TYPE = "docType"
+        private const val NAMESPACES = "namespaces"
+
+        /**
+         * Creates a new [IsoMdocRegistry] for the given documents.
+         *
+         * @param context Application context used to load the bundled WASM matcher and
+         *   to resolve app name / locale for display fields in the credentials structure.
+         * @param documents The issued mdoc documents to register. Documents whose format
+         *   is not [MsoMdocFormat] are ignored by the matcher anyway, but ideally callers
+         *   should filter beforehand.
+         * @param id Unique registry identifier, max 64 characters.
+         * @param logger Optional logger.
+         * @param ioDispatcher Dispatcher used for network I/O (logo download) and asset
+         *   reading.
+         */
+        suspend operator fun invoke(
+            context: Context,
+            documents: List<IssuedDocument>,
+            id: String,
+            logger: Logger? = null,
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+        ): IsoMdocRegistry = withContext(ioDispatcher) {
+            val credentials = documents.toCredentialBytes(context, logger, ioDispatcher)
+            val matcher = context.getMatcher(DEFAULT_MATCHER_FILE)
+            IsoMdocRegistry(id, credentials, matcher)
+        }
+
+        /**
+         * Serializes the documents into the CBOR structure expected by the bundled
+         * WASM matcher.
+         */
+        private suspend fun List<IssuedDocument>.toCredentialBytes(
+            context: Context,
+            logger: Logger?,
+            ioDispatcher: CoroutineDispatcher
+        ): ByteArray {
+            val docsBuilder = CBORObject.NewArray()
+            forEach { document ->
+                val docType = (document.data.format as MsoMdocFormat).docType
+                logger?.d(
+                    TAG,
+                    "Issued Document with id: ${document.id}, type: $docType is being added as a credential"
+                )
+
+                // Try to get document logo provided by issuer else use an empty byte array
+                val bitmapBytes = document.issuerMetadata?.let {
+                    getBitmapBytes(it, context, ioDispatcher, logger)
+                } ?: byteArrayOf(0)
+
+                docsBuilder.Add(CBORObject.NewMap().apply {
+                    Add(TITLE, document.name)
+                    Add(SUBTITLE, context.getAppName())
+                    Add(BITMAP, bitmapBytes)
+                    Add(MDOC, CBORObject.NewMap().apply {
+                        Add(ID, document.id)
+                        Add(DOC_TYPE, docType)
+                        Add(NAMESPACES, CBORObject.NewMap().apply {
+                            (document.data as MsoMdocData).claims.groupBy { it.nameSpace }
+                                .forEach { (nameSpace, elements) ->
+                                    val namespaceBuilder = CBORObject.NewMap()
+                                    elements.forEach { element ->
+                                        val displayName = element.issuerMetadata?.display?.find {
+                                            it.locale?.language == context.getLocale().language
+                                        }?.name ?: element.identifier
+                                        val displayedValue =
+                                            if (Cbor.toDiagnostics(element.rawValue).startsWith("h'")) {
+                                                "${element.rawValue.size} bytes"
+                                            } else {
+                                                Cbor.toDiagnostics(element.rawValue)
+                                            }
+                                        val elementBuilder = CBORObject.NewArray().apply {
+                                            Add(displayName)
+                                            Add(displayedValue)
+                                        }
+                                        namespaceBuilder.Add(element.identifier, elementBuilder)
+                                    }
+                                    Add(nameSpace, namespaceBuilder)
+                                }
+                        })
+                    })
+                })
+            }
+            return docsBuilder.EncodeToBytes()
+        }
+
+        private suspend fun getBitmapBytes(
+            issuerMetadata: IssuerMetadata,
+            context: Context,
+            ioDispatcher: CoroutineDispatcher,
+            logger: Logger?
+        ): ByteArray {
+            return try {
+                issuerMetadata.display.find {
+                    it.locale?.language == context.getLocale().language
+                }?.logo?.uri?.let { uri ->
+                    getLogo(uri.toURL(), ioDispatcher, logger)?.let { logoBytes ->
+                        BitmapFactory.decodeByteArray(logoBytes, 0, logoBytes.size).getIconBytes()
+                    }
+                } ?: byteArrayOf(0)
+            } catch (_: Exception) {
+                byteArrayOf(0)
+            }
+        }
+
+        private suspend fun getLogo(
+            url: URL,
+            ioDispatcher: CoroutineDispatcher,
+            logger: Logger?
+        ): ByteArray? = withContext(ioDispatcher) {
+            try {
+                (url.openConnection() as? HttpURLConnection)?.run {
+                    connectTimeout = 5_000
+                    readTimeout = 10_000
+                    requestMethod = "GET"
+                    doInput = true
+                    connect()
+                    inputStream.use { it.readBytes() }
+                }
+            } catch (e: Exception) {
+                logger?.e(TAG, "Failed to download logo from URL: $url", e)
+                null
+            }
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/Utils.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/Utils.kt
@@ -19,12 +19,12 @@ package eu.europa.ec.eudi.wallet.dcapi
 
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.core.graphics.scale
 import com.upokecenter.cbor.CBORObject
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
 import java.util.Locale
 import kotlin.io.encoding.ExperimentalEncodingApi
-import androidx.core.graphics.scale
 import org.multipaz.util.toBase64
 
 private const val SHA_256_ALGORITHM = "SHA-256"


### PR DESCRIPTION
Replace the `play-services-identity-credentials` integration with `androidx.credentials` and `androidx.credentials.registry:registry-provider`.

**Note:** Apps must now add `androidx.credentials.registry:registry-provider-play-services` as a dependency to enable DCAPI.  See more details in `DIGITAL_CREDENTIAL_API.md`.