### PR TITLE
Fix spurious error during re-issuance authorization fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ file.
 
 ```groovy
 dependencies {
-    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.27.1"
+    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.27.2-SNAPSHOT"
     // required when using the built-in AndroidKeystoreSecureArea implementation provided by the library
     // for user authentication with biometrics
     implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ android.nonTransitiveRClass=true
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 
-VERSION_NAME=0.27.1
+VERSION_NAME=0.27.2-SNAPSHOT
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandler.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandler.kt
@@ -72,29 +72,32 @@ class BrowserAuthorizationHandler(
      * - A failed [Result] with [IllegalArgumentException] if the authorization code parameter ('code') is missing from the URI
      * - A failed [Result] with [IllegalArgumentException] if the server state parameter ('state') is missing from the URI
      *
+     * If no authorization is currently in progress (e.g. duplicate deep link delivery),
+     * this method logs a warning and returns without effect.
+     *
      * @param uri The callback URI containing the authorization code and state parameters
-     * @throws IllegalStateException if no authorization is in progress
      *
      * @see authorize
      */
     fun resumeWithUri(uri: Uri) {
         logger?.d(TAG, "BrowserAuthorizationHandler.resumeWithUri($uri)")
-        continuation?.let { cont ->
-            val response = runCatching {
-                val authorizationCode = uri.getQueryParameter("code")
-                val serverState = uri.getQueryParameter("state")
-
-                requireNotNull(authorizationCode) { "No authorization code found" }
-                requireNotNull(serverState) { "No server state found" }
-
-                AuthorizationResponse(authorizationCode, serverState)
-            }
-            cont.resume(response.onFailure {
-                logger?.e(TAG, "resumeWithUri: ${it.message}", it)
-            })
-        } ?: throw IllegalStateException("No suspended authorization found").also {
-            logger?.e(TAG, "BrowserAuthorizationHandler.resumeWithUri failed", it)
+        val cont = continuation ?: run {
+            logger?.d(TAG, "resumeWithUri: no pending authorization, ignoring duplicate callback")
+            return
         }
+        continuation = null
+        val response = runCatching {
+            val authorizationCode = uri.getQueryParameter("code")
+            val serverState = uri.getQueryParameter("state")
+
+            requireNotNull(authorizationCode) { "No authorization code found" }
+            requireNotNull(serverState) { "No server state found" }
+
+            AuthorizationResponse(authorizationCode, serverState)
+        }
+        cont.resume(response.onFailure {
+            logger?.e(TAG, "resumeWithUri: ${it.message}", it)
+        })
     }
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -58,6 +58,7 @@ import kotlinx.serialization.json.Json
 import org.multipaz.storage.Storage
 import org.multipaz.storage.android.AndroidStorage
 import java.io.File
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executor
 
 /**
@@ -336,13 +337,19 @@ internal class DefaultOpenId4VciManager(
                 )
 
                 //  Refresh the access token using the stored refresh token.
-                //  If the refresh token is also expired (400 invalid_grant from /token),
-                //  fall back to full OAuth authorization when allowed.
+                //  Only fall back to full OAuth authorization on 400 invalid_grant
+                //  (RFC 6749 §5.2: refresh token expired/revoked). Server errors (5xx),
+                //  network failures, and other OAuth error codes are re-thrown — falling
+                //  back to authorization would hit the same broken server or mask
+                //  configuration errors.
                 var updatedAuthorizedRequest = try {
                     with(issuer) {
                         authorizedRequest.refresh().getOrThrow()
                     }
                 } catch (e: Throwable) {
+                    val isInvalidGrant = e is CredentialIssuanceError.AccessTokenRequestFailed
+                            && e.error == "invalid_grant"
+                    if (!isInvalidGrant) throw e
                     if (!allowAuthorizationFallback) {
                         throw ReissuanceAuthorizationException(
                             "Re-issuance of document $documentId requires user authorization (refresh token expired)",
@@ -423,8 +430,9 @@ internal class DefaultOpenId4VciManager(
                 listener(IssueEvent.Finished(issuedDocumentIds + deferredDocumentIds))
 
             } catch (e: Throwable) {
-                logger?.e(TAG, "Something went wrong with reissuance of $documentId", e)
-                listener(failure(e))
+                if (e !is CancellationException) {
+                    listener(failure(e))
+                }
                 coroutineScope.cancel("reissueDocument failed", e)
             }
         }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerAuthorization.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerAuthorization.kt
@@ -62,6 +62,7 @@ internal class IssuerAuthorization(
     /**
      * Resumes the authorization from the given [Uri].
      * This method delegates to the [BrowserAuthorizationHandler] if it's being used.
+     * If no authorization is currently pending, the call is silently ignored.
      * @throws IllegalStateException if the authorization handler is not a [BrowserAuthorizationHandler]
      */
     fun resumeFromUri(uri: Uri) {

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandlerTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandlerTest.kt
@@ -35,7 +35,6 @@ import org.junit.BeforeClass
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -156,15 +155,66 @@ class BrowserAuthorizationHandlerTest {
     }
 
     @Test
-    fun `resumeWithUri throws exception when no authorization in progress`() {
+    fun `resumeWithUri ignores callback when no authorization in progress`() {
         val callbackUri = mockk<Uri>(relaxed = true) {
             every { getQueryParameter("code") } returns "auth_code_123"
             every { getQueryParameter("state") } returns "xyz"
         }
 
-        assertFailsWith<IllegalStateException> {
-            handler.resumeWithUri(callbackUri)
+        // Should not throw — just logs and returns
+        handler.resumeWithUri(callbackUri)
+    }
+
+    @Test
+    fun `resumeWithUri ignores duplicate callback after authorization completes`() = runTest {
+        val authorizationUrl = "https://issuer.example.com/authorize"
+        val callbackUri = mockk<Uri>(relaxed = true) {
+            every { getQueryParameter("code") } returns "auth_code_123"
+            every { getQueryParameter("state") } returns "xyz"
         }
+
+        var result: Result<AuthorizationResponse>? = null
+
+        val job = launch {
+            result = handler.authorize(authorizationUrl)
+        }
+
+        testScheduler.runCurrent()
+
+        // First callback completes the authorization
+        handler.resumeWithUri(callbackUri)
+        job.join()
+
+        assertNotNull(result)
+        assertTrue(result.isSuccess)
+
+        // Second callback (duplicate deep link delivery) should be silently ignored
+        handler.resumeWithUri(callbackUri)
+    }
+
+    @Test
+    fun `resumeWithUri ignores callback after cancellation`() = runTest {
+        val authorizationUrl = "https://issuer.example.com/authorize"
+        val callbackUri = mockk<Uri>(relaxed = true) {
+            every { getQueryParameter("code") } returns "auth_code_123"
+            every { getQueryParameter("state") } returns "xyz"
+        }
+
+        val job = launch {
+            try {
+                handler.authorize(authorizationUrl)
+            } catch (_: Exception) {
+                // Expected cancellation
+            }
+        }
+
+        testScheduler.runCurrent()
+
+        handler.cancel()
+        job.join()
+
+        // Late callback after cancellation should be silently ignored
+        handler.resumeWithUri(callbackUri)
     }
 
     @Test


### PR DESCRIPTION
- Fixed an issue where the wallet-ui could receive a spurious error event when re-issuing a document that requires browser-based authorization, causing an incorrect error page to appear even though the re-issuance succeeds
- Improved BrowserAuthorizationHandler resilience against duplicate deep link callbacks and stale authorization state
- Narrowed the token refresh error handling to only fall back to full OAuth authorization on invalid_grant (RFC 6749 §5.2), ensuring server errors and other non-recoverable failures are reported directly instead of triggering a redundant authorization flow