### PR TITLE
Release 0.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ file.
 
 ```groovy
 dependencies {
-    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.28.1-SNAPSHOT"
+    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.28.1"
     // required when using the built-in AndroidKeystoreSecureArea implementation provided by the library
     // for user authentication with biometrics
     implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ android.nonTransitiveRClass=true
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 
-VERSION_NAME=0.28.1-SNAPSHOT
+VERSION_NAME=0.28.1
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandler.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandler.kt
@@ -72,18 +72,15 @@ class BrowserAuthorizationHandler(
      * - A failed [Result] with [IllegalArgumentException] if the authorization code parameter ('code') is missing from the URI
      * - A failed [Result] with [IllegalArgumentException] if the server state parameter ('state') is missing from the URI
      *
-     * If no authorization is currently in progress (e.g. duplicate deep link delivery),
-     * this method logs a warning and returns without effect.
-     *
      * @param uri The callback URI containing the authorization code and state parameters
+     * @throws IllegalStateException if no authorization is in progress
      *
      * @see authorize
      */
     fun resumeWithUri(uri: Uri) {
         logger?.d(TAG, "BrowserAuthorizationHandler.resumeWithUri($uri)")
-        val cont = continuation ?: run {
-            logger?.d(TAG, "resumeWithUri: no pending authorization, ignoring duplicate callback")
-            return
+        val cont = continuation ?: throw IllegalStateException("No suspended authorization found").also {
+            logger?.e(TAG, "BrowserAuthorizationHandler.resumeWithUri failed", it)
         }
         continuation = null
         val response = runCatching {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerAuthorization.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerAuthorization.kt
@@ -62,8 +62,8 @@ internal class IssuerAuthorization(
     /**
      * Resumes the authorization from the given [Uri].
      * This method delegates to the [BrowserAuthorizationHandler] if it's being used.
-     * If no authorization is currently pending, the call is silently ignored.
      * @throws IllegalStateException if the authorization handler is not a [BrowserAuthorizationHandler]
+     * @throws IllegalStateException if no authorization is currently in progress
      */
     fun resumeFromUri(uri: Uri) {
         logger?.d(TAG, "IssuerAuthorization.resumeFromUri($uri)")

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandlerTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/BrowserAuthorizationHandlerTest.kt
@@ -35,6 +35,7 @@ import org.junit.BeforeClass
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -155,18 +156,19 @@ class BrowserAuthorizationHandlerTest {
     }
 
     @Test
-    fun `resumeWithUri ignores callback when no authorization in progress`() {
+    fun `resumeWithUri throws when no authorization in progress`() {
         val callbackUri = mockk<Uri>(relaxed = true) {
             every { getQueryParameter("code") } returns "auth_code_123"
             every { getQueryParameter("state") } returns "xyz"
         }
 
-        // Should not throw — just logs and returns
-        handler.resumeWithUri(callbackUri)
+        assertFailsWith<IllegalStateException> {
+            handler.resumeWithUri(callbackUri)
+        }
     }
 
     @Test
-    fun `resumeWithUri ignores duplicate callback after authorization completes`() = runTest {
+    fun `resumeWithUri throws on duplicate callback after authorization completes`() = runTest {
         val authorizationUrl = "https://issuer.example.com/authorize"
         val callbackUri = mockk<Uri>(relaxed = true) {
             every { getQueryParameter("code") } returns "auth_code_123"
@@ -188,12 +190,14 @@ class BrowserAuthorizationHandlerTest {
         assertNotNull(result)
         assertTrue(result.isSuccess)
 
-        // Second callback (duplicate deep link delivery) should be silently ignored
-        handler.resumeWithUri(callbackUri)
+        // Second callback throws — continuation was consumed
+        assertFailsWith<IllegalStateException> {
+            handler.resumeWithUri(callbackUri)
+        }
     }
 
     @Test
-    fun `resumeWithUri ignores callback after cancellation`() = runTest {
+    fun `resumeWithUri throws on callback after cancellation`() = runTest {
         val authorizationUrl = "https://issuer.example.com/authorize"
         val callbackUri = mockk<Uri>(relaxed = true) {
             every { getQueryParameter("code") } returns "auth_code_123"
@@ -213,8 +217,10 @@ class BrowserAuthorizationHandlerTest {
         handler.cancel()
         job.join()
 
-        // Late callback after cancellation should be silently ignored
-        handler.resumeWithUri(callbackUri)
+        // Late callback after cancellation throws — continuation was cleared
+        assertFailsWith<IllegalStateException> {
+            handler.resumeWithUri(callbackUri)
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix - BrowserAuthorizationHandler resumeUri() throws IllegalStateException when no suspended authorization found 