### PR TITLE
Etsi List of Trusted Entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,13 +924,17 @@ signature verification without ETSI trust chain validation.
 reader certificate chain validation to the ETSI library's `IsChainTrustedForEUDIW`. It
 uses the `WalletRelyingPartyAccessCertificate` (WRPAC) verification context by default.
 
-Use the convenience extension to create a `ReaderTrustStore` from any ETSI chain trust validator:
+Configure it via `configureReaderTrustStore` on `EudiWalletConfig`, alongside the other
+trust features:
 
 ```kotlin
-val wallet = EudiWallet(context, config) {
-    withReaderTrustStore(isChainTrusted.asReaderTrustStore())
+val config = EudiWalletConfig {
+    configureReaderTrustStore(isChainTrusted.asReaderTrustStore())
 }
 ```
+
+This takes priority over certificate-based configuration. The legacy overloads that accept
+raw `X509Certificate` lists remain available for static trust anchors.
 
 Or create an `EtsiReaderTrustStore` explicitly with a specific verification context:
 
@@ -940,8 +944,8 @@ val readerTrustStore = EtsiReaderTrustStore(
     verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
 )
 
-val wallet = EudiWallet(context, config) {
-    withReaderTrustStore(readerTrustStore)
+val config = EudiWalletConfig {
+    configureReaderTrustStore(readerTrustStore)
 }
 ```
 
@@ -1011,11 +1015,9 @@ val config = EudiWalletConfig {
             }
         }
     }
-}
 
-val wallet = EudiWallet(context, config) {
     // Reader authentication with ETSI trusted lists (same trust source)
-    withReaderTrustStore(isChainTrusted.asReaderTrustStore())
+    configureReaderTrustStore(isChainTrusted.asReaderTrustStore())
 }
 
 // On shutdown:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The library supports the following features:
 |                            | Notify credential issuer                                                | ❌                                                                                                                      |
 | **Issuer Trust**           | Trust verification during issuance (LoTE)                               | ✅ mso_mdoc format <br /> ✅ sd-jwt-vc format                                                                            |
 |                            | Trust policy (ENFORCE / INFORM)                                         | ✅                                                                                                                      |
-|                            | Signed issuer metadata verification                                     | ✅ RequireSigned / PreferSigned / IgnoreSigned                                                                           |
+|                            | Signed issuer metadata verification                                     | ✅ RequireSigned (default) / PreferSigned / IgnoreSigned                                                                 |
 |                            | Custom credential format verifiers                                      | ✅ via CredentialTrustVerifier                                                                                           |
 | **Revocation Status**      | Document status resolution (token status lists)                         | ✅ JWT <br /> ✅ CWT                                                                                                     |
 |                            | Status list token signer trust verification (LoTE)                      | ✅                                                                                                                      |
@@ -754,8 +754,8 @@ val walletConfig = EudiWalletConfig {
             forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
             forDocType("org.example.test", TrustPolicy.Action.INFORM)
         }
-        // Optional: enable signed issuer metadata verification (see below)
-        preferSignedMetadata()
+        // Signed metadata verification defaults to RequireSigned (see below)
+        // override by calling preferSignedMetadata() or ignoreSignedMetadata()
     }
 }
 ```
@@ -765,8 +765,8 @@ val walletConfig = EudiWalletConfig {
 - **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
   as the trust source. Maps credential types to verification contexts.
 - **`policy`** -- configures how the wallet acts on trust results (see below).
-- **`preferSignedMetadata()`** / **`requireSignedMetadata()`** -- controls signed issuer
-  metadata verification (see [Signed Issuer Metadata Verification](#signed-issuer-metadata-verification)).
+- **`preferSignedMetadata()`** / **`ignoreSignedMetadata()`** -- relaxes the default
+  `RequireSigned` metadata policy (see [Signed Issuer Metadata Verification](#signed-issuer-metadata-verification)).
 
 ##### Trust Policies
 
@@ -853,35 +853,29 @@ Three metadata policies are available:
 
 | Policy            | Behaviour                                                                                      |
 |-------------------|------------------------------------------------------------------------------------------------|
-| `IgnoreSigned`    | **(Default)** Signed metadata is ignored; only unsigned metadata is used.                      |
+| `RequireSigned`   | **(Default)** Signed metadata must be available and its certificate chain must be trusted. Otherwise issuance fails. |
 | `PreferSigned`    | Attempts to fetch signed metadata first. Falls back to unsigned if signed is not available. When signed metadata is served but the certificate chain is untrusted, issuance **fails**. |
-| `RequireSigned`   | Signed metadata must be available and its certificate chain must be trusted. Otherwise issuance fails. |
+| `IgnoreSigned`    | Signed metadata is ignored; only unsigned metadata is used. Must be set explicitly via `ignoreSignedMetadata()`. |
 
-Configure metadata verification within the `configureIssuerTrust` DSL:
+When `configureIssuerTrust` is used with an `IsChainTrustedForEUDIW` trust source (the
+standard LoTE setup), signed metadata verification defaults to `RequireSigned`. The library
+automatically creates the trust adapter using
+`VerificationContext.WalletRelyingPartyAccessCertificate`.
+
+To override the default metadata policy:
 
 ```kotlin
 configureIssuerTrust {
     trustSource(isChainTrusted)
     classifications(myClassifications)
-    policy { default(TrustPolicy.Action.INFORM) }
+    policy { default(TrustPolicy.Action.ENFORCE) }
 
-    // Option A: prefer signed, fall back to unsigned if not available
+    // Prefer signed, but fall back to unsigned if not available
     preferSignedMetadata()
 
-    // Option B: require signed metadata (fails if not available or untrusted)
-    // requireSignedMetadata()
+    // Or explicitly disable signed metadata verification
+    // ignoreSignedMetadata()
 }
-```
-
-When `preferSignedMetadata()` or `requireSignedMetadata()` is called without arguments, the
-library automatically creates a `CertificateChainTrust` adapter from the configured
-`trustSource`, using `VerificationContext.WalletRelyingPartyAccessCertificate` as the ETSI
-context for metadata signing certificates.
-
-You can also provide a custom `CertificateChainTrust` implementation:
-
-```kotlin
-preferSignedMetadata(myCustomCertificateChainTrust)
 ```
 
 > **Note:** Metadata verification is a separate check from credential trust verification.
@@ -996,18 +990,17 @@ val config = EudiWalletConfig {
         withSchemes("openid4vp", "eudi-openid4vp", "mdoc-openid4vp")
     }
 
-    // 1. Issuer trust verification (credential issuance)
+    // Issuer trust verification (credential issuance)
+    // Signed metadata verification defaults to RequireSigned
     configureIssuerTrust {
         trustSource(isChainTrusted)
         classifications(classifications)
         policy {
             default(TrustPolicy.Action.ENFORCE)
         }
-        // 2. Signed issuer metadata verification
-        preferSignedMetadata()
     }
 
-    // 3. Revocation status trust verification
+    // Revocation status trust verification
     configureDocumentStatusResolver {
         clockSkew(5)
         configureTrust {
@@ -1021,7 +1014,7 @@ val config = EudiWalletConfig {
 }
 
 val wallet = EudiWallet(context, config) {
-    // 4. Reader authentication with ETSI trusted lists (same trust source)
+    // Reader authentication with ETSI trusted lists (same trust source)
     withReaderTrustStore(isChainTrusted.asReaderTrustStore())
 }
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,63 @@ required to implement the EUDI Wallet functionality. On top of that, it provides
 that can be used by the application to implement the EUDI Wallet functionality.
 
 ```mermaid
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "primaryColor": "#E6F1FB",
+    "primaryTextColor": "#0C447C",
+    "primaryBorderColor": "#378ADD",
+    "lineColor": "#888780",
+    "secondaryColor": "#EAF3DE",
+    "tertiaryColor": "#F1EFE8",
+    "edgeLabelBackground": "#ffffff",
+    "fontSize": "13px"
+  }
+}}%%
+
 graph TD
-;
-    A[eudi-lib-android-wallet-core]
-    B[eudi-lib-android-wallet-document-manager] -->|DocumentManager| A
-    C[eudi-lib-android-iso18013-data-transfer] -->|TransferManager| A
-    D[eudi-lib-jvm-openid4vci-kt] -->|OpenId4VciManager| A
-    E[eudi-lib-jvm-siop-openid4vp-kt] -->|OpenId4VpManager| A
-    F[org.multipaz] -->|SecureArea,Storage| B
-    H[eudi-lib-jvm-presentation-exchange] --> E
-    G[multipaz-android] --> A
+    A("<b>eudi-lib-android-wallet-core</b>")
+
+    subgraph android ["Android"]
+        B["eudi-lib-android-wallet-\ndocument-manager"]
+        C["eudi-lib-android-iso18013-\ndata-transfer"]
+    end
+
+    subgraph jvm ["JVM / KMP"]
+        D["eudi-lib-jvm-openid4vci-kt"]
+        E["eudi-lib-jvm-openid4vp-kt"]
+        J["eudi-lib-jvm-sdjwt-kt"]
+        I["eudi-lib-kmp-etsi-1196x2"]
+        H["eudi-lib-kmp-statium"]
+    end
+
+    subgraph multipaz ["Multipaz"]
+        F["org.multipaz"]
+        G["multipaz-android"]
+    end
+
+    B -->|DocumentManager| A
+    C -->|TransferManager| A
+    D -->|OpenId4VciManager| A
+    E -->|OpenId4VpManager| A
+    J -->|SdJwtVcVerification| A
+    I -->|IssuerTrustVerification| A
+    F -->|"SecureArea, Storage"| B
+    F -->|"SecureArea, Storage"| A
+    G --> A
     B -->|DocumentManager| C
-    F -->|SecureArea,Storage| A
+    J --> B
+    H --> A
+
+    classDef core fill:#185FA5,stroke:#0C447C,color:#fff,font-weight:bold
+    classDef androidLib fill:#E6F1FB,stroke:#378ADD,color:#0C447C
+    classDef jvmLib fill:#EAF3DE,stroke:#639922,color:#27500A
+    classDef multipazLib fill:#FAEEDA,stroke:#BA7517,color:#633806
+
+    class A core
+    class B,C androidLib
+    class D,E,J,I,H jvmLib
+    class F,G multipazLib
 ```
 
 ### Features
@@ -50,6 +95,9 @@ The library supports the following features:
 |                            | Wallet Authentication                                                   | ✅ public client, <br/>✅ Attestation-Based Client Authentication (WIA)                                                  |
 |                            | Supported Proof Types                                                   | ✅ Attestation Proof Type, <br/> ✅ Proof Type without Attestation <br/> ✅ JWT Proof Type with Attestation               |
 |                            | Notify credential issuer                                                | ❌                                                                                                                      |
+| **Issuer Trust**           | Trust verification during issuance (LoTE / LOTL)                        | ✅ mso_mdoc format <br /> ✅ sd-jwt-vc format                                                                            |
+|                            | Trust policy (ENFORCE / INFORM)                                         | ✅                                                                                                                      |
+|                            | Custom credential format verifiers                                      | ✅ via CredentialTrustVerifier                                                                                           |
 | **Proximity Presentation** | ISO-18013-5 device retrieval                                            |                                                                                                                        |
 |                            | Device engagement                                                       | ✅ QR <br /> ✅ NFC                                                                                                      |
 |                            | Data transfer                                                           | ✅ BLE <br /> ❌ NFC <br /> ❌ Wifi-Aware                                                                                 |
@@ -1145,6 +1193,119 @@ val walletConfig = EudiWalletConfig()
             )
         )
     }
+```
+
+### Issuer Trust Verification
+
+The library supports verifying credential issuers against ETSI trusted lists during
+OpenID4VCI issuance. Trust verification runs after the credential is received from the issuer
+and before it is stored. It is protocol-agnostic -- built-in verifiers handle both MsoMdoc and
+SD-JWT VC formats, and custom verifiers can be registered for additional formats.
+
+When issuer trust is not configured, verification is skipped entirely and credentials are
+stored as before.
+
+#### Configuration
+
+Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWalletConfig`:
+
+```kotlin
+val walletConfig = EudiWalletConfig {
+    // ... other configuration ...
+    configureIssuerTrust {
+        trustSource(myComposeChainTrust) // ComposeChainTrust from LoTE, LOTL, or both
+        classifications(myClassifications) // AttestationClassifications from ETSI library
+        policy {
+            default(TrustPolicy.Action.ENFORCE)
+            forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
+            forDocType("org.example.test", TrustPolicy.Action.INFORM)
+            forVct("urn:example:test", TrustPolicy.Action.INFORM)
+        }
+    }
+}
+```
+
+- **`trustSource`** -- sets the trust anchor source. Accepts a `ComposeChainTrust`,
+  `IsChainTrustedForEUDIW`, or a pre-built `IsChainTrustedForAttestation`.
+- **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
+  as the trust source. Maps credential types to verification contexts.
+- **`policy`** -- configures how the wallet acts on trust results (see below).
+
+#### Trust Policies
+
+A `TrustPolicy` determines the action taken when an issuer is not trusted:
+
+| Action    | Behaviour                                                                   |
+|-----------|-----------------------------------------------------------------------------|
+| `ENFORCE` | Reject the credential -- delete it and emit `IssueEvent.DocumentFailed`.    |
+| `INFORM`  | Store the credential regardless and attach the result to `DocumentIssued`.  |
+
+The default policy is `ENFORCE` for all credentials. Use the `policy` DSL to override per
+verification context or per attestation type. Resolution order (highest priority first):
+
+1. Per-attestation overrides (`forDocType`, `forVct`, `forAttestation`)
+2. Per-context overrides (`forContext`)
+3. Default action (`default`)
+
+#### Handling Trust Results
+
+The trust verification result is available on `IssueEvent.DocumentIssued` and
+`IssueEvent.DocumentFailed`:
+
+```kotlin
+wallet.issueDocumentByOfferUri(offerUri) { event ->
+    when (event) {
+        is IssueEvent.DocumentIssued -> {
+            when (event.issuerTrustResult) {
+                is CertificationChainValidation.Trusted -> {
+                    // Issuer is trusted
+                }
+                is CertificationChainValidation.NotTrusted -> {
+                    // INFORM policy: credential stored, but issuer was not trusted
+                }
+                null -> {
+                    // Trust verification not configured
+                }
+            }
+        }
+
+        is IssueEvent.DocumentFailed -> {
+            if (event.cause is IssuerNotTrustedException) {
+                // ENFORCE policy: credential rejected because issuer was not trusted
+            }
+        }
+
+        // ... handle other events ...
+        else -> {}
+    }
+}
+```
+
+#### Custom CredentialTrustVerifier
+
+The library includes built-in verifiers for MsoMdoc and SD-JWT VC formats. To support
+additional credential formats, implement the `CredentialTrustVerifier` interface and register
+it during configuration:
+
+```kotlin
+class MyCustomVerifier(
+    private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+) : CredentialTrustVerifier {
+    override suspend fun verify(
+        credentialValue: String,
+        attestationIdentifier: AttestationIdentifier,
+    ): CertificationChainValidation<TrustAnchor>? {
+        // Extract certificate chain from the credential and evaluate trust
+        // Return null if the chain cannot be extracted
+    }
+}
+
+// Register during configuration
+configureIssuerTrust {
+    trustSource(myComposeChainTrust)
+    classifications(myClassifications)
+    credentialTrustVerifier(MyCustomFormat::class, MyCustomVerifier(isChainTrusted))
+}
 ```
 
 ### Transfer documents

--- a/README.md
+++ b/README.md
@@ -929,14 +929,15 @@ trust features:
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureReaderTrustStore(isChainTrusted.asReaderTrustStore())
+    configureReaderTrustStore(isChainTrusted)
 }
 ```
 
 This takes priority over certificate-based configuration. The legacy overloads that accept
 raw `X509Certificate` lists remain available for static trust anchors.
 
-Or create an `EtsiReaderTrustStore` explicitly with a specific verification context:
+For advanced use cases requiring a specific verification context, create an
+`EtsiReaderTrustStore` explicitly:
 
 ```kotlin
 val readerTrustStore = EtsiReaderTrustStore(
@@ -952,7 +953,7 @@ val config = EudiWalletConfig {
 You can also update the reader trust store at runtime:
 
 ```kotlin
-wallet.setReaderTrustStore(isChainTrusted.asReaderTrustStore())
+wallet.setReaderTrustStore(EtsiReaderTrustStore(isChainTrusted))
 ```
 
 > **Note:** For best performance during presentations, pre-warm the ETSI cache on app startup.
@@ -1017,7 +1018,7 @@ val config = EudiWalletConfig {
     }
 
     // Reader authentication with ETSI trusted lists (same trust source)
-    configureReaderTrustStore(isChainTrusted.asReaderTrustStore())
+    configureReaderTrustStore(isChainTrusted)
 }
 
 // On shutdown:

--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ The library supports the following features:
 |                            | Wallet Authentication                                                   | ✅ public client, <br/>✅ Attestation-Based Client Authentication (WIA)                                                  |
 |                            | Supported Proof Types                                                   | ✅ Attestation Proof Type, <br/> ✅ Proof Type without Attestation <br/> ✅ JWT Proof Type with Attestation               |
 |                            | Notify credential issuer                                                | ❌                                                                                                                      |
-| **Issuer Trust**           | Trust verification during issuance (LoTE / LOTL)                        | ✅ mso_mdoc format <br /> ✅ sd-jwt-vc format                                                                            |
+| **Issuer Trust**           | Trust verification during issuance (LoTE)                               | ✅ mso_mdoc format <br /> ✅ sd-jwt-vc format                                                                            |
 |                            | Trust policy (ENFORCE / INFORM)                                         | ✅                                                                                                                      |
+|                            | Signed issuer metadata verification                                     | ✅ RequireSigned / PreferSigned / IgnoreSigned                                                                           |
 |                            | Custom credential format verifiers                                      | ✅ via CredentialTrustVerifier                                                                                           |
+| **Revocation Status**      | Document status resolution (token status lists)                         | ✅ JWT <br /> ✅ CWT                                                                                                     |
+|                            | Status list token signer trust verification (LoTE)                      | ✅                                                                                                                      |
 | **Proximity Presentation** | ISO-18013-5 device retrieval                                            |                                                                                                                        |
 |                            | Device engagement                                                       | ✅ QR <br /> ✅ NFC                                                                                                      |
 |                            | Data transfer                                                           | ✅ BLE <br /> ❌ NFC <br /> ❌ Wifi-Aware                                                                                 |
@@ -579,10 +582,16 @@ val wallet = EudiWallet(context, config) {
 
 ### Trusted Lists
 
-The library supports trust verification using ETSI Trusted Lists for both **credential issuance**
-(issuer trust) and **credential presentation** (reader/verifier authentication). This enables
-dynamic trust anchor resolution from LoTE (ETSI TS 119 602) and LOTL (ETSI TS 119 612) instead
-of static certificate lists.
+The library supports trust verification using ETSI Trusted Lists for **credential issuance**
+(issuer trust), **credential presentation** (reader/verifier authentication), **revocation
+status** (status list token signer trust), and **signed issuer metadata** verification. This
+enables dynamic trust anchor resolution from LoTE (ETSI TS 119 602) instead of static
+certificate lists.
+
+Each trust verification feature is independently configurable and opt-in. When not configured,
+the library behaves as before (credentials stored without trust checks, status resolved with
+standard signature verification, reader authentication via static certificate lists or
+disabled, unsigned metadata only).
 
 The design is **protocol-agnostic** — wallet-core defines integration contracts, and the developer
 composes trust validation using the
@@ -592,7 +601,7 @@ library directly (or any other trust framework).
 #### Dependencies
 
 The core consultation module (`etsi-1196x2-consultation`) is already included transitively via
-wallet-core. For LoTE or LOTL support, add the corresponding modules to your app's dependencies:
+wallet-core. For LoTE support, add the corresponding module to your app's dependencies:
 
 ```groovy
 dependencies {
@@ -601,17 +610,12 @@ dependencies {
 
     // For LoTE (List of Trusted Entities) support — ETSI TS 119 602
     implementation "eu.europa.ec.eudi:etsi-119602-consultation:0.3.0-alpha.5-SNAPSHOT"
-
-    // For LOTL (List of Trusted Lists) support via DSS — ETSI TS 119 612
-    implementation "eu.europa.ec.eudi:etsi-1196x2-consultation-dss:0.3.0-alpha.5-SNAPSHOT"
 }
 ```
 
-#### Setting Up Trust Anchor Resolution
+#### Setting Up Trust Anchor Resolution (LoTE)
 
-##### LoTE (ETSI TS 119 602)
-
-Set up trust anchor resolution from Lists of Trusted Entities:
+Set up trust anchor resolution from Lists of Trusted Entities (ETSI TS 119 602):
 
 ```kotlin
 // 1. Set up LoTE loading with file cache
@@ -647,7 +651,7 @@ val loteLocations = SupportedLists(
 val disposableScope = DisposableContainer()
 val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
 
-// Use isChainTrusted for both issuer trust and reader authentication (see below)
+// Use isChainTrusted for issuer trust, metadata verification, status resolution, and reader auth (see below)
 
 // When shutting down (e.g. Application.onTerminate()):
 // disposableScope.dispose()
@@ -730,28 +734,6 @@ val myJwtVerifier = VerifyJwtSignature { jwt ->
 > runtime (already included as a `runtimeOnly` dependency by wallet-core). You can also pass a
 > custom `HttpClient` if you need specific configuration (logging, timeouts, etc.).
 
-##### LOTL (ETSI TS 119 612 via DSS)
-
-For trust resolution from Lists of Trusted Lists:
-
-```kotlin
-val getTrustAnchors = GetTrustAnchorsFromLoTL(
-    dssOptions = DssOptions.usingFileCacheDataLoader(
-        cacheDirectory = Path(context.cacheDir.path, "lotl-cache"),
-    )
-)
-// Compose into IsChainTrustedForContext, then into ComposeChainTrust
-```
-
-##### Combining LoTE + LOTL
-
-Multiple trust sources can be combined using the `+` operator on `ComposeChainTrust`, as long
-as they cover disjoint sets of verification contexts:
-
-```kotlin
-val combined = loTeValidator + loTlValidator
-```
-
 #### Issuer Trust Verification
 
 Trust verification runs after the credential is received from the issuer and before it is stored.
@@ -765,13 +747,15 @@ Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWall
 val walletConfig = EudiWalletConfig {
     // ... other configuration ...
     configureIssuerTrust {
-        trustSource(isChainTrusted) // ComposeChainTrust from LoTE, LOTL, or both
+        trustSource(isChainTrusted) // from LoTE setup above
         classifications(myClassifications) // AttestationClassifications from ETSI library
         policy {
             default(TrustPolicy.Action.ENFORCE)
             forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
             forDocType("org.example.test", TrustPolicy.Action.INFORM)
         }
+        // Optional: enable signed issuer metadata verification (see below)
+        preferSignedMetadata()
     }
 }
 ```
@@ -781,6 +765,8 @@ val walletConfig = EudiWalletConfig {
 - **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
   as the trust source. Maps credential types to verification contexts.
 - **`policy`** -- configures how the wallet acts on trust results (see below).
+- **`preferSignedMetadata()`** / **`requireSignedMetadata()`** -- controls signed issuer
+  metadata verification (see [Signed Issuer Metadata Verification](#signed-issuer-metadata-verification)).
 
 ##### Trust Policies
 
@@ -857,6 +843,87 @@ configureIssuerTrust {
 }
 ```
 
+#### Signed Issuer Metadata Verification
+
+The library supports verifying signed issuer metadata (JWT type `openidvci-issuer-metadata+jwt`)
+as defined in OpenID4VCI. When an issuer provides signed metadata, the library extracts the x5c
+certificate chain from the JWT header and validates it against the configured trust source.
+
+Three metadata policies are available:
+
+| Policy            | Behaviour                                                                                      |
+|-------------------|------------------------------------------------------------------------------------------------|
+| `IgnoreSigned`    | **(Default)** Signed metadata is ignored; only unsigned metadata is used.                      |
+| `PreferSigned`    | Attempts to fetch signed metadata first. Falls back to unsigned if signed is not available. When signed metadata is served but the certificate chain is untrusted, issuance **fails**. |
+| `RequireSigned`   | Signed metadata must be available and its certificate chain must be trusted. Otherwise issuance fails. |
+
+Configure metadata verification within the `configureIssuerTrust` DSL:
+
+```kotlin
+configureIssuerTrust {
+    trustSource(isChainTrusted)
+    classifications(myClassifications)
+    policy { default(TrustPolicy.Action.INFORM) }
+
+    // Option A: prefer signed, fall back to unsigned if not available
+    preferSignedMetadata()
+
+    // Option B: require signed metadata (fails if not available or untrusted)
+    // requireSignedMetadata()
+}
+```
+
+When `preferSignedMetadata()` or `requireSignedMetadata()` is called without arguments, the
+library automatically creates a `CertificateChainTrust` adapter from the configured
+`trustSource`, using `VerificationContext.WalletRelyingPartyAccessCertificate` as the ETSI
+context for metadata signing certificates.
+
+You can also provide a custom `CertificateChainTrust` implementation:
+
+```kotlin
+preferSignedMetadata(myCustomCertificateChainTrust)
+```
+
+> **Note:** Metadata verification is a separate check from credential trust verification.
+> Metadata trust runs **before** credential issuance (during offer resolution / issuer metadata
+> fetch), while credential trust runs **after** the credential is received. Both are independent
+> and can be configured separately.
+
+#### Revocation Status Trust Verification
+
+The document status resolver can optionally verify that the signer of status list tokens (JWT
+or CWT) is trusted according to ETSI trusted lists. This adds an additional layer of trust
+beyond the default cryptographic signature verification (x5c/COSE_X509).
+
+Configure status list trust within the `configureDocumentStatusResolver` DSL:
+
+```kotlin
+val walletConfig = EudiWalletConfig {
+    configureDocumentStatusResolver {
+        clockSkew(5) // minutes
+        configureTrust {
+            trustSource(isChainTrusted) // same LoTE trust source
+            classifications(myClassifications)
+            policy {
+                default(TrustPolicy.Action.INFORM)
+            }
+        }
+    }
+}
+```
+
+The `configureTrust` block accepts the same DSL as issuer trust (`trustSource`,
+`classifications`, `policy`). The trust policy determines the action when the status list
+token signer is not trusted:
+
+| Action    | Behaviour                                                                          |
+|-----------|------------------------------------------------------------------------------------|
+| `ENFORCE` | Reject the status result — treat the document's revocation status as unknown.      |
+| `INFORM`  | Accept the status result regardless and let the application decide.                |
+
+When status list trust is not configured, the resolver falls back to standard x5c / COSE_X509
+signature verification without ETSI trust chain validation.
+
 #### Reader Authentication with Trusted Lists
 
 `EtsiReaderTrustStore` is a drop-in replacement for `ReaderTrustStoreImpl` that delegates
@@ -896,13 +963,27 @@ wallet.setReaderTrustStore(isChainTrusted.asReaderTrustStore())
 
 #### Full Configuration Example
 
-The following example shows a complete `EudiWallet` setup with both issuer trust verification
-and reader authentication using the same ETSI trust source:
+The following example shows a complete `EudiWallet` setup with issuer trust verification,
+signed metadata verification, revocation status trust, and reader authentication — all
+using the same ETSI trust source:
 
 ```kotlin
 // Application-scoped — create once, dispose on shutdown
 val disposableScope = DisposableContainer()
 val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
+
+// Attestation classifications map credential types to ETSI verification contexts
+val classifications = AttestationClassifications(
+    pids = AttestationIdentifierPredicate.any(
+        setOf(
+            AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+            AttestationIdentifier.SDJwtVc("urn:eudi:pid:1"),
+        )
+    ),
+    pubEAAs = AttestationIdentifierPredicate.equalsTo(
+        AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+    ),
+)
 
 val config = EudiWalletConfig {
     configureOpenId4Vci {
@@ -914,18 +995,33 @@ val config = EudiWalletConfig {
         withClientIdSchemes(ClientIdScheme.X509SanDns)
         withSchemes("openid4vp", "eudi-openid4vp", "mdoc-openid4vp")
     }
-    // Issuer trust verification
+
+    // 1. Issuer trust verification (credential issuance)
     configureIssuerTrust {
         trustSource(isChainTrusted)
-        classifications(myClassifications)
+        classifications(classifications)
         policy {
             default(TrustPolicy.Action.ENFORCE)
+        }
+        // 2. Signed issuer metadata verification
+        preferSignedMetadata()
+    }
+
+    // 3. Revocation status trust verification
+    configureDocumentStatusResolver {
+        clockSkew(5)
+        configureTrust {
+            trustSource(isChainTrusted)
+            classifications(classifications)
+            policy {
+                default(TrustPolicy.Action.INFORM)
+            }
         }
     }
 }
 
 val wallet = EudiWallet(context, config) {
-    // Reader authentication with ETSI trusted lists (same trust source)
+    // 4. Reader authentication with ETSI trusted lists (same trust source)
     withReaderTrustStore(isChainTrusted.asReaderTrustStore())
 }
 

--- a/README.md
+++ b/README.md
@@ -577,11 +577,369 @@ val wallet = EudiWallet(context, config) {
 }
 ```
 
+### Trusted Lists
+
+The library supports trust verification using ETSI Trusted Lists for both **credential issuance**
+(issuer trust) and **credential presentation** (reader/verifier authentication). This enables
+dynamic trust anchor resolution from LoTE (ETSI TS 119 602) and LOTL (ETSI TS 119 612) instead
+of static certificate lists.
+
+The design is **protocol-agnostic** — wallet-core defines integration contracts, and the developer
+composes trust validation using the
+[eudi-lib-kmp-etsi1196x2](https://github.com/eu-digital-identity-wallet/eudi-lib-kmp-etsi-1196x2)
+library directly (or any other trust framework).
+
+#### Dependencies
+
+The core consultation module (`etsi-1196x2-consultation`) is already included transitively via
+wallet-core. For LoTE or LOTL support, add the corresponding modules to your app's dependencies:
+
+```groovy
+dependencies {
+    // wallet-core (already includes etsi-1196x2-consultation transitively)
+    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0-SNAPSHOT"
+
+    // For LoTE (List of Trusted Entities) support — ETSI TS 119 602
+    implementation "eu.europa.ec.eudi:etsi-119602-consultation:0.3.0-alpha.5-SNAPSHOT"
+
+    // For LOTL (List of Trusted Lists) support via DSS — ETSI TS 119 612
+    implementation "eu.europa.ec.eudi:etsi-1196x2-consultation-dss:0.3.0-alpha.5-SNAPSHOT"
+}
+```
+
+#### Setting Up Trust Anchor Resolution
+
+##### LoTE (ETSI TS 119 602)
+
+Set up trust anchor resolution from Lists of Trusted Entities:
+
+```kotlin
+// 1. Set up LoTE loading with file cache
+// HttpClient() auto-discovers the ktor-client-android engine at runtime
+val httpClient = HttpClient()
+val loadLoTE = LoadSingleLoTEWithFileCache(
+    cacheDirectory = Path(context.cacheDir.path, "lote-cache"),
+    downloadSingleLoTE = DownloadSingleLoTE(httpClient),
+    fileCacheExpiration = 24.hours,
+)
+
+// 2. Configure LoTE pointer loading and JWT verification
+val loadLoTEAndPointers = LoadLoTEAndPointers(
+    constraints = LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers,
+    verifyJwtSignature = myJwtVerifier, // Your VerifyJwtSignature implementation
+    loadLoTE = loadLoTE,
+)
+
+// 3. Build trust anchor provisioner with EU defaults
+val provisionTrustAnchors = ProvisionTrustAnchorsFromLoTEs.eudiwJvm(loadLoTEAndPointers)
+
+// 4. Configure LoTE URLs for the provider types you need
+val loteLocations = SupportedLists(
+    pidProviders = "https://trust.example.eu/pid-providers.jwt",
+    wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
+    // pubEaaProviders = "https://trust.example.eu/pub-eaa-providers.jwt",
+    // qeaProviders = "https://trust.example.eu/qeaa-providers.jwt",
+)
+
+// 5. Create cached trust validator
+// DisposableContainer manages the lifecycle of cached trust anchors.
+// Create it at Application scope and call dispose() when no longer needed.
+val disposableScope = DisposableContainer()
+val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
+
+// Use isChainTrusted for both issuer trust and reader authentication (see below)
+
+// When shutting down (e.g. Application.onTerminate()):
+// disposableScope.dispose()
+```
+
+> **VerifyJwtSignature:** The ETSI library requires a `VerifyJwtSignature` implementation to
+> verify the cryptographic signature of downloaded LoTE JWT documents before trusting their
+> contents. The signing keys vary by deployment (EU production, national lists, acceptance
+> environments). The library provides only a `NotValidating` test stub — **do not use it in
+> production**.
+
+The following example shows how to implement `VerifyJwtSignature` using Nimbus JWT to verify
+the LoTE JWT signature against a list of trusted signing certificates:
+
+```kotlin
+// Trusted certificates for LoTE JWT signature verification
+// (e.g., EU Commission's LoTE signing certificate)
+val loteTrustedCertificates: List<X509Certificate> = listOf(/* your trusted certs */)
+
+val myJwtVerifier = VerifyJwtSignature { jwt ->
+    try {
+        val signedJwt = SignedJWT.parse(jwt)
+
+        // Extract x5c certificate chain from JWT header
+        val x5cChain = signedJwt.header.x509CertChain
+            ?: return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
+                IllegalStateException("Missing x5c in LoTE JWT header")
+            )
+        val chainCerts = x5cChain.mapNotNull { X509CertUtils.parse(it.decode()) }
+        if (chainCerts.isEmpty()) {
+            return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
+                IllegalStateException("No valid certificates in x5c")
+            )
+        }
+
+        // Verify JWT signature using the signing certificate's public key
+        val signingCert = chainCerts.first()
+        val verifier = when (val key = signingCert.publicKey) {
+            is ECPublicKey -> ECDSAVerifier(key)
+            is RSAPublicKey -> RSASSAVerifier(key)
+            else -> return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
+                IllegalStateException("Unsupported key type: ${key.javaClass.name}")
+            )
+        }
+        if (!signedJwt.verify(verifier)) {
+            return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
+                IllegalStateException("JWT signature verification failed")
+            )
+        }
+
+        // Validate signing certificate against trusted certificates
+        // Try direct trust first (subject DN + serial number match)
+        val directlyTrusted = loteTrustedCertificates.any { trusted ->
+            trusted.subjectX500Principal == signingCert.subjectX500Principal &&
+                trusted.serialNumber == signingCert.serialNumber
+        }
+        if (directlyTrusted) {
+            return@VerifyJwtSignature VerifyJwtSignature.Outcome.Verified(jwt)
+        }
+
+        // Fall back to PKIX chain validation
+        val certPath = CertificateFactory.getInstance("X.509").generateCertPath(chainCerts)
+        val trustAnchors = loteTrustedCertificates.map { TrustAnchor(it, null) }.toSet()
+        val params = PKIXParameters(trustAnchors).apply { isRevocationEnabled = false }
+        CertPathValidator.getInstance("PKIX").validate(certPath, params)
+
+        VerifyJwtSignature.Outcome.Verified(jwt)
+    } catch (e: Exception) {
+        VerifyJwtSignature.Outcome.NotVerified(e)
+    }
+}
+```
+>
+> **Lifecycle:** `DisposableContainer` replaces `useResources` for Android. While `useResources`
+> is a scoping block that disposes resources when the block exits (suitable for short-lived
+> operations), Android apps need long-lived trust caches. Create a `DisposableContainer` at
+> Application scope and call `dispose()` during shutdown to release cached resources.
+>
+> **HTTP Client:** `HttpClient()` with no explicit engine auto-discovers `ktor-client-android` at
+> runtime (already included as a `runtimeOnly` dependency by wallet-core). You can also pass a
+> custom `HttpClient` if you need specific configuration (logging, timeouts, etc.).
+
+##### LOTL (ETSI TS 119 612 via DSS)
+
+For trust resolution from Lists of Trusted Lists:
+
+```kotlin
+val getTrustAnchors = GetTrustAnchorsFromLoTL(
+    dssOptions = DssOptions.usingFileCacheDataLoader(
+        cacheDirectory = Path(context.cacheDir.path, "lotl-cache"),
+    )
+)
+// Compose into IsChainTrustedForContext, then into ComposeChainTrust
+```
+
+##### Combining LoTE + LOTL
+
+Multiple trust sources can be combined using the `+` operator on `ComposeChainTrust`, as long
+as they cover disjoint sets of verification contexts:
+
+```kotlin
+val combined = loTeValidator + loTlValidator
+```
+
+#### Issuer Trust Verification
+
+Trust verification runs after the credential is received from the issuer and before it is stored.
+Built-in verifiers handle both MsoMdoc and SD-JWT VC formats, and custom verifiers can be
+registered for additional formats. When issuer trust is not configured, verification is skipped
+entirely and credentials are stored as before.
+
+Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWalletConfig`:
+
+```kotlin
+val walletConfig = EudiWalletConfig {
+    // ... other configuration ...
+    configureIssuerTrust {
+        trustSource(isChainTrusted) // ComposeChainTrust from LoTE, LOTL, or both
+        classifications(myClassifications) // AttestationClassifications from ETSI library
+        policy {
+            default(TrustPolicy.Action.ENFORCE)
+            forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
+            forDocType("org.example.test", TrustPolicy.Action.INFORM)
+        }
+    }
+}
+```
+
+- **`trustSource`** -- sets the trust anchor source. Accepts a `ComposeChainTrust`,
+  `IsChainTrustedForEUDIW`, or a pre-built `IsChainTrustedForAttestation`.
+- **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
+  as the trust source. Maps credential types to verification contexts.
+- **`policy`** -- configures how the wallet acts on trust results (see below).
+
+##### Trust Policies
+
+A `TrustPolicy` determines the action taken when an issuer is not trusted:
+
+| Action    | Behaviour                                                                   |
+|-----------|-----------------------------------------------------------------------------|
+| `ENFORCE` | Reject the credential -- delete it and emit `IssueEvent.DocumentFailed`.    |
+| `INFORM`  | Store the credential regardless and attach the result to `DocumentIssued`.  |
+
+The default policy is `ENFORCE` for all credentials. Use the `policy` DSL to override per
+verification context or per attestation type. Resolution order (highest priority first):
+
+1. Per-attestation overrides (`forDocType`, `forVct`, `forAttestation`)
+2. Per-context overrides (`forContext`)
+3. Default action (`default`)
+
+##### Handling Trust Results
+
+The trust verification result is available on `IssueEvent.DocumentIssued` and
+`IssueEvent.DocumentFailed`:
+
+```kotlin
+manager.issueDocumentByOfferUri(offerUri) { event ->
+    when (event) {
+        is IssueEvent.DocumentIssued -> {
+            when (event.issuerTrustResult) {
+                is CertificationChainValidation.Trusted -> {
+                    // Issuer is trusted
+                }
+                is CertificationChainValidation.NotTrusted -> {
+                    // INFORM policy: credential stored, but issuer was not trusted
+                }
+                null -> {
+                    // Trust verification not configured
+                }
+            }
+        }
+        is IssueEvent.DocumentFailed -> {
+            if (event.cause is IssuerNotTrustedException) {
+                // ENFORCE policy: credential rejected because issuer was not trusted
+                Log.w("Trust", "Issuer not trusted", event.cause)
+            }
+        }
+        else -> Unit
+    }
+}
+```
+
+##### Custom CredentialTrustVerifier
+
+The library includes built-in verifiers for MsoMdoc and SD-JWT VC formats. To support
+additional credential formats, implement the `CredentialTrustVerifier` interface and register
+it during configuration:
+
+```kotlin
+class MyCustomVerifier(
+    private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+) : CredentialTrustVerifier {
+    override suspend fun verify(
+        credentialValue: String,
+        attestationIdentifier: AttestationIdentifier,
+    ): CertificationChainValidation<TrustAnchor>? {
+        // Extract certificate chain from the credential and evaluate trust
+        // Return null if the chain cannot be extracted
+    }
+}
+
+// Register during configuration
+configureIssuerTrust {
+    trustSource(myComposeChainTrust)
+    classifications(myClassifications)
+    credentialTrustVerifier(MyCustomFormat::class, MyCustomVerifier(isChainTrusted))
+}
+```
+
+#### Reader Authentication with Trusted Lists
+
+`EtsiReaderTrustStore` is a drop-in replacement for `ReaderTrustStoreImpl` that delegates
+reader certificate chain validation to the ETSI library's `IsChainTrustedForEUDIW`. It
+uses the `WalletRelyingPartyAccessCertificate` (WRPAC) verification context by default.
+
+Use the convenience extension to create a `ReaderTrustStore` from any ETSI chain trust validator:
+
+```kotlin
+val wallet = EudiWallet(context, config) {
+    withReaderTrustStore(isChainTrusted.asReaderTrustStore())
+}
+```
+
+Or create an `EtsiReaderTrustStore` explicitly with a specific verification context:
+
+```kotlin
+val readerTrustStore = EtsiReaderTrustStore(
+    isChainTrusted = isChainTrusted,
+    verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+)
+
+val wallet = EudiWallet(context, config) {
+    withReaderTrustStore(readerTrustStore)
+}
+```
+
+You can also update the reader trust store at runtime:
+
+```kotlin
+wallet.setReaderTrustStore(isChainTrusted.asReaderTrustStore())
+```
+
+> **Note:** For best performance during presentations, pre-warm the ETSI cache on app startup.
+> This ensures that trust anchors are already resolved and cached before the first reader
+> authentication occurs.
+
+#### Full Configuration Example
+
+The following example shows a complete `EudiWallet` setup with both issuer trust verification
+and reader authentication using the same ETSI trust source:
+
+```kotlin
+// Application-scoped — create once, dispose on shutdown
+val disposableScope = DisposableContainer()
+val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
+
+val config = EudiWalletConfig {
+    configureOpenId4Vci {
+        withIssuerUrl("https://issuer.example.com")
+        withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.AttestationBased)
+        withAuthFlowRedirectionURI("eudi-openid4ci://authorize")
+    }
+    configureOpenId4Vp {
+        withClientIdSchemes(ClientIdScheme.X509SanDns)
+        withSchemes("openid4vp", "eudi-openid4vp", "mdoc-openid4vp")
+    }
+    // Issuer trust verification
+    configureIssuerTrust {
+        trustSource(isChainTrusted)
+        classifications(myClassifications)
+        policy {
+            default(TrustPolicy.Action.ENFORCE)
+        }
+    }
+}
+
+val wallet = EudiWallet(context, config) {
+    // Reader authentication with ETSI trusted lists (same trust source)
+    withReaderTrustStore(isChainTrusted.asReaderTrustStore())
+}
+
+// On shutdown:
+// disposableScope.dispose()
+```
+
 ### Issue document using OpenID4VCI
 
 The library provides issuing documents using OpenID4VCI protocol. To issue a document
 using this functionality, EudiWallet must be initialized with the `openId4VciConfig` configuration,
 during configuration. See the [Initialize the library](#initialize-the-library) section.
+
+To validate issuer trust before storing credentials, see [Trusted Lists](#trusted-lists).
 
 #### Creating an OpenId4VciManager
 
@@ -718,8 +1076,7 @@ val onIssueEvent = OnIssueEvent { event ->
             // Need to provide settings for document creation
             // Create document settings can be varied depending on the document type
 
-            val format = event.offeredDocument.documentFormat
-            val isEuPid = when (format) {
+            val isEuPid = when (val format = event.offeredDocument.documentFormat) {
                 is MsoMdocFormat -> format.docType == "eu.europa.ec.eudi.pid.1"
                 is SdJwtVcFormat -> format.vct == "urn:eudi:pid:1"
                 else -> false
@@ -1195,120 +1552,9 @@ val walletConfig = EudiWalletConfig()
     }
 ```
 
-### Issuer Trust Verification
-
-The library supports verifying credential issuers against ETSI trusted lists during
-OpenID4VCI issuance. Trust verification runs after the credential is received from the issuer
-and before it is stored. It is protocol-agnostic -- built-in verifiers handle both MsoMdoc and
-SD-JWT VC formats, and custom verifiers can be registered for additional formats.
-
-When issuer trust is not configured, verification is skipped entirely and credentials are
-stored as before.
-
-#### Configuration
-
-Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWalletConfig`:
-
-```kotlin
-val walletConfig = EudiWalletConfig {
-    // ... other configuration ...
-    configureIssuerTrust {
-        trustSource(myComposeChainTrust) // ComposeChainTrust from LoTE, LOTL, or both
-        classifications(myClassifications) // AttestationClassifications from ETSI library
-        policy {
-            default(TrustPolicy.Action.ENFORCE)
-            forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
-            forDocType("org.example.test", TrustPolicy.Action.INFORM)
-            forVct("urn:example:test", TrustPolicy.Action.INFORM)
-        }
-    }
-}
-```
-
-- **`trustSource`** -- sets the trust anchor source. Accepts a `ComposeChainTrust`,
-  `IsChainTrustedForEUDIW`, or a pre-built `IsChainTrustedForAttestation`.
-- **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
-  as the trust source. Maps credential types to verification contexts.
-- **`policy`** -- configures how the wallet acts on trust results (see below).
-
-#### Trust Policies
-
-A `TrustPolicy` determines the action taken when an issuer is not trusted:
-
-| Action    | Behaviour                                                                   |
-|-----------|-----------------------------------------------------------------------------|
-| `ENFORCE` | Reject the credential -- delete it and emit `IssueEvent.DocumentFailed`.    |
-| `INFORM`  | Store the credential regardless and attach the result to `DocumentIssued`.  |
-
-The default policy is `ENFORCE` for all credentials. Use the `policy` DSL to override per
-verification context or per attestation type. Resolution order (highest priority first):
-
-1. Per-attestation overrides (`forDocType`, `forVct`, `forAttestation`)
-2. Per-context overrides (`forContext`)
-3. Default action (`default`)
-
-#### Handling Trust Results
-
-The trust verification result is available on `IssueEvent.DocumentIssued` and
-`IssueEvent.DocumentFailed`:
-
-```kotlin
-wallet.issueDocumentByOfferUri(offerUri) { event ->
-    when (event) {
-        is IssueEvent.DocumentIssued -> {
-            when (event.issuerTrustResult) {
-                is CertificationChainValidation.Trusted -> {
-                    // Issuer is trusted
-                }
-                is CertificationChainValidation.NotTrusted -> {
-                    // INFORM policy: credential stored, but issuer was not trusted
-                }
-                null -> {
-                    // Trust verification not configured
-                }
-            }
-        }
-
-        is IssueEvent.DocumentFailed -> {
-            if (event.cause is IssuerNotTrustedException) {
-                // ENFORCE policy: credential rejected because issuer was not trusted
-            }
-        }
-
-        // ... handle other events ...
-        else -> {}
-    }
-}
-```
-
-#### Custom CredentialTrustVerifier
-
-The library includes built-in verifiers for MsoMdoc and SD-JWT VC formats. To support
-additional credential formats, implement the `CredentialTrustVerifier` interface and register
-it during configuration:
-
-```kotlin
-class MyCustomVerifier(
-    private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
-) : CredentialTrustVerifier {
-    override suspend fun verify(
-        credentialValue: String,
-        attestationIdentifier: AttestationIdentifier,
-    ): CertificationChainValidation<TrustAnchor>? {
-        // Extract certificate chain from the credential and evaluate trust
-        // Return null if the chain cannot be extracted
-    }
-}
-
-// Register during configuration
-configureIssuerTrust {
-    trustSource(myComposeChainTrust)
-    classifications(myClassifications)
-    credentialTrustVerifier(MyCustomFormat::class, MyCustomVerifier(isChainTrusted))
-}
-```
-
 ### Transfer documents
+
+To authenticate readers/verifiers using ETSI Trusted Lists, see [Trusted Lists](#trusted-lists).
 
 The library supports the following 3 ways to transfer documents:
 
@@ -1493,8 +1739,6 @@ wallet.addTransferEventListener { event ->
    when the activity is paused.
 
     ```kotlin
-    import androidx.appcompat.app.AppCompatActivity
-    
     class MainActivity : AppCompatActivity() {
         
         lateinit var wallet: EudiWallet

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.issue.openid4vci/-deferred-issue-result/-document-issued/issuer-trust-result.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.issue.openid4vci/-deferred-issue-result/-document-issued/issuer-trust-result.md
@@ -1,0 +1,6 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.issue.openid4vci](../../index.md)/[DeferredIssueResult](../index.md)/[DocumentIssued](index.md)/[issuerTrustResult](issuer-trust-result.md)
+
+# issuerTrustResult
+
+[androidJvm]\
+val [issuerTrustResult](issuer-trust-result.md): CertificationChainValidation&lt;[TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;? = null

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.issue.openid4vci/-issue-event/-document-issued/issuer-trust-result.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.issue.openid4vci/-issue-event/-document-issued/issuer-trust-result.md
@@ -1,0 +1,6 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.issue.openid4vci](../../index.md)/[IssueEvent](../index.md)/[DocumentIssued](index.md)/[issuerTrustResult](issuer-trust-result.md)
+
+# issuerTrustResult
+
+[androidJvm]\
+val [issuerTrustResult](issuer-trust-result.md): CertificationChainValidation&lt;[TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;? = null

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-credential-trust-verifier/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-credential-trust-verifier/index.md
@@ -1,0 +1,26 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[CredentialTrustVerifier](index.md)
+
+# CredentialTrustVerifier
+
+fun interface [CredentialTrustVerifier](index.md)
+
+Per-format credential trust verifier. Implementations extract the certificate chain from the credential and evaluate trust using the ETSI library.
+
+Built-in implementations:
+
+- 
+   MsoMdocCredentialTrustVerifier for MsoMdoc credentials (uses multipaz CBOR/COSE)
+- 
+   SdJwtVcCredentialTrustVerifier for SD-JWT VC credentials (uses eudi sd-jwt-vc library)
+
+#### See also
+
+| | |
+|---|---|
+| [IssuerTrustConfigBuilder.credentialTrustVerifier](../-issuer-trust-config-builder/credential-trust-verifier.md) | for registering custom verifiers |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [verify](verify.md) | [androidJvm]<br>abstract suspend fun [verify](verify.md)(credentialValue: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), attestationIdentifier: AttestationIdentifier): CertificationChainValidation&lt;[TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;?<br>Verify the issuer trust for a credential. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-credential-trust-verifier/verify.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-credential-trust-verifier/verify.md
@@ -1,0 +1,21 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[CredentialTrustVerifier](index.md)/[verify](verify.md)
+
+# verify
+
+[androidJvm]\
+abstract suspend fun [verify](verify.md)(credentialValue: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), attestationIdentifier: AttestationIdentifier): CertificationChainValidation&lt;[TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;?
+
+Verify the issuer trust for a credential.
+
+#### Return
+
+the trust evaluation result, or `null` if the certificate chain could not be extracted or the verification context is not configured
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| credentialValue | the raw credential string (base64url-encoded CBOR for MsoMdoc, or SD-JWT string for SD-JWT VC) |
+| attestationIdentifier | the attestation identifier derived from the document format |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-not-trusted-exception/-issuer-not-trusted-exception.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-not-trusted-exception/-issuer-not-trusted-exception.md
@@ -1,0 +1,14 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerNotTrustedException](index.md)/[IssuerNotTrustedException](-issuer-not-trusted-exception.md)
+
+# IssuerNotTrustedException
+
+[androidJvm]\
+constructor(cause: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html))
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| cause | the underlying cause from the trust evaluation |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-not-trusted-exception/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-not-trusted-exception/index.md
@@ -1,0 +1,41 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerNotTrustedException](index.md)
+
+# IssuerNotTrustedException
+
+class [IssuerNotTrustedException](index.md)(cause: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)) : [Exception](https://developer.android.com/reference/kotlin/java/lang/Exception.html)
+
+Thrown when the issuer certificate chain is not trusted and the [trust policy](../-trust-policy/index.md) action is [TrustPolicy.Action.ENFORCE](../-trust-policy/-action/-e-n-f-o-r-c-e/index.md).
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| cause | the underlying cause from the trust evaluation |
+
+## Constructors
+
+| | |
+|---|---|
+| [IssuerNotTrustedException](-issuer-not-trusted-exception.md) | [androidJvm]<br>constructor(cause: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)) |
+
+## Properties
+
+| Name | Summary |
+|---|---|
+| [cause](index.md#-654012527%2FProperties%2F1615067946) | [androidJvm]<br>open val [cause](index.md#-654012527%2FProperties%2F1615067946): [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)? |
+| [message](index.md#1824300659%2FProperties%2F1615067946) | [androidJvm]<br>open val [message](index.md#1824300659%2FProperties%2F1615067946): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html)? |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [addSuppressed](index.md#282858770%2FFunctions%2F1615067946) | [androidJvm]<br>fun [addSuppressed](index.md#282858770%2FFunctions%2F1615067946)(p0: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)) |
+| [fillInStackTrace](index.md#-1102069925%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [fillInStackTrace](index.md#-1102069925%2FFunctions%2F1615067946)(): [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html) |
+| [getLocalizedMessage](index.md#1043865560%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [getLocalizedMessage](index.md#1043865560%2FFunctions%2F1615067946)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html) |
+| [getStackTrace](index.md#2050903719%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [getStackTrace](index.md#2050903719%2FFunctions%2F1615067946)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-array/index.html)&lt;[StackTraceElement](https://developer.android.com/reference/kotlin/java/lang/StackTraceElement.html)&gt; |
+| [getSuppressed](index.md#672492560%2FFunctions%2F1615067946) | [androidJvm]<br>fun [getSuppressed](index.md#672492560%2FFunctions%2F1615067946)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-array/index.html)&lt;[Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)&gt; |
+| [initCause](index.md#-418225042%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [initCause](index.md#-418225042%2FFunctions%2F1615067946)(p0: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)): [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html) |
+| [printStackTrace](index.md#-1769529168%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [printStackTrace](index.md#-1769529168%2FFunctions%2F1615067946)()<br>open fun [printStackTrace](index.md#1841853697%2FFunctions%2F1615067946)(p0: [PrintStream](https://developer.android.com/reference/kotlin/java/io/PrintStream.html))<br>open fun [printStackTrace](index.md#1175535278%2FFunctions%2F1615067946)(p0: [PrintWriter](https://developer.android.com/reference/kotlin/java/io/PrintWriter.html)) |
+| [setStackTrace](index.md#2135801318%2FFunctions%2F1615067946) | [androidJvm]<br>open fun [setStackTrace](index.md#2135801318%2FFunctions%2F1615067946)(p0: [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-array/index.html)&lt;[StackTraceElement](https://developer.android.com/reference/kotlin/java/lang/StackTraceElement.html)&gt;) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/-issuer-trust-config-builder.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/-issuer-trust-config-builder.md
@@ -1,0 +1,6 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)/[IssuerTrustConfigBuilder](-issuer-trust-config-builder.md)
+
+# IssuerTrustConfigBuilder
+
+[androidJvm]\
+constructor()

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/classifications.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/classifications.md
@@ -1,0 +1,18 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)/[classifications](classifications.md)
+
+# classifications
+
+[androidJvm]\
+fun [classifications](classifications.md)(classifications: AttestationClassifications)
+
+Sets the attestation classifications used to map credential types to verification contexts.
+
+Required when the trust source is an IsChainTrustedForEUDIW or ComposeChainTrust.
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| classifications | the attestation classifications |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/credential-trust-verifier.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/credential-trust-verifier.md
@@ -1,0 +1,17 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)/[credentialTrustVerifier](credential-trust-verifier.md)
+
+# credentialTrustVerifier
+
+[androidJvm]\
+fun [credentialTrustVerifier](credential-trust-verifier.md)(format: [KClass](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.reflect/-k-class/index.html)&lt;out DocumentFormat&gt;, verifier: [CredentialTrustVerifier](../-credential-trust-verifier/index.md))
+
+Registers a custom [CredentialTrustVerifier](../-credential-trust-verifier/index.md) for a specific DocumentFormat type.
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| format | the document format class to associate the verifier with |
+| verifier | the credential trust verifier implementation |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/index.md
@@ -1,0 +1,38 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)
+
+# IssuerTrustConfigBuilder
+
+[androidJvm]\
+class [IssuerTrustConfigBuilder](index.md)
+
+DSL builder for constructing an IssuerTrustConfig.
+
+A trust source must be provided via one of the [trustSource](trust-source.md) overloads. When using IsChainTrustedForEUDIW or ComposeChainTrust as the trust source, [classifications](classifications.md) must also be provided so the builder can construct an IsChainTrustedForAttestation instance.
+
+Example:
+
+```kotlin
+val config = IssuerTrustConfigBuilder().apply {
+    trustSource(myComposeChainTrust)
+    classifications(myClassifications)
+    policy {
+        default(TrustPolicy.Action.ENFORCE)
+        forContext(VerificationContext.PID, TrustPolicy.Action.INFORM)
+    }
+}.build()
+```
+
+## Constructors
+
+| | |
+|---|---|
+| [IssuerTrustConfigBuilder](-issuer-trust-config-builder.md) | [androidJvm]<br>constructor() |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [classifications](classifications.md) | [androidJvm]<br>fun [classifications](classifications.md)(classifications: AttestationClassifications)<br>Sets the attestation classifications used to map credential types to verification contexts. |
+| [credentialTrustVerifier](credential-trust-verifier.md) | [androidJvm]<br>fun [credentialTrustVerifier](credential-trust-verifier.md)(format: [KClass](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.reflect/-k-class/index.html)&lt;out DocumentFormat&gt;, verifier: [CredentialTrustVerifier](../-credential-trust-verifier/index.md))<br>Registers a custom [CredentialTrustVerifier](../-credential-trust-verifier/index.md) for a specific DocumentFormat type. |
+| [policy](policy.md) | [androidJvm]<br>fun [policy](policy.md)(block: [TrustPolicy.Builder](../-trust-policy/-builder/index.md).() -&gt; [Unit](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-unit/index.html))<br>Configures the trust policy using the [TrustPolicy.Builder](../-trust-policy/-builder/index.md) DSL. |
+| [trustSource](trust-source.md) | [androidJvm]<br>fun [trustSource](trust-source.md)(source: &lt;Error class: unknown class&gt;&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)<br>Sets the trust source from an IsChainTrustedForEUDIW instance.<br>[androidJvm]<br>fun [trustSource](trust-source.md)(source: ComposeChainTrust&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, VerificationContext, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)<br>Sets the trust source from a ComposeChainTrust instance.<br>[androidJvm]<br>fun [trustSource](trust-source.md)(source: IsChainTrustedForAttestation&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)<br>Sets the trust source from a pre-built IsChainTrustedForAttestation. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/policy.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/policy.md
@@ -1,0 +1,18 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)/[policy](policy.md)
+
+# policy
+
+[androidJvm]\
+fun [policy](policy.md)(block: [TrustPolicy.Builder](../-trust-policy/-builder/index.md).() -&gt; [Unit](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-unit/index.html))
+
+Configures the trust policy using the [TrustPolicy.Builder](../-trust-policy/-builder/index.md) DSL.
+
+If not called, the default policy is [TrustPolicy.Action.ENFORCE](../-trust-policy/-action/-e-n-f-o-r-c-e/index.md) for all credentials.
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| block | configuration block applied to the [TrustPolicy.Builder](../-trust-policy/-builder/index.md) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/trust-source.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/trust-source.md
@@ -1,0 +1,48 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[IssuerTrustConfigBuilder](index.md)/[trustSource](trust-source.md)
+
+# trustSource
+
+[androidJvm]\
+fun [trustSource](trust-source.md)(source: IsChainTrustedForAttestation&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)
+
+Sets the trust source from a pre-built IsChainTrustedForAttestation.
+
+When using this overload, [classifications](classifications.md) is not required (the attestation already encapsulates the classification logic).
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| source | the pre-built attestation trust source |
+
+[androidJvm]\
+fun [trustSource](trust-source.md)(source: ComposeChainTrust&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, VerificationContext, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)
+
+Sets the trust source from a ComposeChainTrust instance.
+
+When using this overload, [classifications](classifications.md) must be provided before calling build.
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| source | the composed chain trust source |
+
+[androidJvm]\
+fun [trustSource](trust-source.md)(source: &lt;Error class: unknown class&gt;&lt;[List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.collections/-list/index.html)&lt;[X509Certificate](https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate.html)&gt;, [TrustAnchor](https://developer.android.com/reference/kotlin/java/security/cert/TrustAnchor.html)&gt;)
+
+Sets the trust source from an IsChainTrustedForEUDIW instance.
+
+When using this overload, [classifications](classifications.md) must be provided before calling build.
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| source | the EUDIW trust source |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/-e-n-f-o-r-c-e/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/-e-n-f-o-r-c-e/index.md
@@ -1,0 +1,15 @@
+//[wallet-core](../../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../../index.md)/[TrustPolicy](../../index.md)/[Action](../index.md)/[ENFORCE](index.md)
+
+# ENFORCE
+
+[androidJvm]\
+[ENFORCE](index.md)
+
+Strict enforcement: if the issuer is not trusted, reject and delete the document and emit a `DocumentFailed` event.
+
+## Properties
+
+| Name | Summary |
+|---|---|
+| [name](../-i-n-f-o-r-m/index.md#-372974862%2FProperties%2F1615067946) | [androidJvm]<br>val [name](../-i-n-f-o-r-m/index.md#-372974862%2FProperties%2F1615067946): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html) |
+| [ordinal](../-i-n-f-o-r-m/index.md#-739389684%2FProperties%2F1615067946) | [androidJvm]<br>val [ordinal](../-i-n-f-o-r-m/index.md#-739389684%2FProperties%2F1615067946): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-int/index.html) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/-i-n-f-o-r-m/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/-i-n-f-o-r-m/index.md
@@ -1,0 +1,15 @@
+//[wallet-core](../../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../../index.md)/[TrustPolicy](../../index.md)/[Action](../index.md)/[INFORM](index.md)
+
+# INFORM
+
+[androidJvm]\
+[INFORM](index.md)
+
+Informational only: always store the document regardless of trust result, and attach the trust verification result to the `DocumentIssued` event.
+
+## Properties
+
+| Name | Summary |
+|---|---|
+| [name](index.md#-372974862%2FProperties%2F1615067946) | [androidJvm]<br>val [name](index.md#-372974862%2FProperties%2F1615067946): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html) |
+| [ordinal](index.md#-739389684%2FProperties%2F1615067946) | [androidJvm]<br>val [ordinal](index.md#-739389684%2FProperties%2F1615067946): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-int/index.html) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/entries.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/entries.md
@@ -1,0 +1,10 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Action](index.md)/[entries](entries.md)
+
+# entries
+
+[androidJvm]\
+val [entries](entries.md): [EnumEntries](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.enums/-enum-entries/index.html)&lt;[TrustPolicy.Action](index.md)&gt;
+
+Returns a representation of an immutable list of all enum entries, in the order they're declared.
+
+This method may be used to iterate over the enum entries.

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/index.md
@@ -1,0 +1,30 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Action](index.md)
+
+# Action
+
+[androidJvm]\
+enum [Action](index.md) : [Enum](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-enum/index.html)&lt;[TrustPolicy.Action](index.md)&gt; 
+
+Describes how the wallet should react to trust verification outcomes.
+
+## Entries
+
+| | |
+|---|---|
+| [ENFORCE](-e-n-f-o-r-c-e/index.md) | [androidJvm]<br>[ENFORCE](-e-n-f-o-r-c-e/index.md)<br>Strict enforcement: if the issuer is not trusted, reject and delete the document and emit a `DocumentFailed` event. |
+| [INFORM](-i-n-f-o-r-m/index.md) | [androidJvm]<br>[INFORM](-i-n-f-o-r-m/index.md)<br>Informational only: always store the document regardless of trust result, and attach the trust verification result to the `DocumentIssued` event. |
+
+## Properties
+
+| Name | Summary |
+|---|---|
+| [entries](entries.md) | [androidJvm]<br>val [entries](entries.md): [EnumEntries](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin.enums/-enum-entries/index.html)&lt;[TrustPolicy.Action](index.md)&gt;<br>Returns a representation of an immutable list of all enum entries, in the order they're declared. |
+| [name](-i-n-f-o-r-m/index.md#-372974862%2FProperties%2F1615067946) | [androidJvm]<br>val [name](-i-n-f-o-r-m/index.md#-372974862%2FProperties%2F1615067946): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html) |
+| [ordinal](-i-n-f-o-r-m/index.md#-739389684%2FProperties%2F1615067946) | [androidJvm]<br>val [ordinal](-i-n-f-o-r-m/index.md#-739389684%2FProperties%2F1615067946): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-int/index.html) |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [valueOf](value-of.md) | [androidJvm]<br>fun [valueOf](value-of.md)(value: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html)): [TrustPolicy.Action](index.md)<br>Returns the enum constant of this type with the specified name. The string must match exactly an identifier used to declare an enum constant in this type. (Extraneous whitespace characters are not permitted.) |
+| [values](values.md) | [androidJvm]<br>fun [values](values.md)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-array/index.html)&lt;[TrustPolicy.Action](index.md)&gt;<br>Returns an array containing the constants of this enum type, in the order they're declared. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/value-of.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/value-of.md
@@ -1,0 +1,14 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Action](index.md)/[valueOf](value-of.md)
+
+# valueOf
+
+[androidJvm]\
+fun [valueOf](value-of.md)(value: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html)): [TrustPolicy.Action](index.md)
+
+Returns the enum constant of this type with the specified name. The string must match exactly an identifier used to declare an enum constant in this type. (Extraneous whitespace characters are not permitted.)
+
+#### Throws
+
+| | |
+|---|---|
+| kotlin.IllegalArgumentException | if this enum type has no constant with the specified name |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/values.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-action/values.md
@@ -1,0 +1,10 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Action](index.md)/[values](values.md)
+
+# values
+
+[androidJvm]\
+fun [values](values.md)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-array/index.html)&lt;[TrustPolicy.Action](index.md)&gt;
+
+Returns an array containing the constants of this enum type, in the order they're declared.
+
+This method may be used to iterate over the constants.

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/-builder.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/-builder.md
@@ -1,0 +1,6 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[Builder](-builder.md)
+
+# Builder
+
+[androidJvm]\
+constructor()

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/build.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/build.md
@@ -1,0 +1,12 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[build](build.md)
+
+# build
+
+[androidJvm]\
+fun [build](build.md)(): [TrustPolicy](../index.md)
+
+Builds the [TrustPolicy](../index.md) with the configured overrides.
+
+#### Return
+
+a [TrustPolicy](../index.md) that resolves actions using the layered override rules

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/default.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/default.md
@@ -1,0 +1,20 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[default](default.md)
+
+# default
+
+[androidJvm]\
+fun [default](default.md)(action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;
+
+Sets the default action when no specific override matches.
+
+#### Return
+
+this builder for chaining
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| action | the fallback action (defaults to [Action.ENFORCE](../-action/-e-n-f-o-r-c-e/index.md) if not called) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-attestation.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-attestation.md
@@ -1,0 +1,23 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[forAttestation](for-attestation.md)
+
+# forAttestation
+
+[androidJvm]\
+fun [forAttestation](for-attestation.md)(identifier: AttestationIdentifier, action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;
+
+Adds an override for a specific AttestationIdentifier.
+
+This takes the highest priority in resolution order.
+
+#### Return
+
+this builder for chaining
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| identifier | the attestation identifier to match |
+| action | the action to return when the identifier matches |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-context.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-context.md
@@ -1,0 +1,21 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[forContext](for-context.md)
+
+# forContext
+
+[androidJvm]\
+fun [forContext](for-context.md)(context: VerificationContext, action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;
+
+Adds an override for a specific VerificationContext.
+
+#### Return
+
+this builder for chaining
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| context | the verification context to match |
+| action | the action to return when the context matches |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-doc-type.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-doc-type.md
@@ -1,0 +1,23 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[forDocType](for-doc-type.md)
+
+# forDocType
+
+[androidJvm]\
+fun [forDocType](for-doc-type.md)(docType: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;
+
+Convenience method to add an override for an MDoc document type.
+
+Equivalent to `forAttestation(AttestationIdentifier.MDoc(docType), action)`.
+
+#### Return
+
+this builder for chaining
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| docType | the MDoc document type string |
+| action | the action to return when the document type matches |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-vct.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/for-vct.md
@@ -1,0 +1,23 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)/[forVct](for-vct.md)
+
+# forVct
+
+[androidJvm]\
+fun [forVct](for-vct.md)(vct: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;
+
+Convenience method to add an override for an SD-JWT VC type.
+
+Equivalent to `forAttestation(AttestationIdentifier.SDJwtVc(vct), action)`.
+
+#### Return
+
+this builder for chaining
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| vct | the SD-JWT Verifiable Credential Type |
+| action | the action to return when the VCT matches |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-builder/index.md
@@ -1,0 +1,34 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Builder](index.md)
+
+# Builder
+
+[androidJvm]\
+class [Builder](index.md)
+
+DSL builder for constructing a [TrustPolicy](../index.md) with layered override rules.
+
+Resolution order (highest priority first):
+
+1. 
+   Per-attestation overrides (added via [forAttestation](for-attestation.md), [forDocType](for-doc-type.md), or [forVct](for-vct.md))
+2. 
+   Per-context overrides (added via [forContext](for-context.md))
+3. 
+   Default action (set via [default](default.md), defaults to [Action.ENFORCE](../-action/-e-n-f-o-r-c-e/index.md))
+
+## Constructors
+
+| | |
+|---|---|
+| [Builder](-builder.md) | [androidJvm]<br>constructor() |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [build](build.md) | [androidJvm]<br>fun [build](build.md)(): [TrustPolicy](../index.md)<br>Builds the [TrustPolicy](../index.md) with the configured overrides. |
+| [default](default.md) | [androidJvm]<br>fun [default](default.md)(action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;<br>Sets the default action when no specific override matches. |
+| [forAttestation](for-attestation.md) | [androidJvm]<br>fun [forAttestation](for-attestation.md)(identifier: AttestationIdentifier, action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;<br>Adds an override for a specific AttestationIdentifier. |
+| [forContext](for-context.md) | [androidJvm]<br>fun [forContext](for-context.md)(context: VerificationContext, action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;<br>Adds an override for a specific VerificationContext. |
+| [forDocType](for-doc-type.md) | [androidJvm]<br>fun [forDocType](for-doc-type.md)(docType: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;<br>Convenience method to add an override for an MDoc document type. |
+| [forVct](for-vct.md) | [androidJvm]<br>fun [forVct](for-vct.md)(vct: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-string/index.html), action: [TrustPolicy.Action](../-action/index.md)): &lt;Error class: unknown class&gt;<br>Convenience method to add an override for an SD-JWT VC type. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/build.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/build.md
@@ -1,0 +1,30 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Companion](index.md)/[build](build.md)
+
+# build
+
+[androidJvm]\
+fun [build](build.md)(block: [TrustPolicy.Builder](../-builder/index.md).() -&gt; [Unit](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-unit/index.html)): [TrustPolicy](../index.md)
+
+Creates a policy using the [Builder](../-builder/index.md) DSL.
+
+Example:
+
+```kotlin
+val policy = TrustPolicy.build {
+    default(Action.ENFORCE)
+    forContext(VerificationContext.PID, Action.INFORM)
+    forDocType("org.iso.18013.5.1.mDL", Action.INFORM)
+}
+```
+
+#### Return
+
+a [TrustPolicy](../index.md) configured according to the builder
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| block | configuration block applied to the [Builder](../-builder/index.md) |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/index.md
@@ -1,0 +1,13 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Companion](index.md)
+
+# Companion
+
+[androidJvm]\
+object [Companion](index.md)
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [build](build.md) | [androidJvm]<br>fun [build](build.md)(block: [TrustPolicy.Builder](../-builder/index.md).() -&gt; [Unit](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-unit/index.html)): [TrustPolicy](../index.md)<br>Creates a policy using the [Builder](../-builder/index.md) DSL. |
+| [uniform](uniform.md) | [androidJvm]<br>fun [uniform](uniform.md)(action: [TrustPolicy.Action](../-action/index.md)): [TrustPolicy](../index.md)<br>Creates a policy that returns the same [action](uniform.md) for every input. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/uniform.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/-companion/uniform.md
@@ -1,0 +1,20 @@
+//[wallet-core](../../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../../index.md)/[TrustPolicy](../index.md)/[Companion](index.md)/[uniform](uniform.md)
+
+# uniform
+
+[androidJvm]\
+fun [uniform](uniform.md)(action: [TrustPolicy.Action](../-action/index.md)): [TrustPolicy](../index.md)
+
+Creates a policy that returns the same [action](uniform.md) for every input.
+
+#### Return
+
+a [TrustPolicy](../index.md) that always returns [action](uniform.md)
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| action | the action to return unconditionally |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/index.md
@@ -1,0 +1,26 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[TrustPolicy](index.md)
+
+# TrustPolicy
+
+[androidJvm]\
+fun interface [TrustPolicy](index.md)
+
+Defines the policy for how the wallet should handle issuer trust verification results.
+
+A [TrustPolicy](index.md) determines the [Action](-action/index.md) to take based on the type of credential (AttestationIdentifier) being issued and the optional VerificationContext.
+
+Use [uniform](-companion/uniform.md) for a single action regardless of input, or [build](-companion/build.md) for a fine-grained policy with per-attestation and per-context overrides.
+
+## Types
+
+| Name | Summary |
+|---|---|
+| [Action](-action/index.md) | [androidJvm]<br>enum [Action](-action/index.md) : [Enum](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-enum/index.html)&lt;[TrustPolicy.Action](-action/index.md)&gt; <br>Describes how the wallet should react to trust verification outcomes. |
+| [Builder](-builder/index.md) | [androidJvm]<br>class [Builder](-builder/index.md)<br>DSL builder for constructing a [TrustPolicy](index.md) with layered override rules. |
+| [Companion](-companion/index.md) | [androidJvm]<br>object [Companion](-companion/index.md) |
+
+## Functions
+
+| Name | Summary |
+|---|---|
+| [resolve](resolve.md) | [androidJvm]<br>abstract fun [resolve](resolve.md)(attestationIdentifier: AttestationIdentifier, verificationContext: VerificationContext?): [TrustPolicy.Action](-action/index.md)<br>Resolves the trust action for a given attestation identifier and verification context. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/resolve.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/-trust-policy/resolve.md
@@ -1,0 +1,21 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet.trust](../index.md)/[TrustPolicy](index.md)/[resolve](resolve.md)
+
+# resolve
+
+[androidJvm]\
+abstract fun [resolve](resolve.md)(attestationIdentifier: AttestationIdentifier, verificationContext: VerificationContext?): [TrustPolicy.Action](-action/index.md)
+
+Resolves the trust action for a given attestation identifier and verification context.
+
+#### Return
+
+the [Action](-action/index.md) indicating how the wallet should handle the trust verification result
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| attestationIdentifier | the type of credential being issued (e.g., MDoc or SDJwtVc) |
+| verificationContext | the optional verification context (e.g., PID, QEAA), or null if unknown |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/index.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet.trust/index.md
@@ -1,0 +1,12 @@
+//[wallet-core](../../index.md)/[eu.europa.ec.eudi.wallet.trust](index.md)
+
+# Package-level declarations
+
+## Types
+
+| Name | Summary |
+|---|---|
+| [CredentialTrustVerifier](-credential-trust-verifier/index.md) | [androidJvm]<br>fun interface [CredentialTrustVerifier](-credential-trust-verifier/index.md)<br>Per-format credential trust verifier. Implementations extract the certificate chain from the credential and evaluate trust using the ETSI library. |
+| [IssuerNotTrustedException](-issuer-not-trusted-exception/index.md) | [androidJvm]<br>class [IssuerNotTrustedException](-issuer-not-trusted-exception/index.md)(cause: [Throwable](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-throwable/index.html)) : [Exception](https://developer.android.com/reference/kotlin/java/lang/Exception.html)<br>Thrown when the issuer certificate chain is not trusted and the [trust policy](-trust-policy/index.md) action is [TrustPolicy.Action.ENFORCE](-trust-policy/-action/-e-n-f-o-r-c-e/index.md). |
+| [IssuerTrustConfigBuilder](-issuer-trust-config-builder/index.md) | [androidJvm]<br>class [IssuerTrustConfigBuilder](-issuer-trust-config-builder/index.md)<br>DSL builder for constructing an IssuerTrustConfig. |
+| [TrustPolicy](-trust-policy/index.md) | [androidJvm]<br>fun interface [TrustPolicy](-trust-policy/index.md)<br>Defines the policy for how the wallet should handle issuer trust verification results. |

--- a/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet-config/configure-issuer-trust.md
+++ b/docs/wallet-core/eu.europa.ec.eudi.wallet/-eudi-wallet-config/configure-issuer-trust.md
@@ -1,0 +1,26 @@
+//[wallet-core](../../../index.md)/[eu.europa.ec.eudi.wallet](../index.md)/[EudiWalletConfig](index.md)/[configureIssuerTrust](configure-issuer-trust.md)
+
+# configureIssuerTrust
+
+[androidJvm]\
+fun [configureIssuerTrust](configure-issuer-trust.md)(block: [IssuerTrustConfigBuilder](../../eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/index.md).() -&gt; [Unit](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin-stdlib/kotlin/-unit/index.html)): &lt;Error class: unknown class&gt;
+
+Configure issuer trust verification for credentials issued via OpenID4VCI. Trust verification occurs after issuance, before storage. When not configured, trust verification is skipped entirely.
+
+#### Return
+
+the [EudiWalletConfig](index.md) instance
+
+#### Parameters
+
+androidJvm
+
+| | |
+|---|---|
+| block | configuration block applied to the [IssuerTrustConfigBuilder](../../eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/index.md) |
+
+#### See also
+
+| |
+|---|
+| [IssuerTrustConfigBuilder](../../eu.europa.ec.eudi.wallet.trust/-issuer-trust-config-builder/index.md) |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ eudi-lib-jvm-openid4vci-kt = "0.10.1"
 eudi-lib-jvm-openid4vp-kt = "0.12.2"
 eudi-lib-jvm-sdjwt-kt = "0.20.0"
 eudi-lib-kmp-statium = "0.5.1"
-gradle-plugin = "9.0.1"
+gradle-plugin = "9.1.1"
 java = "17"
 json = "20250517"
 junit = "5.13.2"
@@ -44,6 +44,7 @@ material = "1.12.0"
 jetbrainsKotlinJvm = "2.2.21"
 testng = "7.11.0"
 kover = "0.9.1"
+eudi-lib-kmp-etsi1196x2="0.3.0-alpha.5"
 
 [libraries]
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidx-credentials" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ eudi-iso18013-data-transfer = { module = "eu.europa.ec.eudi:eudi-lib-android-iso
 eudi-lib-jvm-openid4vci-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-openid4vci-kt", version.ref = "eudi-lib-jvm-openid4vci-kt" }
 eudi-lib-jvm-siop-openid4vp-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-openid4vp-kt", version.ref = "eudi-lib-jvm-openid4vp-kt" }
 eudi-lib-jvm-sdjwt-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-sdjwt-kt", version.ref = "eudi-lib-jvm-sdjwt-kt" }
+eudi-lib-kmp-etsi1196x2-consultation = { module = "eu.europa.ec.eudi:etsi-1196x2-consultation", version.ref = "eudi-lib-kmp-etsi1196x2" }
 eudi-lib-kmp-statium = { module = "eu.europa.ec.eudi:eudi-lib-kmp-statium-android", version.ref = "eudi-lib-kmp-statium" }
 json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 #Thu Sep 12 17:12:58 EEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -136,15 +136,8 @@ dependencies {
     // Document status
     api(libs.eudi.lib.kmp.statium)
 
-    // ETSI Trusted Lists (VerificationContext, AttestationIdentifier, etc.)
+    // ETSI Trusted Lists
     api(libs.eudi.lib.kmp.etsi1196x2.consultation)
-    // ETSI Trusted Lists - DSS module for LOTL support (TS 119 612)
-//    implementation(libs.eudi.lib.kmp.etsi1196x2.consultation.dss)
-//    implementation(libs.dss.policy.jaxb)
-//    implementation(libs.dss.utils.google.guava)
-    // Force JAXB 4.0.7+ for Android support (DSS 6.4 pulls 3.0.2 which crashes on Android)
-//    implementation(libs.jaxb.runtime)
-//    implementation(libs.jaxb.core)
 
     // Digital Credential API
     implementation(libs.androidx.credentials)

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -138,6 +138,13 @@ dependencies {
 
     // ETSI Trusted Lists (VerificationContext, AttestationIdentifier, etc.)
     api(libs.eudi.lib.kmp.etsi1196x2.consultation)
+    // ETSI Trusted Lists - DSS module for LOTL support (TS 119 612)
+//    implementation(libs.eudi.lib.kmp.etsi1196x2.consultation.dss)
+//    implementation(libs.dss.policy.jaxb)
+//    implementation(libs.dss.utils.google.guava)
+    // Force JAXB 4.0.7+ for Android support (DSS 6.4 pulls 3.0.2 which crashes on Android)
+//    implementation(libs.jaxb.runtime)
+//    implementation(libs.jaxb.core)
 
     // Digital Credential API
     implementation(libs.androidx.credentials)

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -136,6 +136,9 @@ dependencies {
     // Document status
     api(libs.eudi.lib.kmp.statium)
 
+    // ETSI Trusted Lists (VerificationContext, AttestationIdentifier, etc.)
+    api(libs.eudi.lib.kmp.etsi1196x2.consultation)
+
     // Digital Credential API
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.registry.provider)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -43,6 +43,7 @@ import eu.europa.ec.eudi.wallet.provider.WalletAttestationsProvider
 import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
 import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolver
 import eu.europa.ec.eudi.wallet.transactionLogging.TransactionLogger
+import eu.europa.ec.eudi.wallet.trust.EtsiReaderTrustStore
 import eu.europa.ec.eudi.wallet.transactionLogging.presentation.TransactionsDecorator
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpManager
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.dcql.DcqlRequestProcessor
@@ -389,7 +390,9 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                         } else manager
                     }
 
-            val readerTrustStoreToUse = readerTrustStore ?: defaultReaderTrustStore
+            val readerTrustStoreToUse = (readerTrustStore ?: defaultReaderTrustStore)?.also {
+                if (it is EtsiReaderTrustStore) it.logger = loggerToUse
+            }
 
             val transferManager = getTransferManager(documentManagerToUse, readerTrustStoreToUse)
 
@@ -474,12 +477,14 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
             ).absolutePath
 
         /**
-         * Get the default [ReaderTrustStore] instance based on the certificates provided in the configuration
+         * Get the default [ReaderTrustStore] instance based on the configuration.
+         * A custom [ReaderTrustStore] set via [EudiWalletConfig.configureReaderTrustStore]
+         * takes priority over certificate-based configuration.
          * @return the default [ReaderTrustStore] instance
          */
         @get:JvmSynthetic
         internal val defaultReaderTrustStore: ReaderTrustStore?
-            get() = config.readerTrustedCertificates?.let { certificates ->
+            get() = config.readerTrustStore ?: config.readerTrustedCertificates?.let { certificates ->
                 ReaderTrustStoreImpl(certificates, profileValidation = { _, _ -> true })
             }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -564,12 +564,11 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
          */
         @JvmSynthetic
         internal fun getDocumentStatusResolver(): DocumentStatusResolver {
-            return documentStatusResolver ?: ktorHttpClientFactory?.let {
-                DocumentStatusResolver(
-                    ktorHttpClientFactory = it,
-                    allowedClockSkew = config.documentStatusResolverClockSkew
-                )
-            } ?: DocumentStatusResolver(allowedClockSkew = config.documentStatusResolverClockSkew)
+            return documentStatusResolver ?: DocumentStatusResolver {
+                ktorHttpClientFactory?.let { withKtorHttpClientFactory(it) }
+                withAllowedClockSkew(config.documentStatusResolverClockSkew)
+                config.statusListTrustConfig?.let { withStatusListTrustConfig(it) }
+            }
         }
 
         /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -400,7 +400,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                 loggerObj = loggerToUse
             ).wrapWithTrasactionLogger(documentManagerToUse, loggerToUse)
 
-            val documentStatusResolverToUse = getDocumentStatusResolver()
+            val documentStatusResolverToUse = getDocumentStatusResolver(loggerToUse)
 
             return EudiWalletImpl(
                 context = context,
@@ -563,11 +563,12 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
          * @return the [DocumentStatusResolver] instance
          */
         @JvmSynthetic
-        internal fun getDocumentStatusResolver(): DocumentStatusResolver {
+        internal fun getDocumentStatusResolver(logger: Logger): DocumentStatusResolver {
             return documentStatusResolver ?: DocumentStatusResolver {
                 ktorHttpClientFactory?.let { withKtorHttpClientFactory(it) }
                 withAllowedClockSkew(config.documentStatusResolverClockSkew)
                 config.statusListTrustConfig?.let { withStatusListTrustConfig(it) }
+                withLogger(logger)
             }
         }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -29,8 +29,10 @@ import eu.europa.ec.eudi.wallet.internal.getCertificate
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpConfig
+import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolverConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import java.security.cert.X509Certificate
 import kotlin.time.Duration
@@ -448,12 +450,45 @@ class EudiWalletConfig {
     var documentStatusResolverClockSkew: Duration = Duration.ZERO
         private set
 
+    internal var statusListTrustConfig: StatusListTrustConfig? = null
+        private set
+
     /**
      * Configure the document status resolver clock skew. This allows to configure the clock skew for
      * the provided document status resolver.
      */
     fun configureDocumentStatusResolver(clockSkewInMinutes: Long) = apply {
         this.documentStatusResolverClockSkew = clockSkewInMinutes.minutes
+    }
+
+    /**
+     * Configure the document status resolver with clock skew and optional ETSI trust verification
+     * for status list token signers.
+     *
+     * Example:
+     * ```
+     * configureDocumentStatusResolver {
+     *     clockSkew(5)
+     *     configureTrust {
+     *         trustSource(myComposeChainTrust)
+     *         classifications(myClassifications)
+     *         policy {
+     *             default(TrustPolicy.Action.ENFORCE)
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * @param block configuration block applied to the [DocumentStatusResolverConfigBuilder]
+     * @return the [EudiWalletConfig] instance
+     * @see DocumentStatusResolverConfigBuilder
+     */
+    fun configureDocumentStatusResolver(
+        block: DocumentStatusResolverConfigBuilder.() -> Unit,
+    ) = apply {
+        val builder = DocumentStatusResolverConfigBuilder().apply(block)
+        this.documentStatusResolverClockSkew = builder.clockSkew
+        this.statusListTrustConfig = builder.buildTrustConfig()
     }
 
     var zkSystemRepository: ZkSystemRepository? = null

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -325,6 +325,9 @@ class EudiWalletConfig {
     var readerTrustedCertificates: List<X509Certificate>? = null
         private set
 
+    internal var readerTrustStore: ReaderTrustStore? = null
+        private set
+
     /**
      * Configure the built-in [ReaderTrustStore]. This allows to set the reader trusted
      * certificates for the reader trust store.
@@ -358,6 +361,21 @@ class EudiWalletConfig {
      */
     fun configureReaderTrustStore(context: Context, @RawRes vararg certificateRes: Int) = apply {
         this.readerTrustedCertificates = certificateRes.map { context.getCertificate(it) }
+    }
+
+    /**
+     * Configure the [ReaderTrustStore] with a custom implementation.
+     *
+     * Use this to provide an ETSI-backed trust store (e.g. via
+     * [eu.europa.ec.eudi.wallet.trust.asReaderTrustStore]) or any other custom
+     * [ReaderTrustStore] implementation. This takes priority over certificate-based
+     * configuration set via the other [configureReaderTrustStore] overloads.
+     *
+     * @param readerTrustStore the custom reader trust store implementation
+     * @return the [EudiWalletConfig] instance
+     */
+    fun configureReaderTrustStore(readerTrustStore: ReaderTrustStore) = apply {
+        this.readerTrustStore = readerTrustStore
     }
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -20,6 +20,7 @@ package eu.europa.ec.eudi.wallet
 import android.content.Context
 import androidx.annotation.RawRes
 import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.wallet.EudiWalletConfig.Companion.DEFAULT_DOCUMENT_MANAGER_IDENTIFIER
@@ -33,6 +34,8 @@ import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolverConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
+import eu.europa.ec.eudi.wallet.trust.asReaderTrustStore
+import java.security.cert.TrustAnchor
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import java.security.cert.X509Certificate
 import kotlin.time.Duration
@@ -366,16 +369,32 @@ class EudiWalletConfig {
     /**
      * Configure the [ReaderTrustStore] with a custom implementation.
      *
-     * Use this to provide an ETSI-backed trust store (e.g. via
-     * [eu.europa.ec.eudi.wallet.trust.asReaderTrustStore]) or any other custom
-     * [ReaderTrustStore] implementation. This takes priority over certificate-based
-     * configuration set via the other [configureReaderTrustStore] overloads.
+     * Use this to provide any custom [ReaderTrustStore] implementation.
+     * This takes priority over certificate-based configuration set via the
+     * other [configureReaderTrustStore] overloads.
      *
      * @param readerTrustStore the custom reader trust store implementation
      * @return the [EudiWalletConfig] instance
      */
     fun configureReaderTrustStore(readerTrustStore: ReaderTrustStore) = apply {
         this.readerTrustStore = readerTrustStore
+    }
+
+    /**
+     * Configure the [ReaderTrustStore] with an ETSI-backed trust source.
+     *
+     * Creates an [eu.europa.ec.eudi.wallet.trust.EtsiReaderTrustStore] that delegates
+     * reader certificate chain validation to the given [IsChainTrustedForEUDIW], using the
+     * [VerificationContext.WalletRelyingPartyAccessCertificate][eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext.WalletRelyingPartyAccessCertificate]
+     * verification context. This takes priority over certificate-based configuration.
+     *
+     * @param isChainTrusted the ETSI chain trust validator
+     * @return the [EudiWalletConfig] instance
+     */
+    fun configureReaderTrustStore(
+        isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
+    ) = apply {
+        this.readerTrustStore = isChainTrusted.asReaderTrustStore()
     }
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 European Commission
+ * Copyright (c) 2023-2026 European Commission
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import eu.europa.ec.eudi.wallet.internal.getCertificate
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpConfig
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import java.security.cert.X509Certificate
 import kotlin.time.Duration
@@ -465,6 +467,24 @@ class EudiWalletConfig {
         zkSystemRepository: ZkSystemRepository
     ) = apply {
         this.zkSystemRepository = zkSystemRepository
+    }
+
+    internal var issuerTrustConfig: IssuerTrustConfig? = null
+        private set
+
+    /**
+     * Configure issuer trust verification for credentials issued via OpenID4VCI.
+     * Trust verification occurs after issuance, before storage. When not configured,
+     * trust verification is skipped entirely.
+     *
+     * @param block configuration block applied to the [IssuerTrustConfigBuilder]
+     * @return the [EudiWalletConfig] instance
+     * @see IssuerTrustConfigBuilder
+     */
+    fun configureIssuerTrust(
+        block: IssuerTrustConfigBuilder.() -> Unit,
+    ) = apply {
+        this.issuerTrustConfig = IssuerTrustConfigBuilder().apply(block).build()
     }
 
     companion object {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ class EudiWalletImpl internal constructor(
             if (httpClientFactory != null) {
                 ktorHttpClientFactory(httpClientFactory)
             }
+            this@EudiWalletImpl.config.issuerTrustConfig?.let { issuerTrustConfig(it) }
         }
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRegistration.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRegistration.kt
@@ -60,14 +60,18 @@ class DCAPIIsoMdocRegistration(
     override suspend fun registerCredentials() {
         withContext(ioDispatcher) {
             try {
+                logger?.d(TAG, "registerCredentials() started, documentManager=${documentManager::class.qualifiedName}@${System.identityHashCode(documentManager).toString(16)}")
                 val issuedMsoMdocDocuments = documentManager.getDocuments()
                     .filterIsInstance<IssuedDocument>()
                     .filter { it.format is MsoMdocFormat }
+                logger?.d(TAG, "Found ${issuedMsoMdocDocuments.size} issued mdoc documents: ${issuedMsoMdocDocuments.map { it.id }}")
 
                 // clear previously registered credentials
+                logger?.d(TAG, "Calling clearCredentialRegistry(isDeleteAll=true)...")
                 registryManager.clearCredentialRegistry(
                     ClearCredentialRegistryRequest(isDeleteAll = true)
                 )
+                logger?.d(TAG, "clearCredentialRegistry completed")
 
                 if (issuedMsoMdocDocuments.isEmpty()) {
                     logger?.d(TAG, "No mdoc documents to register; cleared existing registries")
@@ -82,10 +86,11 @@ class DCAPIIsoMdocRegistration(
                     ioDispatcher = ioDispatcher
                 )
 
+                logger?.d(TAG, "Calling registryManager.registerCredentials()...")
                 registryManager.registerCredentials(registry)
-                logger?.d(TAG, "Registered ${issuedMsoMdocDocuments.size} mdoc credential(s)")
+                logger?.d(TAG, "Registered ${issuedMsoMdocDocuments.size} mdoc credential(s) with registryId=$REGISTRY_ID")
             } catch (e: Exception) {
-                logger?.e(TAG, "Error during DCAPI registration", e)
+                logger?.e(TAG, "Error during DCAPI registration: ${e::class.simpleName}: ${e.message}", e)
             }
         }
     }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRequestProcessor.kt
@@ -76,16 +76,20 @@ internal class DCAPIRequestProcessor(
         ).process(deviceRequest) as ProcessedDeviceRequest
 
         val credentialId = credRequest.selectedEntryId
-        logger?.d(TAG, "Selected credential ID: $credentialId")
+        logger?.d(TAG, "Selected credential ID (selectedEntryId): '$credentialId' (type=${credentialId?.let { it::class.simpleName }}, isNull=${credentialId == null})")
+        logger?.d(TAG, "Available requestedDocuments IDs: ${processedDeviceRequest.requestedDocuments.map { "'${it.documentId}'" }}")
+        logger?.d(TAG, "DocumentManager instance: ${documentManager::class.qualifiedName}@${System.identityHashCode(documentManager).toString(16)}")
 
         // Filter the requested documents and ProcessedDeviceRequest
         // based on the selected credential ID provided by the credential request.
-        logger?.d(TAG, "Filtering requested documents for credential ID: $credentialId")
+        logger?.d(TAG, "Filtering requested documents for credential ID: '$credentialId'")
         val filteredRequestedDocuments = processedDeviceRequest.requestedDocuments.filter {
-            it.documentId == credentialId
+            val matches = it.documentId == credentialId
+            logger?.d(TAG, "  Comparing documentId='${it.documentId}' == selectedEntryId='$credentialId' => $matches")
+            matches
         }
         if (filteredRequestedDocuments.isEmpty()) {
-            logger?.e(TAG, "No requested document found for credential ID: $credentialId")
+            logger?.e(TAG, "No requested document found for credential ID: '$credentialId'. Available IDs: ${processedDeviceRequest.requestedDocuments.map { it.documentId }}")
             return RequestProcessor.ProcessedRequest.Failure(
                 DCAPIException("No requested document found for credential ID: $credentialId")
             )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/ProcessedDCPAPIRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/ProcessedDCPAPIRequest.kt
@@ -89,6 +89,10 @@ class ProcessedDCPAPIRequest(
                     encryptionInfo[1][RECIPIENT_PUBLIC_KEY].EncodeToBytes()
                 ).asCoseKey.ecPublicKey
 
+            logger?.d(TAG, "Calling processedDeviceRequest.generateResponse() with ${disclosedDocuments.size} disclosed docs")
+            disclosedDocuments.forEach { dd ->
+                logger?.d(TAG, "  DisclosedDoc: id=${dd.documentId}, items=${dd.disclosedItems.size}, keyUnlockData=${dd.keyUnlockData != null}")
+            }
             val deviceResponse = processedDeviceRequest.generateResponse(
                 disclosedDocuments,
                 signatureAlgorithm

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import eu.europa.ec.eudi.wallet.issue.openid4vci.reissue.ReissuanceIssuer
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.provider.WalletAttestationsProvider
 import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
@@ -79,6 +80,7 @@ internal class DefaultOpenId4VciManager(
     var config: OpenId4VciManager.Config,
     var logger: Logger? = null,
     var ktorHttpClientFactory: (() -> HttpClient)? = null,
+    val issuerTrustConfig: IssuerTrustConfig? = null,
 ) : OpenId4VciManager {
 
     internal val httpClientFactory
@@ -275,7 +277,8 @@ internal class DefaultOpenId4VciManager(
                                 )
                             } ?: deferredContext,
                             logger = logger,
-                            issuanceMetadataStorage = issuanceMetadataStorage,
+                            issuerTrustConfig = issuerTrustConfig,
+                            issuanceMetadataStorage = issuanceMetadataStorage
                         ).process(deferredDocument, deferredContext.keyAliases, outcome)
                     }
                 }
@@ -508,6 +511,7 @@ internal class DefaultOpenId4VciManager(
             issuedDocumentIds = issuedDocumentIds,
             deferredDocumentIds = deferredDocumentIds,
             logger = logger,
+            issuerTrustConfig = issuerTrustConfig,
             authorizedRequest = authorizedRequest,
             issuer = issuer,
             documentToConfigurationMap = requestMap,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -88,11 +88,14 @@ internal class DefaultOpenId4VciManager(
             .wrappedWithLogging(logger)
             .wrappedWithContentNegotiation()
 
+    private val issuerMetadataPolicy: IssuerMetadataPolicy
+        get() = issuerTrustConfig?.issuerMetadataPolicy ?: IssuerMetadataPolicy.IgnoreSigned
+
     private val offerResolver: OfferResolver by lazy {
-        OfferResolver(httpClientFactory)
+        OfferResolver(httpClientFactory, issuerMetadataPolicy)
     }
     private val issuerCreator: IssuerCreator by lazy {
-        IssuerCreator(context, config, httpClientFactory, walletProvider, walletAttestationKeyManager, logger)
+        IssuerCreator(context, config, httpClientFactory, walletProvider, walletAttestationKeyManager, logger, issuerMetadataPolicy)
     }
     private val issuerAuthorization: IssuerAuthorization by lazy {
         val handler = config.authorizationHandler ?: BrowserAuthorizationHandler(context, logger)
@@ -117,7 +120,7 @@ internal class DefaultOpenId4VciManager(
         return CredentialIssuerId(config.issuerUrl).mapCatching {
             CredentialIssuerMetadataResolver(httpClientFactory()).resolve(
                 issuer = it,
-                policy = IssuerMetadataPolicy.IgnoreSigned
+                policy = issuerMetadataPolicy
             ).getOrThrow()
         }
     }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -422,6 +422,7 @@ internal class DefaultOpenId4VciManager(
                     issuanceMetadataStorage = issuanceMetadataStorage,
                     clientAuthentication = issuerCreator.clientAuthentication,
                     replacesDocumentId = documentId,
+                    issuerTrustConfig = issuerTrustConfig,
                 ).process(response)
 
                 //  If new document(s) issued successfully, delete the old document.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DeferredIssueResult.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DeferredIssueResult.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 European Commission
+ *  Copyright (c) 2024-2026 European Commission
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.Document
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import java.security.cert.TrustAnchor
 
 /**
  * Result of a deferred document issuance.
@@ -39,10 +41,12 @@ sealed interface DeferredIssueResult : OpenId4VciResult {
      * @property documentId the id of the issued document
      * @property name the name of the document
      * @property docType the document type
+     * @property issuerTrustResult the result of issuer trust verification, or null if not configured
      * @see[DocumentId] for the document id
      */
     data class DocumentIssued(
         override val document: IssuedDocument,
+        val issuerTrustResult: CertificationChainValidation<TrustAnchor>? = null,
     ) : DeferredIssueResult, DocumentDetails by DocumentDetails(document)
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssueEvent.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssueEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.wallet.document.CreateDocumentSettings
 import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.DocumentId
@@ -23,6 +24,7 @@ import eu.europa.ec.eudi.wallet.document.UnsignedDocument
 import org.multipaz.crypto.Algorithm
 import org.multipaz.securearea.KeyUnlockData
 import org.multipaz.securearea.SecureArea
+import java.security.cert.TrustAnchor
 
 /**
  * Events related to document issuance.
@@ -54,10 +56,13 @@ sealed interface IssueEvent : OpenId4VciResult {
      * @property documentId the id of the issued document
      * @property name the name of the document
      * @property docType the document type
+     * @property issuerTrustResult the result of issuer trust verification, or null if not configured
      * @see[DocumentId] for the document id
      */
-    data class DocumentIssued(val document: IssuedDocument) :
-        IssueEvent,
+    data class DocumentIssued(
+        val document: IssuedDocument,
+        val issuerTrustResult: CertificationChainValidation<TrustAnchor>? = null,
+    ) : IssueEvent,
         DocumentDetails by DocumentDetails(document)
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerCreator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerCreator.kt
@@ -58,6 +58,7 @@ internal class IssuerCreator(
     private val walletProvider: WalletAttestationsProvider?,
     private val walletAttestationKeyManager: WalletKeyManager,
     private val logger: Logger?,
+    private val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
 ) {
 
     internal var clientAttestationPopKeyId: String? = null
@@ -127,7 +128,7 @@ internal class IssuerCreator(
 
     private suspend fun getIssuerMetadata(credentialIssuerId: CredentialIssuerId): Pair<CredentialIssuerMetadata, List<CIAuthorizationServerMetadata>> {
         return ktorHttpClientFactory().use {
-            Issuer.metaData(it, credentialIssuerId, IssuerMetadataPolicy.IgnoreSigned)
+            Issuer.metaData(it, credentialIssuerId, issuerMetadataPolicy)
         }
     }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OfferResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OfferResolver.kt
@@ -23,11 +23,12 @@ import org.jetbrains.annotations.VisibleForTesting
 
 internal class OfferResolver(
     private val ktorHttpClientFactory: () -> HttpClient,
+    private val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
 ) {
     val resolver by lazy {
         CredentialOfferRequestResolver(
             httpClient = ktorHttpClientFactory(),
-            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned
+            issuerMetadataPolicy = issuerMetadataPolicy
         )
     }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import eu.europa.ec.eudi.wallet.logging.Logger
 import org.multipaz.storage.Storage
 import eu.europa.ec.eudi.wallet.provider.WalletAttestationsProvider
 import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import io.ktor.client.HttpClient
 import java.util.concurrent.Executor
 
@@ -311,6 +312,7 @@ interface OpenId4VciManager {
         var ktorHttpClientFactory: (() -> HttpClient)? = null
         var walletKeyManager: WalletKeyManager? = null
         var walletAttestationsProvider: WalletAttestationsProvider? = null
+        internal var issuerTrustConfig: IssuerTrustConfig? = null
 
         /**
          * Set the [Config] to use
@@ -366,6 +368,15 @@ interface OpenId4VciManager {
         }
 
         /**
+         * Set the [IssuerTrustConfig] to use for issuer trust verification
+         * @param config the issuer trust configuration
+         * @return this builder
+         */
+        internal fun issuerTrustConfig(config: IssuerTrustConfig) = apply {
+            this.issuerTrustConfig = config
+        }
+
+        /**
          * Build the [OpenId4VciManager]
          * @return the [OpenId4VciManager]
          * @throws [IllegalStateException] if config or documentManager is not set
@@ -387,7 +398,8 @@ interface OpenId4VciManager {
                 logger = logger,
                 ktorHttpClientFactory = ktorHttpClientFactory,
                 walletProvider = walletAttestationsProvider,
-                walletAttestationKeyManager = walletKeyManager
+                walletAttestationKeyManager = walletKeyManager,
+                issuerTrustConfig = issuerTrustConfig
             )
         }
     }
@@ -713,7 +725,7 @@ interface OpenId4VciManager {
                 val authFlowRedirectionURI =
                     checkNotNull(authFlowRedirectionURI) { "authFlowRedirectionURI is required" }
                 return Config(
-                    issuerUrl = issuerUrl!!,
+                    issuerUrl = issuerUrl,
                     authorizationHandler = authorizationHandler,
                     clientAuthenticationType = clientAuthenticationType,
                     authFlowRedirectionURI = authFlowRedirectionURI,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessDeferredOutcome.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessDeferredOutcome.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.storage.Storage
+import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
+import eu.europa.ec.eudi.wallet.trust.evaluateIssuerTrust
 
 internal class ProcessDeferredOutcome(
     val documentManager: DocumentManager,
@@ -37,9 +40,10 @@ internal class ProcessDeferredOutcome(
     val deferredContext: DeferredContext?,
     val logger: Logger? = null,
     val issuanceMetadataStorage: Storage? = null,
+    val issuerTrustConfig: IssuerTrustConfig? = null
 ) {
 
-    fun process(
+    suspend fun process(
         deferredDocument: DeferredDocument,
         keyAliases: List<String>,
         outcome: DeferredCredentialQueryOutcome,
@@ -77,6 +81,12 @@ internal class ProcessDeferredOutcome(
 
                 is DeferredCredentialQueryOutcome.Issued -> {
                     val credentials = outcome.credentials.map { it.credential }.zip(keyAliases)
+                    val trustResult = evaluateIssuerTrust(
+                        issuerTrustConfig = issuerTrustConfig,
+                        document = deferredDocument,
+                        credential = credentials.first().first,
+                        logger = logger,
+                    )
                     documentManager.storeIssuedDocument(deferredDocument, credentials) {
                         logger?.d(TAG, message = it)
                     }.onSuccess { document ->
@@ -94,7 +104,7 @@ internal class ProcessDeferredOutcome(
                             }
                         }
 
-                        callback(DeferredIssueResult.DocumentIssued(document))
+                        callback(DeferredIssueResult.DocumentIssued(document, trustResult))
                     }.onFailure { error ->
                         documentManager.deleteDocumentById(deferredDocument.id)
                         callback(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ import eu.europa.ec.eudi.wallet.logging.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
+import eu.europa.ec.eudi.wallet.trust.evaluateIssuerTrust
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.bytestring.ByteString
@@ -53,6 +56,7 @@ internal class ProcessResponse(
     val issuanceMetadataStorage: Storage,
     val clientAuthentication: ClientAuthentication,
     val replacesDocumentId: DocumentId? = null,
+    val issuerTrustConfig: IssuerTrustConfig? = null
 ) {
 
     suspend fun process(response: SubmitRequest.Response) {
@@ -101,7 +105,7 @@ internal class ProcessResponse(
         }
     }
 
-    fun processSubmittedRequest(
+    suspend fun processSubmittedRequest(
         unsignedDocument: UnsignedDocument,
         keyAliases: List<String>,
         outcome: SubmissionOutcome,
@@ -109,18 +113,26 @@ internal class ProcessResponse(
         when (outcome) {
             is SubmissionOutcome.Success -> runCatching {
                 val credentials = outcome.credentials.map { it.credential }.zip(keyAliases)
-                documentManager.storeIssuedDocument(unsignedDocument, credentials) { message ->
-                    logger?.d(TAG, message)
-                }.getOrThrow()
-            }.onSuccess { document ->
-                issuedDocumentIds.add(document.id)
 
+                val trustResult = evaluateIssuerTrust(
+                    issuerTrustConfig = issuerTrustConfig,
+                    document = unsignedDocument,
+                    credential = credentials.first().first,
+                    logger = logger,
+                )
+
+                val issuedDocument = documentManager.storeIssuedDocument(
+                    unsignedDocument, credentials
+                ) { message -> logger?.d(TAG, message) }.getOrThrow()
+
+                issuedDocument to trustResult
+            }.onSuccess { (document, trustResult) ->
+                issuedDocumentIds.add(document.id)
+                listener(IssueEvent.DocumentIssued(document, trustResult))
                 // Store issuance metadata in background coroutine
                 CoroutineScope(Dispatchers.IO).launch {
                     storeIssuanceMetadata(document.id, unsignedDocument, keyAliases)
                 }
-
-                listener(IssueEvent.DocumentIssued(document))
             }.onFailure { error ->
                 documentManager.deleteDocumentById(unsignedDocument.id)
                 listener(IssueEvent.DocumentFailed(unsignedDocument, error))

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
@@ -16,11 +16,16 @@
 
 package eu.europa.ec.eudi.wallet.statium
 
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
 import eu.europa.ec.eudi.statium.GetStatus
 import eu.europa.ec.eudi.statium.GetStatusListToken
 import eu.europa.ec.eudi.statium.Status
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
 import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -47,8 +52,8 @@ interface DocumentStatusResolver {
         /**
          * Creates an instance of [DocumentStatusResolver]
          *
+         * @param verifySignature a function to verify the JWT status list token signature
          * @param ktorHttpClientFactory a factory function to create an [HttpClient]
-         * @param verifySignature a function to verify the status list token signature
          * @param allowedClockSkew the allowed clock skew for the verification
          */
         operator fun invoke(
@@ -57,9 +62,10 @@ interface DocumentStatusResolver {
             allowedClockSkew: Duration = Duration.ZERO,
         ): DocumentStatusResolver {
             return DocumentStatusResolverImpl(
-                verifySignature,
-                allowedClockSkew,
-                ktorHttpClientFactory
+                verifyJwtSignature = verifySignature,
+                verifyCwtSignature = VerifyStatusListTokenCwtSignature.x5c,
+                allowedClockSkew = allowedClockSkew,
+                ktorHttpClientFactory = ktorHttpClientFactory,
             )
         }
 
@@ -78,25 +84,38 @@ interface DocumentStatusResolver {
      * Builder for [DocumentStatusResolver]
      * It allows to set the parameters for the resolver it builds a [DocumentStatusResolverImpl]
      *
-     * @property verifySignature a function to verify the status list token signature; default is [VerifyStatusListTokenJwtSignature.x5c]
+     * @property verifyJwtSignature a function to verify the JWT status list token signature; default is [VerifyStatusListTokenJwtSignature.x5c]
+     * @property verifyCwtSignature a function to verify the CWT status list token signature; default is [VerifyStatusListTokenCwtSignature.x5c]
      * @property ktorHttpClientFactory a factory function to create an [HttpClient]; default is [HttpClient]
      * @property allowedClockSkew the allowed clock skew for the verification; default is [Duration.ZERO]
      * @property extractor an instance of [StatusReferenceExtractor] to extract the status reference from the document; default is [DefaultStatusReferenceExtractor]
+     * @property statusListTrustConfig optional ETSI trust configuration for status list token signers
      */
     class Builder {
 
-        var verifySignature: VerifyStatusListTokenJwtSignature = VerifyStatusListTokenJwtSignature.x5c
+        var verifyJwtSignature: VerifyStatusListTokenJwtSignature = VerifyStatusListTokenJwtSignature.x5c
+        var verifyCwtSignature: VerifyStatusListTokenCwtSignature = VerifyStatusListTokenCwtSignature.x5c
         var ktorHttpClientFactory: () -> HttpClient = { HttpClient() }
         var allowedClockSkew: Duration = Duration.ZERO
         var extractor: StatusReferenceExtractor = DefaultStatusReferenceExtractor
+        var statusListTrustConfig: StatusListTrustConfig? = null
 
         /**
-         * Sets the function to verify the status list token signature
-         * @param verifySignature a function to verify the status list token signature
+         * Sets the function to verify the JWT status list token signature
+         * @param verifySignature a function to verify the JWT status list token signature
          * @return the builder instance
          */
-        fun withVerifySignature(verifySignature: VerifyStatusListTokenJwtSignature) = apply {
-            this.verifySignature = verifySignature
+        fun withVerifyJwtSignature(verifySignature: VerifyStatusListTokenJwtSignature) = apply {
+            this.verifyJwtSignature = verifySignature
+        }
+
+        /**
+         * Sets the function to verify the CWT status list token signature
+         * @param verifySignature a function to verify the CWT status list token signature
+         * @return the builder instance
+         */
+        fun withVerifyCwtSignature(verifySignature: VerifyStatusListTokenCwtSignature) = apply {
+            this.verifyCwtSignature = verifySignature
         }
 
         /**
@@ -127,14 +146,25 @@ interface DocumentStatusResolver {
         }
 
         /**
+         * Sets the ETSI trust configuration for status list token signers
+         * @param config the trust configuration
+         * @return the builder instance
+         */
+        fun withStatusListTrustConfig(config: StatusListTrustConfig) = apply {
+            this.statusListTrustConfig = config
+        }
+
+        /**
          * Builds the [DocumentStatusResolver] instance
          */
         fun build(): DocumentStatusResolver {
             return DocumentStatusResolverImpl(
-                verifySignature,
-                allowedClockSkew,
-                ktorHttpClientFactory,
-                extractor
+                verifyJwtSignature = verifyJwtSignature,
+                verifyCwtSignature = verifyCwtSignature,
+                allowedClockSkew = allowedClockSkew,
+                ktorHttpClientFactory = ktorHttpClientFactory,
+                extractor = extractor,
+                statusListTrustConfig = statusListTrustConfig,
             )
         }
     }
@@ -143,33 +173,84 @@ interface DocumentStatusResolver {
 /**
  * Default implementation of [DocumentStatusResolver]
  *
- * @param verifySignature a function to verify the status list token signature
+ * Selects JWT or CWT token format based on the document format:
+ * - [SdJwtVcFormat] documents use JWT status list tokens
+ * - [MsoMdocFormat] documents use CWT status list tokens
+ *
+ * When a [StatusListTrustConfig] is provided, the signature verifiers are wrapped
+ * with trust-evaluating decorators that validate the signer's certificate chain
+ * against ETSI trusted lists.
+ *
+ * @param verifyJwtSignature a function to verify the JWT status list token signature
+ * @param verifyCwtSignature a function to verify the CWT status list token signature
  * @param allowedClockSkew the allowed clock skew for the verification
  * @param ktorHttpClientFactory a factory function to create an [HttpClient]
  * @param extractor an instance of [StatusReferenceExtractor] to extract the status reference from the document
+ * @param statusListTrustConfig optional ETSI trust configuration for status list token signers
  */
 class DocumentStatusResolverImpl(
-    internal val verifySignature: VerifyStatusListTokenJwtSignature,
+    internal val verifyJwtSignature: VerifyStatusListTokenJwtSignature,
+    internal val verifyCwtSignature: VerifyStatusListTokenCwtSignature,
     internal val allowedClockSkew: Duration,
     internal val ktorHttpClientFactory: () -> HttpClient,
     internal val extractor: StatusReferenceExtractor = DefaultStatusReferenceExtractor,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    internal val statusListTrustConfig: StatusListTrustConfig? = null,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DocumentStatusResolver {
-
 
     override suspend fun resolveStatus(document: IssuedDocument): Result<Status> = runCatching {
         withContext(ioDispatcher) {
             val statusReference = extractor.extractStatusReference(document).getOrThrow()
 
-            val getStatusListToken = GetStatusListToken.usingJwt(
-                clock = Clock.System,
-                httpClient = ktorHttpClientFactory(),
-                verifyStatusListTokenSignature = verifySignature,
-                allowedClockSkew = allowedClockSkew,
-            )
+            val getStatusListToken = when (document.format) {
+                is MsoMdocFormat -> {
+                    val verifier = maybeWrapCwtVerifier(
+                        verifyCwtSignature,
+                        document.format as MsoMdocFormat,
+                    )
+                    GetStatusListToken.usingCwt(
+                        clock = Clock.System,
+                        httpClient = ktorHttpClientFactory(),
+                        verifyStatusListTokenSignature = verifier,
+                        allowedClockSkew = allowedClockSkew,
+                    )
+                }
+
+                is SdJwtVcFormat -> {
+                    val verifier = maybeWrapJwtVerifier(
+                        verifyJwtSignature,
+                        document.format as SdJwtVcFormat,
+                    )
+                    GetStatusListToken.usingJwt(
+                        clock = Clock.System,
+                        httpClient = ktorHttpClientFactory(),
+                        verifyStatusListTokenSignature = verifier,
+                        allowedClockSkew = allowedClockSkew,
+                    )
+                }
+            }
+
             with(GetStatus(getStatusListToken)) {
                 statusReference.currentStatus().getOrThrow()
             }
         }
+    }
+
+    private fun maybeWrapJwtVerifier(
+        verifier: VerifyStatusListTokenJwtSignature,
+        format: SdJwtVcFormat,
+    ): VerifyStatusListTokenJwtSignature {
+        val trustConfig = statusListTrustConfig ?: return verifier
+        val attestationIdentifier = AttestationIdentifier.SDJwtVc(format.vct)
+        return TrustEvaluatingJwtSignatureVerifier(verifier, trustConfig, attestationIdentifier)
+    }
+
+    private fun maybeWrapCwtVerifier(
+        verifier: VerifyStatusListTokenCwtSignature,
+        format: MsoMdocFormat,
+    ): VerifyStatusListTokenCwtSignature {
+        val trustConfig = statusListTrustConfig ?: return verifier
+        val attestationIdentifier = AttestationIdentifier.MDoc(format.docType)
+        return TrustEvaluatingCwtSignatureVerifier(verifier, trustConfig, attestationIdentifier)
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
@@ -25,6 +25,8 @@ import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
@@ -90,6 +92,7 @@ interface DocumentStatusResolver {
      * @property allowedClockSkew the allowed clock skew for the verification; default is [Duration.ZERO]
      * @property extractor an instance of [StatusReferenceExtractor] to extract the status reference from the document; default is [DefaultStatusReferenceExtractor]
      * @property statusListTrustConfig optional ETSI trust configuration for status list token signers
+     * @property logger optional logger for logging events
      */
     class Builder {
 
@@ -99,6 +102,7 @@ interface DocumentStatusResolver {
         var allowedClockSkew: Duration = Duration.ZERO
         var extractor: StatusReferenceExtractor = DefaultStatusReferenceExtractor
         var statusListTrustConfig: StatusListTrustConfig? = null
+        var logger: Logger? = null
 
         /**
          * Sets the function to verify the JWT status list token signature
@@ -155,6 +159,15 @@ interface DocumentStatusResolver {
         }
 
         /**
+         * Sets the logger for logging events
+         * @param logger the logger
+         * @return the builder instance
+         */
+        fun withLogger(logger: Logger?) = apply {
+            this.logger = logger
+        }
+
+        /**
          * Builds the [DocumentStatusResolver] instance
          */
         fun build(): DocumentStatusResolver {
@@ -165,6 +178,7 @@ interface DocumentStatusResolver {
                 ktorHttpClientFactory = ktorHttpClientFactory,
                 extractor = extractor,
                 statusListTrustConfig = statusListTrustConfig,
+                logger = logger,
             )
         }
     }
@@ -195,16 +209,20 @@ class DocumentStatusResolverImpl(
     internal val ktorHttpClientFactory: () -> HttpClient,
     internal val extractor: StatusReferenceExtractor = DefaultStatusReferenceExtractor,
     internal val statusListTrustConfig: StatusListTrustConfig? = null,
+    private val logger: Logger? = null,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DocumentStatusResolver {
 
     override suspend fun resolveStatus(document: IssuedDocument): Result<Status> = runCatching {
         withContext(ioDispatcher) {
+            logger?.d(TAG, "resolveStatus: format=${document.format}, trustConfig=${if (statusListTrustConfig != null) "present" else "null"}")
             val statusReference = extractor.extractStatusReference(document).getOrThrow()
+            logger?.d(TAG, "resolveStatus: statusReference uri=${statusReference.uri}, index=${statusReference.index}")
 
             val getStatusListToken = when (document.format) {
                 is MsoMdocFormat -> {
-                    val verifier = maybeWrapCwtVerifier(
+                    logger?.d(TAG, "resolveStatus: using CWT path for MsoMdoc")
+                    val verifier = withCwtVerifier(
                         verifyCwtSignature,
                         document.format as MsoMdocFormat,
                     )
@@ -217,7 +235,8 @@ class DocumentStatusResolverImpl(
                 }
 
                 is SdJwtVcFormat -> {
-                    val verifier = maybeWrapJwtVerifier(
+                    logger?.d(TAG, "resolveStatus: using JWT path for SdJwtVc")
+                    val verifier = withJwtVerifier(
                         verifyJwtSignature,
                         document.format as SdJwtVcFormat,
                     )
@@ -230,27 +249,33 @@ class DocumentStatusResolverImpl(
                 }
             }
 
-            with(GetStatus(getStatusListToken)) {
+            val status = with(GetStatus(getStatusListToken)) {
                 statusReference.currentStatus().getOrThrow()
             }
+            logger?.d(TAG, "resolveStatus: result=$status")
+            status
         }
     }
 
-    private fun maybeWrapJwtVerifier(
+    private fun withJwtVerifier(
         verifier: VerifyStatusListTokenJwtSignature,
         format: SdJwtVcFormat,
     ): VerifyStatusListTokenJwtSignature {
         val trustConfig = statusListTrustConfig ?: return verifier
         val attestationIdentifier = AttestationIdentifier.SDJwtVc(format.vct)
-        return TrustEvaluatingJwtSignatureVerifier(verifier, trustConfig, attestationIdentifier)
+        return TrustEvaluatingJwtSignatureVerifier(verifier, trustConfig, attestationIdentifier, logger)
     }
 
-    private fun maybeWrapCwtVerifier(
+    private fun withCwtVerifier(
         verifier: VerifyStatusListTokenCwtSignature,
         format: MsoMdocFormat,
     ): VerifyStatusListTokenCwtSignature {
         val trustConfig = statusListTrustConfig ?: return verifier
         val attestationIdentifier = AttestationIdentifier.MDoc(format.docType)
-        return TrustEvaluatingCwtSignatureVerifier(verifier, trustConfig, attestationIdentifier)
+        return TrustEvaluatingCwtSignatureVerifier(verifier, trustConfig, attestationIdentifier, logger)
+    }
+
+    companion object {
+        private const val TAG = "StatusList"
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverConfigBuilder.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.statium
+
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfigBuilder
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * DSL builder for configuring the document status resolver.
+ *
+ * Allows configuring both the clock skew and optional ETSI trust verification
+ * for status list token signers.
+ *
+ * Example:
+ * ```
+ * configureDocumentStatusResolver {
+ *     clockSkew(5)
+ *     configureTrust {
+ *         trustSource(myComposeChainTrust)
+ *         classifications(myClassifications)
+ *         policy {
+ *             default(TrustPolicy.Action.ENFORCE)
+ *         }
+ *     }
+ * }
+ * ```
+ */
+class DocumentStatusResolverConfigBuilder {
+
+    var clockSkew: Duration = Duration.ZERO
+        private set
+
+    private var trustConfigBuilder: StatusListTrustConfigBuilder? = null
+
+    /**
+     * Sets the allowed clock skew in minutes for status list token verification.
+     *
+     * @param minutes the clock skew in minutes
+     */
+    fun clockSkew(minutes: Long) {
+        this.clockSkew = minutes.minutes
+    }
+
+    /**
+     * Configures ETSI trust verification for status list token signers.
+     *
+     * When configured, the signer's certificate chain will be evaluated against
+     * ETSI trusted lists before accepting the status list token.
+     *
+     * @param block configuration block applied to the [StatusListTrustConfigBuilder]
+     */
+    fun configureTrust(block: StatusListTrustConfigBuilder.() -> Unit) {
+        this.trustConfigBuilder = StatusListTrustConfigBuilder().apply(block)
+    }
+
+    /**
+     * Builds the [StatusListTrustConfig] from the current builder state, if trust was configured.
+     *
+     * @return the built [StatusListTrustConfig], or null if [configureTrust] was not called
+     */
+    internal fun buildTrustConfig(): StatusListTrustConfig? {
+        return trustConfigBuilder?.build()
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/StatusListNotTrustedException.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/StatusListNotTrustedException.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.statium
+
+/**
+ * Thrown when the status list token signer's certificate chain is not trusted and the
+ * [trust policy][eu.europa.ec.eudi.wallet.trust.TrustPolicy] action is
+ * [ENFORCE][eu.europa.ec.eudi.wallet.trust.TrustPolicy.Action.ENFORCE].
+ *
+ * @param cause the underlying cause from the trust evaluation
+ */
+class StatusListNotTrustedException(cause: Throwable) : Exception(
+    "Status list token signer certificate chain is not trusted", cause
+)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
@@ -19,6 +19,9 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
 import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import eu.europa.ec.eudi.wallet.trust.TrustPolicy
 import org.multipaz.cbor.Cbor
@@ -43,23 +46,28 @@ internal class TrustEvaluatingCwtSignatureVerifier(
     private val delegate: VerifyStatusListTokenCwtSignature,
     private val trustConfig: StatusListTrustConfig,
     private val attestationIdentifier: AttestationIdentifier,
+    private val logger: Logger? = null,
 ) : VerifyStatusListTokenCwtSignature {
 
     override suspend fun invoke(
         statusListToken: ByteArray,
         at: Instant,
     ): Result<Unit> = runCatching {
-        // 1. Delegate cryptographic signature verification
+        // Delegate cryptographic signature verification
+        logger?.d(TAG, "CWT: delegating signature verification...")
         delegate(statusListToken, at).getOrThrow()
+        logger?.d(TAG, "CWT: signature verification passed")
 
-        // 2. Extract x5chain from COSE_Sign1 unprotected headers (label 33)
+        // Extract x5chain from COSE_Sign1 unprotected headers (label 33)
         val certs = extractX5cFromCwt(statusListToken)
+        logger?.d(TAG, "CWT: x5chain has ${certs.size} certs, leaf=${certs.firstOrNull()?.subjectX500Principal}")
 
-        // 3. Evaluate trust via ETSI
+        // Evaluate trust via ETSI
         val trustResult = trustConfig.isChainTrustedForAttestation
             .issuance(certs, attestationIdentifier)
+        logger?.d(TAG, "CWT: trustResult=$trustResult for attestation=$attestationIdentifier")
 
-        // 4. Resolve verification context from classifications
+        // Resolve verification context from classifications
         val verificationContext = trustConfig.classifications
             ?.classify(attestationIdentifier)
             ?.fold(
@@ -68,15 +76,19 @@ internal class TrustEvaluatingCwtSignatureVerifier(
                 ifQEaa = VerificationContext.QEAA,
                 ifEaa = { useCase -> VerificationContext.EAA(useCase) },
             )
+        logger?.d(TAG, "CWT: verificationContext=$verificationContext")
 
-        // 5. Apply policy
+        // Apply policy
         val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
+        logger?.d(TAG, "CWT: policy action=$action")
         if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
+            logger?.e(TAG, "CWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
             throw StatusListNotTrustedException(trustResult.cause)
         }
     }
 
     companion object {
+        private const val TAG = "StatusListTrust"
         private fun extractX5cFromCwt(statusListToken: ByteArray): List<X509Certificate> {
             val coseSign1 = Cbor.decode(statusListToken).asCoseSign1
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.statium
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
+import eu.europa.ec.eudi.wallet.trust.TrustPolicy
+import org.multipaz.cbor.Cbor
+import org.multipaz.cose.Cose
+import org.multipaz.cose.toCoseLabel
+import org.multipaz.crypto.javaX509Certificates
+import java.security.cert.X509Certificate
+import kotlin.time.Instant
+
+/**
+ * Wraps a [VerifyStatusListTokenCwtSignature] to add ETSI trust evaluation of
+ * the signer's certificate chain after cryptographic signature verification.
+ *
+ * Extracts the x5chain from COSE_Sign1 unprotected headers (label 33) and evaluates
+ * trust using the configured ETSI trust source.
+ *
+ * @param delegate the underlying CWT signature verifier
+ * @param trustConfig the ETSI trust configuration for status list tokens
+ * @param attestationIdentifier the attestation identifier derived from the document format
+ */
+internal class TrustEvaluatingCwtSignatureVerifier(
+    private val delegate: VerifyStatusListTokenCwtSignature,
+    private val trustConfig: StatusListTrustConfig,
+    private val attestationIdentifier: AttestationIdentifier,
+) : VerifyStatusListTokenCwtSignature {
+
+    override suspend fun invoke(
+        statusListToken: ByteArray,
+        at: Instant,
+    ): Result<Unit> = runCatching {
+        // 1. Delegate cryptographic signature verification
+        delegate(statusListToken, at).getOrThrow()
+
+        // 2. Extract x5chain from COSE_Sign1 unprotected headers (label 33)
+        val certs = extractX5cFromCwt(statusListToken)
+
+        // 3. Evaluate trust via ETSI
+        val trustResult = trustConfig.isChainTrustedForAttestation
+            .issuance(certs, attestationIdentifier)
+
+        // 4. Resolve verification context from classifications
+        val verificationContext = trustConfig.classifications
+            ?.classify(attestationIdentifier)
+            ?.fold(
+                ifPid = VerificationContext.PID,
+                ifPubEaa = VerificationContext.PubEAA,
+                ifQEaa = VerificationContext.QEAA,
+                ifEaa = { useCase -> VerificationContext.EAA(useCase) },
+            )
+
+        // 5. Apply policy
+        val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
+        if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
+            throw StatusListNotTrustedException(trustResult.cause)
+        }
+    }
+
+    companion object {
+        private fun extractX5cFromCwt(statusListToken: ByteArray): List<X509Certificate> {
+            val coseSign1 = Cbor.decode(statusListToken).asCoseSign1
+
+            val x5chainDataItem = coseSign1.unprotectedHeaders[Cose.COSE_LABEL_X5CHAIN.toCoseLabel]
+                ?: throw IllegalStateException("Missing x5chain in COSE unprotected headers")
+            val x5chain = x5chainDataItem.asX509CertChain
+
+            val javaCerts = x5chain.javaX509Certificates
+            require(javaCerts.isNotEmpty()) { "x5chain must contain at least one certificate" }
+
+            return javaCerts
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.statium
+
+import com.nimbusds.jose.util.X509CertUtils
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
+import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
+import eu.europa.ec.eudi.wallet.trust.TrustPolicy
+import java.security.cert.X509Certificate
+import kotlin.time.Instant
+
+/**
+ * Wraps a [VerifyStatusListTokenJwtSignature] to add ETSI trust evaluation of
+ * the signer's certificate chain after cryptographic signature verification.
+ *
+ * @param delegate the underlying JWT signature verifier
+ * @param trustConfig the ETSI trust configuration for status list tokens
+ * @param attestationIdentifier the attestation identifier derived from the document format
+ */
+internal class TrustEvaluatingJwtSignatureVerifier(
+    private val delegate: VerifyStatusListTokenJwtSignature,
+    private val trustConfig: StatusListTrustConfig,
+    private val attestationIdentifier: AttestationIdentifier,
+) : VerifyStatusListTokenJwtSignature {
+
+    override suspend fun invoke(
+        statusListToken: String,
+        at: Instant,
+    ): Result<Unit> = runCatching {
+        // 1. Delegate cryptographic signature verification
+        delegate(statusListToken, at).getOrThrow()
+
+        // 2. Extract x5c certificate chain from JWT header
+        val certs = extractX5cFromJwt(statusListToken)
+
+        // 3. Evaluate trust via ETSI
+        val trustResult = trustConfig.isChainTrustedForAttestation
+            .issuance(certs, attestationIdentifier)
+
+        // 4. Resolve verification context from classifications
+        val verificationContext = trustConfig.classifications
+            ?.classify(attestationIdentifier)
+            ?.fold(
+                ifPid = VerificationContext.PID,
+                ifPubEaa = VerificationContext.PubEAA,
+                ifQEaa = VerificationContext.QEAA,
+                ifEaa = { useCase -> VerificationContext.EAA(useCase) },
+            )
+
+        // 5. Apply policy
+        val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
+        if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
+            throw StatusListNotTrustedException(trustResult.cause)
+        }
+    }
+
+    companion object {
+        private fun extractX5cFromJwt(statusListToken: String): List<X509Certificate> {
+            val signedJwt = SignedJWT.parse(statusListToken)
+            val x5cChain = signedJwt.header?.x509CertChain
+                ?: throw IllegalStateException("Missing x5c in JWT header")
+            return x5cChain.map { certBase64 ->
+                X509CertUtils.parse(certBase64.decode())
+                    ?: throw IllegalStateException("Failed to parse x5c certificate")
+            }
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
@@ -21,6 +21,9 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
 import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import eu.europa.ec.eudi.wallet.trust.TrustPolicy
 import java.security.cert.X509Certificate
@@ -38,23 +41,28 @@ internal class TrustEvaluatingJwtSignatureVerifier(
     private val delegate: VerifyStatusListTokenJwtSignature,
     private val trustConfig: StatusListTrustConfig,
     private val attestationIdentifier: AttestationIdentifier,
+    private val logger: Logger? = null,
 ) : VerifyStatusListTokenJwtSignature {
 
     override suspend fun invoke(
         statusListToken: String,
         at: Instant,
     ): Result<Unit> = runCatching {
-        // 1. Delegate cryptographic signature verification
+        // Delegate cryptographic signature verification
+        logger?.d(TAG, "JWT: delegating signature verification...")
         delegate(statusListToken, at).getOrThrow()
+        logger?.d(TAG, "JWT: signature verification passed")
 
-        // 2. Extract x5c certificate chain from JWT header
+        // Extract x5c certificate chain from JWT header
         val certs = extractX5cFromJwt(statusListToken)
+        logger?.d(TAG, "JWT: x5c chain has ${certs.size} certs, leaf=${certs.firstOrNull()?.subjectX500Principal}")
 
-        // 3. Evaluate trust via ETSI
+        // Evaluate trust via ETSI
         val trustResult = trustConfig.isChainTrustedForAttestation
             .issuance(certs, attestationIdentifier)
+        logger?.d(TAG, "JWT: trustResult=$trustResult for attestation=$attestationIdentifier")
 
-        // 4. Resolve verification context from classifications
+        // Resolve verification context from classifications
         val verificationContext = trustConfig.classifications
             ?.classify(attestationIdentifier)
             ?.fold(
@@ -63,18 +71,22 @@ internal class TrustEvaluatingJwtSignatureVerifier(
                 ifQEaa = VerificationContext.QEAA,
                 ifEaa = { useCase -> VerificationContext.EAA(useCase) },
             )
+        logger?.d(TAG, "JWT: verificationContext=$verificationContext")
 
-        // 5. Apply policy
+        // Apply policy
         val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
+        logger?.d(TAG, "JWT: policy action=$action")
         if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
+            logger?.e(TAG, "JWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
             throw StatusListNotTrustedException(trustResult.cause)
         }
     }
 
     companion object {
+        private const val TAG = "StatusListTrust"
         private fun extractX5cFromJwt(statusListToken: String): List<X509Certificate> {
             val signedJwt = SignedJWT.parse(statusListToken)
-            val x5cChain = signedJwt.header?.x509CertChain
+            val x5cChain = signedJwt.header?.x509CertChain?.toList()
                 ?: throw IllegalStateException("Missing x5c in JWT header")
             return x5cChain.map { certBase64 ->
                 X509CertUtils.parse(certBase64.decode())

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/VerifyStatusListTokenSignatureCwtX5c.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/VerifyStatusListTokenSignatureCwtX5c.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.statium
+
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
+import org.multipaz.cbor.Cbor
+import org.multipaz.cose.Cose
+import org.multipaz.cose.toCoseLabel
+import org.multipaz.crypto.Algorithm
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+import kotlin.time.Instant
+
+/**
+ * Verifies the signature of a CWT (CBOR Web Token) status list token using the x5chain header.
+ *
+ * Parses the COSE_Sign1 structure, extracts the x5chain from unprotected headers (label 33),
+ * and verifies the signature using the leaf certificate's public key.
+ */
+class VerifyStatusListTokenSignatureCwtX5c : VerifyStatusListTokenCwtSignature {
+
+    override suspend fun invoke(
+        statusListToken: ByteArray,
+        at: Instant,
+    ): Result<Unit> = runCatching {
+        // Decode COSE_Sign1 from CWT bytes
+        val coseSign1 = Cbor.decode(statusListToken).asCoseSign1
+
+        // Extract x5chain from unprotected headers (COSE label 33)
+        val x5chainDataItem = coseSign1.unprotectedHeaders[Cose.COSE_LABEL_X5CHAIN.toCoseLabel]
+            ?: throw IllegalStateException("Missing x5chain in COSE unprotected headers")
+        val x5chain = x5chainDataItem.asX509CertChain
+
+        // Get the leaf certificate
+        val leafCert = x5chain.certificates.firstOrNull()
+            ?: throw IllegalStateException("x5chain must contain at least one certificate")
+
+        // Determine algorithm from protected headers
+        val algIdentifier = coseSign1.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]
+            ?.asNumber?.toInt()
+            ?: throw IllegalStateException("Missing algorithm in COSE protected headers")
+        val algorithm = Algorithm.fromCoseAlgorithmIdentifier(algIdentifier)
+
+        // Verify COSE signature using the leaf certificate's public key
+        Cose.coseSign1Check(
+            publicKey = leafCert.ecPublicKey,
+            detachedData = null,
+            signature = coseSign1,
+            signatureAlgorithm = algorithm,
+        )
+    }
+}
+
+/**
+ * Companion object extension for [VerifyStatusListTokenCwtSignature] to provide an x5c implementation.
+ */
+val VerifyStatusListTokenCwtSignature.Companion.x5c: VerifyStatusListTokenCwtSignature
+    get() = VerifyStatusListTokenSignatureCwtX5c()

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/CredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/CredentialTrustVerifier.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import java.security.cert.TrustAnchor
+
+/**
+ * Per-format credential trust verifier. Implementations extract the certificate
+ * chain from the credential and evaluate trust using the ETSI library.
+ *
+ * Built-in implementations:
+ * - [MsoMdocCredentialTrustVerifier] for MsoMdoc credentials (uses multipaz CBOR/COSE)
+ * - [SdJwtVcCredentialTrustVerifier] for SD-JWT VC credentials (uses eudi sd-jwt-vc library)
+ *
+ * @see IssuerTrustConfigBuilder.credentialTrustVerifier for registering custom verifiers
+ */
+fun interface CredentialTrustVerifier {
+    /**
+     * Verify the issuer trust for a credential.
+     *
+     * @param credentialValue the raw credential string (base64url-encoded CBOR for MsoMdoc,
+     *   or SD-JWT string for SD-JWT VC)
+     * @param attestationIdentifier the attestation identifier derived from the document format
+     * @return the trust evaluation result, or `null` if the certificate chain could not be
+     *   extracted or the verification context is not configured
+     */
+    suspend fun verify(
+        credentialValue: String,
+        attestationIdentifier: AttestationIdentifier,
+    ): CertificationChainValidation<TrustAnchor>?
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrust.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrust.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * Adapts the ETSI [IsChainTrustedForEUDIW] to the OpenID4VCI [CertificateChainTrust] interface
+ * for validating signed issuer metadata certificate chains.
+ *
+ * Uses [VerificationContext.WalletRelyingPartyAccessCertificate] as the ETSI verification context,
+ * which is the correct context for metadata signing certificates per the EUDI specification.
+ *
+ * @param isChainTrusted the ETSI chain trust validator
+ * @see EtsiReaderTrustStore for the analogous adapter for reader authentication
+ */
+internal class EtsiCertificateChainTrust(
+    private val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
+) : CertificateChainTrust {
+
+    override suspend fun isTrusted(chain: List<X509Certificate>): Boolean {
+        return try {
+            val result = isChainTrusted(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+            result is CertificationChainValidation.Trusted
+        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            false
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrust.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrust.kt
@@ -19,6 +19,9 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 
@@ -30,18 +33,29 @@ import java.security.cert.X509Certificate
  * which is the correct context for metadata signing certificates per the EUDI specification.
  *
  * @param isChainTrusted the ETSI chain trust validator
+ * @param logger optional [Logger] for diagnostic output
  * @see EtsiReaderTrustStore for the analogous adapter for reader authentication
  */
 internal class EtsiCertificateChainTrust(
     private val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
+    private val logger: Logger? = null,
 ) : CertificateChainTrust {
 
     override suspend fun isTrusted(chain: List<X509Certificate>): Boolean {
+        logger?.d(TAG, "isTrusted: chain has ${chain.size} certs, " +
+            "leaf=${chain.firstOrNull()?.subjectX500Principal}")
         return try {
             val result = isChainTrusted(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
-            result is CertificationChainValidation.Trusted
-        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            val trusted = result is CertificationChainValidation.Trusted
+            logger?.d(TAG, "isTrusted: result=$result, trusted=$trusted")
+            trusted
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            logger?.e(TAG, "isTrusted failed: ${e.message}", e)
             false
         }
+    }
+
+    private companion object {
+        const val TAG = "MetadataTrust"
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * [ReaderTrustStore] implementation backed by ETSI Trusted Lists.
+ *
+ * Delegates reader certificate chain validation to the ETSI library's
+ * [IsChainTrustedForEUDIW], enabling dynamic trust anchor resolution
+ * from LoTE (ETSI TS 119 602) and/or LOTL (ETSI TS 119 612).
+ *
+ * This is a drop-in replacement for
+ * [eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl] — use it with
+ * [eu.europa.ec.eudi.wallet.EudiWallet.Builder.withReaderTrustStore] or
+ * [eu.europa.ec.eudi.wallet.EudiWallet.setReaderTrustStore].
+ *
+ * @param isChainTrusted the ETSI chain trust validator (supports LoTE, LOTL, or combined sources)
+ * @param verificationContext the EUDI verification context for reader authentication
+ *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
+ * @param coroutineContext the coroutine context for the sync/async bridge
+ *        (defaults to [Dispatchers.IO])
+ * @see asReaderTrustStore convenience extension function
+ */
+class EtsiReaderTrustStore(
+    private val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
+    private val verificationContext: VerificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+) : ReaderTrustStore {
+
+    /**
+     * Creates a certification trust path by validating the chain against ETSI trusted lists.
+     *
+     * @param chain the certificate chain to validate
+     * @return the chain plus the trust anchor certificate if trusted, null otherwise
+     */
+    override fun createCertificationTrustPath(
+        chain: List<X509Certificate>
+    ): List<X509Certificate>? {
+        val result = evaluateChain(chain) ?: return null
+        return when (result) {
+            is CertificationChainValidation.Trusted -> chain + result.trustAnchor.trustedCert
+            is CertificationChainValidation.NotTrusted -> null
+        }
+    }
+
+    /**
+     * Validates that the certificate chain is trusted according to ETSI trusted lists.
+     *
+     * @param chainToDocumentSigner the certificate chain to validate
+     * @return true if the chain is trusted, false otherwise
+     */
+    override fun validateCertificationTrustPath(
+        chainToDocumentSigner: List<X509Certificate>
+    ): Boolean {
+        val result = evaluateChain(chainToDocumentSigner) ?: return false
+        return result is CertificationChainValidation.Trusted
+    }
+
+    private fun evaluateChain(
+        chain: List<X509Certificate>
+    ): CertificationChainValidation<TrustAnchor>? = try {
+        runBlocking(coroutineContext) {
+            isChainTrusted(chain, verificationContext)
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        // Network errors, cold cache failures, etc. — treat as not trusted
+        null
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
@@ -36,8 +36,8 @@ import kotlin.coroutines.CoroutineContext
  * from LoTE (ETSI TS 119 602) and/or LOTL (ETSI TS 119 612).
  *
  * This is a drop-in replacement for
- * [eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl] — use it with
- * [eu.europa.ec.eudi.wallet.EudiWallet.Builder.withReaderTrustStore] or
+ * [eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl] — configure it
+ * via [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureReaderTrustStore] or
  * [eu.europa.ec.eudi.wallet.EudiWallet.setReaderTrustStore].
  *
  * @param isChainTrusted the ETSI chain trust validator (supports LoTE, LOTL, or combined sources)
@@ -46,7 +46,6 @@ import kotlin.coroutines.CoroutineContext
  * @param coroutineContext the coroutine context for the sync/async bridge
  *        (defaults to [Dispatchers.IO])
  * @param logger optional [Logger] for diagnostic output
- * @see asReaderTrustStore convenience extension function
  */
 class EtsiReaderTrustStore(
     private val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
@@ -19,6 +19,9 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import java.security.cert.TrustAnchor
@@ -42,12 +45,14 @@ import kotlin.coroutines.CoroutineContext
  *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
  * @param coroutineContext the coroutine context for the sync/async bridge
  *        (defaults to [Dispatchers.IO])
+ * @param logger optional [Logger] for diagnostic output
  * @see asReaderTrustStore convenience extension function
  */
 class EtsiReaderTrustStore(
     private val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
     private val verificationContext: VerificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
+    @JvmField var logger: Logger? = null,
 ) : ReaderTrustStore {
 
     /**
@@ -75,8 +80,12 @@ class EtsiReaderTrustStore(
     override fun validateCertificationTrustPath(
         chainToDocumentSigner: List<X509Certificate>
     ): Boolean {
+        logger?.d(TAG, "validateCertificationTrustPath: chain has ${chainToDocumentSigner.size} certs, " +
+            "leaf=${chainToDocumentSigner.firstOrNull()?.subjectX500Principal}")
         val result = evaluateChain(chainToDocumentSigner) ?: return false
-        return result is CertificationChainValidation.Trusted
+        val trusted = result is CertificationChainValidation.Trusted
+        logger?.d(TAG, "validateCertificationTrustPath: result=$result, trusted=$trusted")
+        return trusted
     }
 
     private fun evaluateChain(
@@ -85,8 +94,12 @@ class EtsiReaderTrustStore(
         runBlocking(coroutineContext) {
             isChainTrusted(chain, verificationContext)
         }
-    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
-        // Network errors, cold cache failures, etc. — treat as not trusted
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        logger?.e(TAG, "evaluateChain failed: ${e.message}", e)
         null
+    }
+
+    private companion object {
+        const val TAG = "ReaderTrust"
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import kotlinx.coroutines.Dispatchers
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Creates a [ReaderTrustStore] backed by this ETSI chain trust validator.
+ *
+ * Convenience extension for creating an [EtsiReaderTrustStore] with sensible defaults.
+ *
+ * Usage:
+ * ```kotlin
+ * val wallet = EudiWallet(context, config) {
+ *     withReaderTrustStore(isChainTrusted.asReaderTrustStore())
+ * }
+ * ```
+ *
+ * @param verificationContext the EUDI verification context for reader authentication
+ *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
+ * @param coroutineContext the coroutine context for the sync/async bridge
+ *        (defaults to [Dispatchers.IO])
+ * @return a [ReaderTrustStore] that delegates to this chain trust validator
+ */
+fun IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>.asReaderTrustStore(
+    verificationContext: VerificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+    coroutineContext: CoroutineContext = Dispatchers.IO,
+): ReaderTrustStore = EtsiReaderTrustStore(this, verificationContext, coroutineContext)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
@@ -28,13 +28,7 @@ import kotlin.coroutines.CoroutineContext
  * Creates a [ReaderTrustStore] backed by this ETSI chain trust validator.
  *
  * Convenience extension for creating an [EtsiReaderTrustStore] with sensible defaults.
- *
- * Usage:
- * ```kotlin
- * val wallet = EudiWallet(context, config) {
- *     withReaderTrustStore(isChainTrusted.asReaderTrustStore())
- * }
- * ```
+ * Used internally by [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureReaderTrustStore].
  *
  * @param verificationContext the EUDI verification context for reader authentication
  *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
@@ -43,7 +37,7 @@ import kotlin.coroutines.CoroutineContext
  * @param logger optional [Logger] for diagnostic output
  * @return a [ReaderTrustStore] that delegates to this chain trust validator
  */
-fun IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>.asReaderTrustStore(
+internal fun IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>.asReaderTrustStore(
     verificationContext: VerificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
     coroutineContext: CoroutineContext = Dispatchers.IO,
     logger: Logger? = null,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreExt.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.wallet.trust
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.wallet.logging.Logger
 import kotlinx.coroutines.Dispatchers
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
@@ -39,9 +40,11 @@ import kotlin.coroutines.CoroutineContext
  *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
  * @param coroutineContext the coroutine context for the sync/async bridge
  *        (defaults to [Dispatchers.IO])
+ * @param logger optional [Logger] for diagnostic output
  * @return a [ReaderTrustStore] that delegates to this chain trust validator
  */
 fun IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>.asReaderTrustStore(
     verificationContext: VerificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
     coroutineContext: CoroutineContext = Dispatchers.IO,
-): ReaderTrustStore = EtsiReaderTrustStore(this, verificationContext, coroutineContext)
+    logger: Logger? = null,
+): ReaderTrustStore = EtsiReaderTrustStore(this, verificationContext, coroutineContext, logger)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrust.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrust.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.wallet.document.Document
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.logging.Logger
+import java.security.cert.TrustAnchor
+
+/**
+ * Shared logic for evaluating issuer trust during credential issuance.
+ *
+ * Used by both ProcessResponse and ProcessDeferredOutcome to verify the issuer's
+ * certificate chain against the configured trust lists.
+ *
+ * @param issuerTrustConfig the trust configuration, or null if trust verification is not configured
+ * @param document the document being issued
+ * @param credential the credential received from the issuer
+ * @param logger optional logger for debug messages
+ * @return the trust evaluation result, or null if trust verification is not configured or not applicable
+ * @throws IssuerNotTrustedException if the issuer is not trusted and the policy is [TrustPolicy.Action.ENFORCE]
+ */
+internal suspend fun evaluateIssuerTrust(
+    issuerTrustConfig: IssuerTrustConfig?,
+    document: Document,
+    credential: Credential,
+    logger: Logger?,
+): CertificationChainValidation<TrustAnchor>? {
+    if (issuerTrustConfig == null) return null
+
+    require(credential is Credential.Str) { "Credential must be a string" }
+
+    // 1. Derive AttestationIdentifier from document format
+    val attestationIdentifier = when (val fmt = document.format) {
+        is MsoMdocFormat -> AttestationIdentifier.MDoc(fmt.docType)
+        is SdJwtVcFormat -> AttestationIdentifier.SDJwtVc(fmt.vct)
+        else -> {
+            logger?.d(TAG, "Unknown document format, skipping trust verification")
+            return null
+        }
+    }
+
+    // 2. Look up verifier by format
+    val verifier = issuerTrustConfig.credentialTrustVerifiers[document.format::class]
+    if (verifier == null) {
+        logger?.d(TAG, "No CredentialTrustVerifier for format, skipping trust verification")
+        return null
+    }
+
+    // 3. Verify trust
+    val result = verifier.verify(credential.value, attestationIdentifier)
+    if (result == null) {
+        logger?.d(TAG, "No certificate chain found, skipping trust verification")
+        return null
+    }
+
+    // 4. Resolve policy
+    val verificationContext = issuerTrustConfig.classifications
+        ?.classify(attestationIdentifier)
+        ?.fold(
+            ifPid = VerificationContext.PID,
+            ifPubEaa = VerificationContext.PubEAA,
+            ifQEaa = VerificationContext.QEAA,
+            ifEaa = { useCase -> VerificationContext.EAA(useCase) },
+        )
+
+    val action = issuerTrustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
+
+    // 5. Apply policy
+    if (action == TrustPolicy.Action.ENFORCE && result is CertificationChainValidation.NotTrusted) {
+        throw IssuerNotTrustedException(result.cause)
+    }
+
+    return result
+}
+
+private const val TAG = "OpenId4VciManager"

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrust.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrust.kt
@@ -45,7 +45,10 @@ internal suspend fun evaluateIssuerTrust(
     credential: Credential,
     logger: Logger?,
 ): CertificationChainValidation<TrustAnchor>? {
-    if (issuerTrustConfig == null) return null
+    if (issuerTrustConfig == null) {
+        logger?.d(TAG, "EXIT 1: issuerTrustConfig is null")
+        return null
+    }
 
     require(credential is Credential.Str) { "Credential must be a string" }
 
@@ -54,24 +57,32 @@ internal suspend fun evaluateIssuerTrust(
         is MsoMdocFormat -> AttestationIdentifier.MDoc(fmt.docType)
         is SdJwtVcFormat -> AttestationIdentifier.SDJwtVc(fmt.vct)
         else -> {
+            logger?.d(TAG, "EXIT 2: Unknown document format ${document.format}")
             logger?.d(TAG, "Unknown document format, skipping trust verification")
             return null
         }
     }
 
+    logger?.d(TAG, "attestationIdentifier=$attestationIdentifier")
+
     // 2. Look up verifier by format
     val verifier = issuerTrustConfig.credentialTrustVerifiers[document.format::class]
     if (verifier == null) {
+        logger?.d(TAG, "EXIT 3: No verifier for ${document.format::class}, available: ${issuerTrustConfig.credentialTrustVerifiers.keys}")
         logger?.d(TAG, "No CredentialTrustVerifier for format, skipping trust verification")
         return null
     }
 
     // 3. Verify trust
+    logger?.d(TAG, "Calling verifier.verify()...")
     val result = verifier.verify(credential.value, attestationIdentifier)
     if (result == null) {
+        logger?.d(TAG, "EXIT 4: verifier.verify() returned null")
         logger?.d(TAG, "No certificate chain found, skipping trust verification")
         return null
     }
+
+    logger?.d(TAG, "Trust result: $result")
 
     // 4. Resolve policy
     val verificationContext = issuerTrustConfig.classifications
@@ -93,4 +104,4 @@ internal suspend fun evaluateIssuerTrust(
     return result
 }
 
-private const val TAG = "OpenId4VciManager"
+private const val TAG = "EvaluateTrust"

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerNotTrustedException.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerNotTrustedException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+/**
+ * Thrown when the issuer certificate chain is not trusted and the
+ * [trust policy][TrustPolicy] action is [TrustPolicy.Action.ENFORCE].
+ *
+ * @param cause the underlying cause from the trust evaluation
+ */
+class IssuerNotTrustedException(cause: Throwable) : Exception(
+    "Issuer certificate chain is not trusted", cause
+)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import kotlin.reflect.KClass
+
+/**
+ * Configuration for issuer trust verification.
+ *
+ * Holds the trust source, optional attestation classifications, the trust policy,
+ * and per-format credential trust verifiers.
+ *
+ * @param isChainTrustedForAttestation the ETSI trust source for validating certificate chains
+ * @param classifications optional attestation classifications for mapping credentials to verification contexts
+ * @param trustPolicy the policy determining how to handle trust verification results
+ * @param credentialTrustVerifiers per-format verifiers that extract certificate chains from credentials
+ */
+internal data class IssuerTrustConfig(
+    val isChainTrustedForAttestation: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+    val classifications: AttestationClassifications?,
+    val trustPolicy: TrustPolicy,
+    val credentialTrustVerifiers: Map<KClass<out DocumentFormat>, CredentialTrustVerifier>,
+)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
@@ -40,5 +40,5 @@ internal data class IssuerTrustConfig(
     val classifications: AttestationClassifications?,
     val trustPolicy: TrustPolicy,
     val credentialTrustVerifiers: Map<KClass<out DocumentFormat>, CredentialTrustVerifier>,
-    val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+    val issuerMetadataPolicy: IssuerMetadataPolicy,
 )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfig.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.wallet.trust
 
 import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
@@ -26,16 +27,18 @@ import kotlin.reflect.KClass
  * Configuration for issuer trust verification.
  *
  * Holds the trust source, optional attestation classifications, the trust policy,
- * and per-format credential trust verifiers.
+ * per-format credential trust verifiers, and the issuer metadata policy.
  *
  * @param isChainTrustedForAttestation the ETSI trust source for validating certificate chains
  * @param classifications optional attestation classifications for mapping credentials to verification contexts
  * @param trustPolicy the policy determining how to handle trust verification results
  * @param credentialTrustVerifiers per-format verifiers that extract certificate chains from credentials
+ * @param issuerMetadataPolicy the OpenID4VCI metadata policy controlling signed metadata verification
  */
 internal data class IssuerTrustConfig(
     val isChainTrustedForAttestation: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
     val classifications: AttestationClassifications?,
     val trustPolicy: TrustPolicy,
     val credentialTrustVerifiers: Map<KClass<out DocumentFormat>, CredentialTrustVerifier>,
+    val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
 )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.ComposeChainTrust
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import kotlin.reflect.KClass
+
+/**
+ * DSL builder for constructing an [IssuerTrustConfig].
+ *
+ * A trust source must be provided via one of the [trustSource] overloads.
+ * When using [IsChainTrustedForEUDIW] or [ComposeChainTrust] as the trust source,
+ * [classifications] must also be provided so the builder can construct an
+ * [IsChainTrustedForAttestation] instance.
+ *
+ * Example:
+ * ```
+ * val config = IssuerTrustConfigBuilder().apply {
+ *     trustSource(myComposeChainTrust)
+ *     classifications(myClassifications)
+ *     policy {
+ *         default(TrustPolicy.Action.ENFORCE)
+ *         forContext(VerificationContext.PID, TrustPolicy.Action.INFORM)
+ *     }
+ * }.build()
+ * ```
+ */
+class IssuerTrustConfigBuilder {
+
+    private var preBuiltAttestation: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>? = null
+    private var eudiwSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>? = null
+    private var classifications: AttestationClassifications? = null
+    private var policyBuilder: (TrustPolicy.Builder.() -> Unit)? = null
+    private val customVerifiers = mutableMapOf<KClass<out DocumentFormat>, CredentialTrustVerifier>()
+
+    /**
+     * Sets the trust source from a pre-built [IsChainTrustedForAttestation].
+     *
+     * When using this overload, [classifications] is not required (the attestation
+     * already encapsulates the classification logic).
+     *
+     * @param source the pre-built attestation trust source
+     */
+    fun trustSource(source: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>) {
+        this.preBuiltAttestation = source
+        this.eudiwSource = null
+    }
+
+    /**
+     * Sets the trust source from a [ComposeChainTrust] instance.
+     *
+     * When using this overload, [classifications] must be provided before calling [build].
+     *
+     * @param source the composed chain trust source
+     */
+    fun trustSource(source: ComposeChainTrust<List<X509Certificate>, VerificationContext, TrustAnchor>) {
+        this.eudiwSource = source
+        this.preBuiltAttestation = null
+    }
+
+    /**
+     * Sets the trust source from an [IsChainTrustedForEUDIW] instance.
+     *
+     * When using this overload, [classifications] must be provided before calling [build].
+     *
+     * @param source the EUDIW trust source
+     */
+    fun trustSource(source: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>) {
+        this.eudiwSource = source
+        this.preBuiltAttestation = null
+    }
+
+    /**
+     * Sets the attestation classifications used to map credential types to verification contexts.
+     *
+     * Required when the trust source is an [IsChainTrustedForEUDIW] or [ComposeChainTrust].
+     *
+     * @param classifications the attestation classifications
+     */
+    fun classifications(classifications: AttestationClassifications) {
+        this.classifications = classifications
+    }
+
+    /**
+     * Configures the trust policy using the [TrustPolicy.Builder] DSL.
+     *
+     * If not called, the default policy is [TrustPolicy.Action.ENFORCE] for all credentials.
+     *
+     * @param block configuration block applied to the [TrustPolicy.Builder]
+     */
+    fun policy(block: TrustPolicy.Builder.() -> Unit) {
+        this.policyBuilder = block
+    }
+
+    /**
+     * Registers a custom [CredentialTrustVerifier] for a specific [DocumentFormat] type.
+     *
+     * @param format the document format class to associate the verifier with
+     * @param verifier the credential trust verifier implementation
+     */
+    fun credentialTrustVerifier(format: KClass<out DocumentFormat>, verifier: CredentialTrustVerifier) {
+        customVerifiers[format] = verifier
+    }
+
+    /**
+     * Builds the [IssuerTrustConfig] from the current builder state.
+     *
+     * @return a validated [IssuerTrustConfig]
+     * @throws IllegalArgumentException if no trust source is configured, or if classifications
+     *   are missing when required by the trust source type
+     */
+    internal fun build(): IssuerTrustConfig {
+        val attestation = preBuiltAttestation ?: run {
+            val eudiw = requireNotNull(eudiwSource) {
+                "A trust source must be provided via trustSource()"
+            }
+            val cls = requireNotNull(classifications) {
+                "AttestationClassifications must be provided when using IsChainTrustedForEUDIW as trust source"
+            }
+            IsChainTrustedForAttestation(eudiw, cls)
+        }
+
+        val trustPolicy = policyBuilder?.let { TrustPolicy.build(it) }
+            ?: TrustPolicy.uniform(TrustPolicy.Action.ENFORCE)
+
+        val defaultVerifiers = mapOf<KClass<out DocumentFormat>, CredentialTrustVerifier>(
+            MsoMdocFormat::class to MsoMdocCredentialTrustVerifier(attestation),
+            SdJwtVcFormat::class to SdJwtVcCredentialTrustVerifier(attestation),
+        )
+        val verifiers = defaultVerifiers + customVerifiers
+
+        return IssuerTrustConfig(
+            isChainTrustedForAttestation = attestation,
+            classifications = classifications,
+            trustPolicy = trustPolicy,
+            credentialTrustVerifiers = verifiers,
+        )
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -20,7 +20,6 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.ComposeChainTrust
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
-import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.openid4vci.IssuerTrust
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
@@ -57,8 +56,7 @@ class IssuerTrustConfigBuilder {
     private var classifications: AttestationClassifications? = null
     private var policyBuilder: (TrustPolicy.Builder.() -> Unit)? = null
     private val customVerifiers = mutableMapOf<KClass<out DocumentFormat>, CredentialTrustVerifier>()
-    private var metadataPolicyMode: MetadataPolicyMode = MetadataPolicyMode.IGNORE
-    private var customCertificateChainTrust: CertificateChainTrust? = null
+    private var metadataPolicyMode: MetadataPolicyMode = MetadataPolicyMode.REQUIRE
 
     private enum class MetadataPolicyMode { IGNORE, REQUIRE, PREFER }
 
@@ -129,31 +127,33 @@ class IssuerTrustConfigBuilder {
      * configured ETSI trust source using
      * [VerificationContext.WalletRelyingPartyAccessCertificate].
      *
-     * If the trust source is an [IsChainTrustedForEUDIW] (set via [trustSource]),
-     * the ETSI adapter is used automatically. Otherwise, a custom
-     * [CertificateChainTrust] must be provided.
-     *
-     * @param certificateChainTrust optional custom trust validator; if null,
-     *   the ETSI-backed adapter is used (requires [IsChainTrustedForEUDIW] trust source)
+     * Requires an [IsChainTrustedForEUDIW] trust source (set via [trustSource]).
      */
-    fun requireSignedMetadata(certificateChainTrust: CertificateChainTrust? = null) {
+    fun requireSignedMetadata() {
         this.metadataPolicyMode = MetadataPolicyMode.REQUIRE
-        this.customCertificateChainTrust = certificateChainTrust
     }
 
     /**
      * Prefers signed issuer metadata for OpenID4VCI operations.
      *
-     * When set, the wallet will prefer signed JWT metadata from credential issuers but
+     * The wallet will prefer signed JWT metadata from credential issuers but
      * will fall back to unsigned metadata if signed metadata is not available.
-     * The certificate chain validation follows the same rules as [requireSignedMetadata].
+     * Use this to relax the default [requireSignedMetadata] behaviour.
      *
-     * @param certificateChainTrust optional custom trust validator; if null,
-     *   the ETSI-backed adapter is used (requires [IsChainTrustedForEUDIW] trust source)
+     * Requires an [IsChainTrustedForEUDIW] trust source (set via [trustSource]).
      */
-    fun preferSignedMetadata(certificateChainTrust: CertificateChainTrust? = null) {
+    fun preferSignedMetadata() {
         this.metadataPolicyMode = MetadataPolicyMode.PREFER
-        this.customCertificateChainTrust = certificateChainTrust
+    }
+
+    /**
+     * Disables signed issuer metadata verification.
+     *
+     * When set, the wallet will ignore signed metadata and use only unsigned metadata.
+     * Use this to explicitly opt out of the default [requireSignedMetadata] behaviour.
+     */
+    fun ignoreSignedMetadata() {
+        this.metadataPolicyMode = MetadataPolicyMode.IGNORE
     }
 
     /**
@@ -204,24 +204,22 @@ class IssuerTrustConfigBuilder {
         )
     }
 
-    private fun buildIssuerMetadataPolicy(): IssuerMetadataPolicy {
-        if (metadataPolicyMode == MetadataPolicyMode.IGNORE) {
-            return IssuerMetadataPolicy.IgnoreSigned
-        }
-
-        val chainTrust = customCertificateChainTrust
-            ?: eudiwSource?.let { EtsiCertificateChainTrust(it) }
-            ?: throw IllegalArgumentException(
-                "Signed metadata verification requires either a CertificateChainTrust " +
-                    "or an IsChainTrustedForEUDIW trust source"
-            )
-
-        val issuerTrust = IssuerTrust.ByCertificateChain(chainTrust)
-
-        return when (metadataPolicyMode) {
-            MetadataPolicyMode.REQUIRE -> IssuerMetadataPolicy.RequireSigned(issuerTrust)
-            MetadataPolicyMode.PREFER -> IssuerMetadataPolicy.PreferSigned(issuerTrust)
+    private fun buildIssuerMetadataPolicy(): IssuerMetadataPolicy =
+        when (metadataPolicyMode) {
             MetadataPolicyMode.IGNORE -> IssuerMetadataPolicy.IgnoreSigned
+            MetadataPolicyMode.REQUIRE,
+            MetadataPolicyMode.PREFER -> {
+                val source = eudiwSource
+                    ?: throw IllegalArgumentException(
+                        "Signed metadata verification requires an IsChainTrustedForEUDIW trust source. " +
+                            "Call ignoreSignedMetadata() to opt out."
+                    )
+                val issuerTrust = IssuerTrust.ByCertificateChain(EtsiCertificateChainTrust(source))
+                if (metadataPolicyMode == MetadataPolicyMode.REQUIRE) {
+                    IssuerMetadataPolicy.RequireSigned(issuerTrust)
+                } else {
+                    IssuerMetadataPolicy.PreferSigned(issuerTrust)
+                }
+            }
         }
-    }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -20,6 +20,9 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.ComposeChainTrust
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
+import eu.europa.ec.eudi.openid4vci.IssuerTrust
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
@@ -54,6 +57,10 @@ class IssuerTrustConfigBuilder {
     private var classifications: AttestationClassifications? = null
     private var policyBuilder: (TrustPolicy.Builder.() -> Unit)? = null
     private val customVerifiers = mutableMapOf<KClass<out DocumentFormat>, CredentialTrustVerifier>()
+    private var metadataPolicyMode: MetadataPolicyMode = MetadataPolicyMode.IGNORE
+    private var customCertificateChainTrust: CertificateChainTrust? = null
+
+    private enum class MetadataPolicyMode { IGNORE, REQUIRE, PREFER }
 
     /**
      * Sets the trust source from a pre-built [IsChainTrustedForAttestation].
@@ -115,6 +122,41 @@ class IssuerTrustConfigBuilder {
     }
 
     /**
+     * Requires signed issuer metadata for OpenID4VCI operations.
+     *
+     * When set, the wallet will only accept signed JWT metadata from credential issuers.
+     * The signing certificate chain from the JWT `x5c` header is validated against the
+     * configured ETSI trust source using
+     * [VerificationContext.WalletRelyingPartyAccessCertificate].
+     *
+     * If the trust source is an [IsChainTrustedForEUDIW] (set via [trustSource]),
+     * the ETSI adapter is used automatically. Otherwise, a custom
+     * [CertificateChainTrust] must be provided.
+     *
+     * @param certificateChainTrust optional custom trust validator; if null,
+     *   the ETSI-backed adapter is used (requires [IsChainTrustedForEUDIW] trust source)
+     */
+    fun requireSignedMetadata(certificateChainTrust: CertificateChainTrust? = null) {
+        this.metadataPolicyMode = MetadataPolicyMode.REQUIRE
+        this.customCertificateChainTrust = certificateChainTrust
+    }
+
+    /**
+     * Prefers signed issuer metadata for OpenID4VCI operations.
+     *
+     * When set, the wallet will prefer signed JWT metadata from credential issuers but
+     * will fall back to unsigned metadata if signed metadata is not available.
+     * The certificate chain validation follows the same rules as [requireSignedMetadata].
+     *
+     * @param certificateChainTrust optional custom trust validator; if null,
+     *   the ETSI-backed adapter is used (requires [IsChainTrustedForEUDIW] trust source)
+     */
+    fun preferSignedMetadata(certificateChainTrust: CertificateChainTrust? = null) {
+        this.metadataPolicyMode = MetadataPolicyMode.PREFER
+        this.customCertificateChainTrust = certificateChainTrust
+    }
+
+    /**
      * Registers a custom [CredentialTrustVerifier] for a specific [DocumentFormat] type.
      *
      * @param format the document format class to associate the verifier with
@@ -151,11 +193,35 @@ class IssuerTrustConfigBuilder {
         )
         val verifiers = defaultVerifiers + customVerifiers
 
+        val issuerMetadataPolicy = buildIssuerMetadataPolicy()
+
         return IssuerTrustConfig(
             isChainTrustedForAttestation = attestation,
             classifications = classifications,
             trustPolicy = trustPolicy,
             credentialTrustVerifiers = verifiers,
+            issuerMetadataPolicy = issuerMetadataPolicy,
         )
+    }
+
+    private fun buildIssuerMetadataPolicy(): IssuerMetadataPolicy {
+        if (metadataPolicyMode == MetadataPolicyMode.IGNORE) {
+            return IssuerMetadataPolicy.IgnoreSigned
+        }
+
+        val chainTrust = customCertificateChainTrust
+            ?: eudiwSource?.let { EtsiCertificateChainTrust(it) }
+            ?: throw IllegalArgumentException(
+                "Signed metadata verification requires either a CertificateChainTrust " +
+                    "or an IsChainTrustedForEUDIW trust source"
+            )
+
+        val issuerTrust = IssuerTrust.ByCertificateChain(chainTrust)
+
+        return when (metadataPolicyMode) {
+            MetadataPolicyMode.REQUIRE -> IssuerMetadataPolicy.RequireSigned(issuerTrust)
+            MetadataPolicyMode.PREFER -> IssuerMetadataPolicy.PreferSigned(issuerTrust)
+            MetadataPolicyMode.IGNORE -> IssuerMetadataPolicy.IgnoreSigned
+        }
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import org.multipaz.cbor.Cbor
+import org.multipaz.cose.Cose
+import org.multipaz.cose.toCoseLabel
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.javaX509Certificates
+import org.multipaz.mdoc.mso.StaticAuthDataParser
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+/**
+ * [CredentialTrustVerifier] for MsoMdoc credentials.
+ *
+ * Extracts the X.509 certificate chain from the COSE_Sign1 unprotected `x5chain` header
+ * (label 33), evaluates trust via [IsChainTrustedForAttestation], and verifies the COSE
+ * signature using the leaf certificate's public key.
+ *
+ * @param isChainTrusted the ETSI trust source for validating certificate chains
+ */
+internal class MsoMdocCredentialTrustVerifier(
+    private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+) : CredentialTrustVerifier {
+
+    override suspend fun verify(
+        credentialValue: String,
+        attestationIdentifier: AttestationIdentifier,
+    ): CertificationChainValidation<TrustAnchor>? = runCatching {
+        // 1. Base64url-decode the credential string
+        val credentialBytes = Base64.getUrlDecoder().decode(credentialValue)
+
+        // 2. Parse issuerAuth from StaticAuthData
+        val issuerAuthBytes = StaticAuthDataParser(credentialBytes)
+            .parse()
+            .issuerAuth
+
+        // 3. Decode COSE_Sign1 from issuerAuth
+        val coseSign1 = Cbor.decode(issuerAuthBytes).asCoseSign1
+
+        // 4. Extract x5chain from unprotected headers (COSE label 33)
+        val x5chainDataItem = coseSign1.unprotectedHeaders[Cose.COSE_LABEL_X5CHAIN.toCoseLabel]
+            ?: return@runCatching null
+        val x5chain = x5chainDataItem.asX509CertChain
+
+        // 5. Convert to List<X509Certificate> (JVM extension)
+        val javaCerts = x5chain.javaX509Certificates
+        require(javaCerts.isNotEmpty()) { "x5chain must contain at least one certificate" }
+
+        // 6. Evaluate trust via the ETSI library
+        val trustResult = isChainTrusted.issuance(javaCerts, attestationIdentifier)
+            ?: return@runCatching null
+
+        // 7. Verify COSE signature using the leaf certificate's public key
+        val leafCert = x5chain.certificates.first()
+        val algIdentifier = coseSign1.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]
+            ?.asNumber?.toInt()
+            ?: return@runCatching null
+        val algorithm = Algorithm.fromCoseAlgorithmIdentifier(algIdentifier)
+
+        Cose.coseSign1Check(
+            publicKey = leafCert.ecPublicKey,
+            detachedData = null,
+            signature = coseSign1,
+            signatureAlgorithm = algorithm,
+        )
+
+        trustResult
+    }.getOrNull()
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
@@ -45,35 +45,39 @@ internal class MsoMdocCredentialTrustVerifier(
         credentialValue: String,
         attestationIdentifier: AttestationIdentifier,
     ): CertificationChainValidation<TrustAnchor>? = runCatching {
-        // 1. Base64url-decode the credential string
+        //  Base64url-decode the credential string
         val credentialBytes = Base64.getUrlDecoder().decode(credentialValue)
 
-        // 2. Parse issuerAuth from StaticAuthData
+        //  Parse issuerAuth from StaticAuthData
         val issuerAuthBytes = StaticAuthDataParser(credentialBytes)
             .parse()
             .issuerAuth
 
-        // 3. Decode COSE_Sign1 from issuerAuth
+        //  Decode COSE_Sign1 from issuerAuth
         val coseSign1 = Cbor.decode(issuerAuthBytes).asCoseSign1
 
-        // 4. Extract x5chain from unprotected headers (COSE label 33)
+        //  Extract x5chain from unprotected headers (COSE label 33)
         val x5chainDataItem = coseSign1.unprotectedHeaders[Cose.COSE_LABEL_X5CHAIN.toCoseLabel]
-            ?: return@runCatching null
+            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL A: no x5chain in COSE headers"); return@runCatching null }
         val x5chain = x5chainDataItem.asX509CertChain
 
-        // 5. Convert to List<X509Certificate> (JVM extension)
+        //  Convert to List<X509Certificate> (JVM extension)
         val javaCerts = x5chain.javaX509Certificates
+        android.util.Log.d("IssuerTrust", "VERIFIER: x5chain has ${javaCerts.size} certs, leaf=${javaCerts.firstOrNull()?.subjectX500Principal}")
         require(javaCerts.isNotEmpty()) { "x5chain must contain at least one certificate" }
 
-        // 6. Evaluate trust via the ETSI library
+        //  Evaluate trust via the ETSI library
+        android.util.Log.d("IssuerTrust", "VERIFIER: calling isChainTrusted.issuance()...")
         val trustResult = isChainTrusted.issuance(javaCerts, attestationIdentifier)
-            ?: return@runCatching null
+            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL B: issuance() returned null"); return@runCatching null }
 
-        // 7. Verify COSE signature using the leaf certificate's public key
+        android.util.Log.d("IssuerTrust", "VERIFIER: trustResult=$trustResult")
+
+        //  Verify COSE signature using the leaf certificate's public key
         val leafCert = x5chain.certificates.first()
         val algIdentifier = coseSign1.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]
             ?.asNumber?.toInt()
-            ?: return@runCatching null
+            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL C: no algorithm in COSE headers"); return@runCatching null }
         val algorithm = Algorithm.fromCoseAlgorithmIdentifier(algIdentifier)
 
         Cose.coseSign1Check(
@@ -84,5 +88,7 @@ internal class MsoMdocCredentialTrustVerifier(
         )
 
         trustResult
+    }.onFailure { e ->
+        android.util.Log.e("IssuerTrust", "MsoMdocCredentialTrustVerifier failed", e)
     }.getOrNull()
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
+import eu.europa.ec.eudi.sdjwt.vc.X509CertificateTrust
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * [CredentialTrustVerifier] for SD-JWT VC credentials.
+ *
+ * Delegates to the eudi sd-jwt-vc library's verify method, plugging in the ETSI
+ * trust evaluator via the [X509CertificateTrust] callback. The x5c certificate
+ * chain is extracted from the JWT header by the sd-jwt-vc library during
+ * verification; the trust callback captures the evaluation result.
+ *
+ * @param isChainTrusted the ETSI trust source for validating certificate chains
+ */
+internal class SdJwtVcCredentialTrustVerifier(
+    private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+) : CredentialTrustVerifier {
+
+    override suspend fun verify(
+        credentialValue: String,
+        attestationIdentifier: AttestationIdentifier,
+    ): CertificationChainValidation<TrustAnchor>? {
+        var result: CertificationChainValidation<TrustAnchor>? = null
+
+        // Create trust callback that captures the evaluation result
+        val trust = X509CertificateTrust<List<X509Certificate>> { chain, _ ->
+            result = isChainTrusted.issuance(chain, attestationIdentifier)
+            result is CertificationChainValidation.Trusted
+        }
+
+        // Create verifier with UsingX5c method
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod.UsingX5c(trust),
+            TypeMetadataPolicy.NotUsed,
+        )
+
+        verifier.verify(credentialValue).getOrNull()
+        return result
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
@@ -55,6 +55,7 @@ internal class SdJwtVcCredentialTrustVerifier(
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             IssuerVerificationMethod.UsingX5c(trust),
             TypeMetadataPolicy.NotUsed,
+            checkStatus = null
         )
 
         verifier.verify(credentialValue).getOrNull()

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfig.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * Configuration for status list token trust verification.
+ *
+ * Holds the trust source, optional attestation classifications, and the trust policy
+ * for verifying the signer of status list tokens (JWT or CWT) used in document
+ * revocation checks.
+ *
+ * @param isChainTrustedForAttestation the ETSI trust source for validating certificate chains
+ * @param classifications optional attestation classifications for mapping credentials to verification contexts
+ * @param trustPolicy the policy determining how to handle trust verification results
+ */
+data class StatusListTrustConfig(
+    val isChainTrustedForAttestation: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+    val classifications: AttestationClassifications?,
+    val trustPolicy: TrustPolicy,
+)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfigBuilder.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.ComposeChainTrust
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * DSL builder for constructing a [StatusListTrustConfig].
+ *
+ * A trust source must be provided via one of the [trustSource] overloads.
+ * When using [IsChainTrustedForEUDIW] or [ComposeChainTrust] as the trust source,
+ * [classifications] must also be provided so the builder can construct an
+ * [IsChainTrustedForAttestation] instance.
+ *
+ * Example:
+ * ```
+ * val config = StatusListTrustConfigBuilder().apply {
+ *     trustSource(myComposeChainTrust)
+ *     classifications(myClassifications)
+ *     policy {
+ *         default(TrustPolicy.Action.ENFORCE)
+ *         forContext(VerificationContext.PID, TrustPolicy.Action.INFORM)
+ *     }
+ * }.build()
+ * ```
+ */
+class StatusListTrustConfigBuilder {
+
+    private var preBuiltAttestation: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>? = null
+    private var eudiwSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>? = null
+    private var classifications: AttestationClassifications? = null
+    private var policyBuilder: (TrustPolicy.Builder.() -> Unit)? = null
+
+    /**
+     * Sets the trust source from a pre-built [IsChainTrustedForAttestation].
+     *
+     * When using this overload, [classifications] is not required (the attestation
+     * already encapsulates the classification logic).
+     *
+     * @param source the pre-built attestation trust source
+     */
+    fun trustSource(source: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>) {
+        this.preBuiltAttestation = source
+        this.eudiwSource = null
+    }
+
+    /**
+     * Sets the trust source from a [ComposeChainTrust] instance.
+     *
+     * When using this overload, [classifications] must be provided before calling [build].
+     *
+     * @param source the composed chain trust source
+     */
+    fun trustSource(source: ComposeChainTrust<List<X509Certificate>, VerificationContext, TrustAnchor>) {
+        this.eudiwSource = source
+        this.preBuiltAttestation = null
+    }
+
+    /**
+     * Sets the trust source from an [IsChainTrustedForEUDIW] instance.
+     *
+     * When using this overload, [classifications] must be provided before calling [build].
+     *
+     * @param source the EUDIW trust source
+     */
+    fun trustSource(source: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>) {
+        this.eudiwSource = source
+        this.preBuiltAttestation = null
+    }
+
+    /**
+     * Sets the attestation classifications used to map credential types to verification contexts.
+     *
+     * Required when the trust source is an [IsChainTrustedForEUDIW] or [ComposeChainTrust].
+     *
+     * @param classifications the attestation classifications
+     */
+    fun classifications(classifications: AttestationClassifications) {
+        this.classifications = classifications
+    }
+
+    /**
+     * Configures the trust policy using the [TrustPolicy.Builder] DSL.
+     *
+     * If not called, the default policy is [TrustPolicy.Action.ENFORCE] for all credentials.
+     *
+     * @param block configuration block applied to the [TrustPolicy.Builder]
+     */
+    fun policy(block: TrustPolicy.Builder.() -> Unit) {
+        this.policyBuilder = block
+    }
+
+    /**
+     * Builds the [StatusListTrustConfig] from the current builder state.
+     *
+     * @return a validated [StatusListTrustConfig]
+     * @throws IllegalArgumentException if no trust source is configured, or if classifications
+     *   are missing when required by the trust source type
+     */
+    internal fun build(): StatusListTrustConfig {
+        val attestation = preBuiltAttestation ?: run {
+            val eudiw = requireNotNull(eudiwSource) {
+                "A trust source must be provided via trustSource()"
+            }
+            val cls = requireNotNull(classifications) {
+                "AttestationClassifications must be provided when using IsChainTrustedForEUDIW as trust source"
+            }
+            IsChainTrustedForAttestation(eudiw, cls)
+        }
+
+        val trustPolicy = policyBuilder?.let { TrustPolicy.build(it) }
+            ?: TrustPolicy.uniform(TrustPolicy.Action.ENFORCE)
+
+        return StatusListTrustConfig(
+            isChainTrustedForAttestation = attestation,
+            classifications = classifications,
+            trustPolicy = trustPolicy,
+        )
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/TrustPolicy.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/TrustPolicy.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+
+/**
+ * Defines the policy for how the wallet should handle issuer trust verification results.
+ *
+ * A [TrustPolicy] determines the [Action] to take based on the type of credential
+ * ([AttestationIdentifier]) being issued and the optional [VerificationContext].
+ *
+ * Use [uniform] for a single action regardless of input, or [build] for a fine-grained
+ * policy with per-attestation and per-context overrides.
+ */
+fun interface TrustPolicy {
+
+    /**
+     * Resolves the trust action for a given attestation identifier and verification context.
+     *
+     * @param attestationIdentifier the type of credential being issued (e.g., MDoc or SDJwtVc)
+     * @param verificationContext the optional verification context (e.g., PID, QEAA), or null if unknown
+     * @return the [Action] indicating how the wallet should handle the trust verification result
+     */
+    fun resolve(
+        attestationIdentifier: AttestationIdentifier,
+        verificationContext: VerificationContext?,
+    ): Action
+
+    /**
+     * Describes how the wallet should react to trust verification outcomes.
+     */
+    enum class Action {
+        /**
+         * Strict enforcement: if the issuer is not trusted, reject and delete the document
+         * and emit a `DocumentFailed` event.
+         */
+        ENFORCE,
+
+        /**
+         * Informational only: always store the document regardless of trust result,
+         * and attach the trust verification result to the `DocumentIssued` event.
+         */
+        INFORM
+    }
+
+    companion object {
+        /**
+         * Creates a policy that returns the same [action] for every input.
+         *
+         * @param action the action to return unconditionally
+         * @return a [TrustPolicy] that always returns [action]
+         */
+        fun uniform(action: Action): TrustPolicy = TrustPolicy { _, _ -> action }
+
+        /**
+         * Creates a policy using the [Builder] DSL.
+         *
+         * Example:
+         * ```
+         * val policy = TrustPolicy.build {
+         *     default(Action.ENFORCE)
+         *     forContext(VerificationContext.PID, Action.INFORM)
+         *     forDocType("org.iso.18013.5.1.mDL", Action.INFORM)
+         * }
+         * ```
+         *
+         * @param block configuration block applied to the [Builder]
+         * @return a [TrustPolicy] configured according to the builder
+         */
+        fun build(block: Builder.() -> Unit): TrustPolicy = Builder().apply(block).build()
+    }
+
+    /**
+     * DSL builder for constructing a [TrustPolicy] with layered override rules.
+     *
+     * Resolution order (highest priority first):
+     * 1. Per-attestation overrides (added via [forAttestation], [forDocType], or [forVct])
+     * 2. Per-context overrides (added via [forContext])
+     * 3. Default action (set via [default], defaults to [Action.ENFORCE])
+     */
+    class Builder {
+        private var default: Action = Action.ENFORCE
+        private val byContext = mutableMapOf<VerificationContext, Action>()
+        private val byAttestation = mutableMapOf<AttestationIdentifier, Action>()
+
+        /**
+         * Sets the default action when no specific override matches.
+         *
+         * @param action the fallback action (defaults to [Action.ENFORCE] if not called)
+         * @return this builder for chaining
+         */
+        fun default(action: Action) = apply { this.default = action }
+
+        /**
+         * Adds an override for a specific [VerificationContext].
+         *
+         * @param context the verification context to match
+         * @param action the action to return when the context matches
+         * @return this builder for chaining
+         */
+        fun forContext(context: VerificationContext, action: Action) = apply { byContext[context] = action }
+
+        /**
+         * Adds an override for a specific [AttestationIdentifier].
+         *
+         * This takes the highest priority in resolution order.
+         *
+         * @param identifier the attestation identifier to match
+         * @param action the action to return when the identifier matches
+         * @return this builder for chaining
+         */
+        fun forAttestation(identifier: AttestationIdentifier, action: Action) = apply { byAttestation[identifier] = action }
+
+        /**
+         * Convenience method to add an override for an MDoc document type.
+         *
+         * Equivalent to `forAttestation(AttestationIdentifier.MDoc(docType), action)`.
+         *
+         * @param docType the MDoc document type string
+         * @param action the action to return when the document type matches
+         * @return this builder for chaining
+         */
+        fun forDocType(docType: String, action: Action) = apply { byAttestation[AttestationIdentifier.MDoc(docType)] = action }
+
+        /**
+         * Convenience method to add an override for an SD-JWT VC type.
+         *
+         * Equivalent to `forAttestation(AttestationIdentifier.SDJwtVc(vct), action)`.
+         *
+         * @param vct the SD-JWT Verifiable Credential Type
+         * @param action the action to return when the VCT matches
+         * @return this builder for chaining
+         */
+        fun forVct(vct: String, action: Action) = apply { byAttestation[AttestationIdentifier.SDJwtVc(vct)] = action }
+
+        /**
+         * Builds the [TrustPolicy] with the configured overrides.
+         *
+         * @return a [TrustPolicy] that resolves actions using the layered override rules
+         */
+        fun build(): TrustPolicy = TrustPolicy { attestationId, verificationContext ->
+            byAttestation[attestationId]
+                ?: verificationContext?.let { byContext[it] }
+                ?: default
+        }
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderTest.kt
@@ -66,7 +66,7 @@ class EudiWalletBuilderTest {
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns mockk(relaxed = true)
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -77,7 +77,7 @@ class EudiWalletBuilderTest {
         assertIs<EudiWalletImpl>(wallet)
         verify(exactly = 1) { builder.getDefaultDocumentManager(null, null) }
         verify(exactly = 1) { builder.getTransferManager(any(), null) }
-        verify(exactly = 1) { builder.getDocumentStatusResolver() }
+        verify(exactly = 1) { builder.getDocumentStatusResolver(any()) }
     }
 
     @Test
@@ -105,7 +105,7 @@ class EudiWalletBuilderTest {
                 mockk(relaxed = true)
             }
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -140,7 +140,7 @@ class EudiWalletBuilderTest {
                 mockk(relaxed = true)
             }
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -169,7 +169,7 @@ class EudiWalletBuilderTest {
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -210,7 +210,7 @@ class EudiWalletBuilderTest {
                 assertEquals(customReaderTrustStore, readerTrustStore)
                 transferManager
             }
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -249,7 +249,7 @@ class EudiWalletBuilderTest {
                     any()
                 )
             } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -281,7 +281,7 @@ class EudiWalletBuilderTest {
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns mockk(relaxed = true)
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 
@@ -312,7 +312,7 @@ class EudiWalletBuilderTest {
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns mockk(relaxed = true)
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } answers {
+            every { getDocumentStatusResolver(any()) } answers {
                 // Custom HTTP client factory should be used by DocumentStatusResolver
                 mockk(relaxed = true)
             }
@@ -356,7 +356,7 @@ class EudiWalletBuilderTest {
                     any()
                 )
             } returns defaultPresentationManager
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
             // Mock the wrapWithTrasactionLogger function to verify it's called
             every {
@@ -405,7 +405,7 @@ class EudiWalletBuilderTest {
         // Verify
         assertIs<EudiWalletImpl>(wallet)
         assertEquals(customDocumentStatusResolver, wallet.documentStatusResolver)
-        verify(exactly = 1) { builder.getDocumentStatusResolver() }
+        verify(exactly = 1) { builder.getDocumentStatusResolver(any()) }
     }
 
     @Test
@@ -435,7 +435,7 @@ class EudiWalletBuilderTest {
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns mockk(relaxed = true)
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
-            every { getDocumentStatusResolver() } returns mockk(relaxed = true)
+            every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
             every { this@spyk.capabilities } returns capabilities
         }
 

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletConfigTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletConfigTest.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.eudi.wallet
 
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.ClientIdScheme
@@ -132,5 +133,16 @@ class EudiWalletConfigTest {
 
         assertEquals(Logger.OFF, config.logLevel)
         assertEquals(10, config.logSizeLimit)
+    }
+
+    @Test
+    fun testConfigureReaderTrustStoreWithCustomImplementation() {
+        val customTrustStore = mockk<ReaderTrustStore>()
+        val config = EudiWalletConfig {
+            configureReaderTrustStore(customTrustStore)
+        }
+
+        assertEquals(customTrustStore, config.readerTrustStore)
+        assertNull(config.readerTrustedCertificates)
     }
 }

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverBuilderTest.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.eudi.wallet.statium
 
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
 import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
 import io.ktor.client.HttpClient
 import io.mockk.mockk
@@ -31,6 +32,7 @@ import kotlin.time.Duration.Companion.minutes
 class DocumentStatusResolverBuilderTest {
 
     private lateinit var mockVerifySignature: VerifyStatusListTokenJwtSignature
+    private lateinit var mockVerifyCwtSignature: VerifyStatusListTokenCwtSignature
     private lateinit var mockHttpClient: HttpClient
     private lateinit var mockHttpClientFactory: () -> HttpClient
     private lateinit var mockExtractor: StatusReferenceExtractor
@@ -38,6 +40,7 @@ class DocumentStatusResolverBuilderTest {
     @Before
     fun setup() {
         mockVerifySignature = mockk()
+        mockVerifyCwtSignature = mockk()
         mockHttpClient = mockk()
         mockHttpClientFactory = { mockHttpClient }
         mockExtractor = mockk()
@@ -48,7 +51,8 @@ class DocumentStatusResolverBuilderTest {
         val builder = DocumentStatusResolver.Builder()
 
         // Assert default values
-        assertEquals(VerifyStatusListTokenJwtSignature.x5c::class, builder.verifySignature::class)
+        assertEquals(VerifyStatusListTokenJwtSignature.x5c::class, builder.verifyJwtSignature::class)
+        assertEquals(VerifyStatusListTokenCwtSignature.x5c::class, builder.verifyCwtSignature::class)
         assertEquals(Duration.ZERO, builder.allowedClockSkew)
         assertEquals(DefaultStatusReferenceExtractor, builder.extractor)
     }
@@ -58,13 +62,15 @@ class DocumentStatusResolverBuilderTest {
         val builder = DocumentStatusResolver.Builder()
 
         // Apply custom values using individual setters
-        builder.verifySignature = mockVerifySignature
+        builder.verifyJwtSignature = mockVerifySignature
+        builder.verifyCwtSignature = mockVerifyCwtSignature
         builder.ktorHttpClientFactory = mockHttpClientFactory
         builder.allowedClockSkew = 5.minutes
         builder.extractor = mockExtractor
 
         // Assert custom values
-        assertSame(mockVerifySignature, builder.verifySignature)
+        assertSame(mockVerifySignature, builder.verifyJwtSignature)
+        assertSame(mockVerifyCwtSignature, builder.verifyCwtSignature)
         assertSame(mockHttpClientFactory, builder.ktorHttpClientFactory)
         assertEquals(5.minutes, builder.allowedClockSkew)
         assertSame(mockExtractor, builder.extractor)
@@ -73,13 +79,15 @@ class DocumentStatusResolverBuilderTest {
     @Test
     fun `builder should apply custom values using fluent API`() {
         val builder = DocumentStatusResolver.Builder()
-            .withVerifySignature(mockVerifySignature)
+            .withVerifyJwtSignature(mockVerifySignature)
+            .withVerifyCwtSignature(mockVerifyCwtSignature)
             .withKtorHttpClientFactory(mockHttpClientFactory)
             .withAllowedClockSkew(10.minutes)
             .withExtractor(mockExtractor)
 
         // Assert custom values
-        assertSame(mockVerifySignature, builder.verifySignature)
+        assertSame(mockVerifySignature, builder.verifyJwtSignature)
+        assertSame(mockVerifyCwtSignature, builder.verifyCwtSignature)
         assertSame(mockHttpClientFactory, builder.ktorHttpClientFactory)
         assertEquals(10.minutes, builder.allowedClockSkew)
         assertSame(mockExtractor, builder.extractor)
@@ -88,7 +96,8 @@ class DocumentStatusResolverBuilderTest {
     @Test
     fun `build should create DocumentStatusResolverImpl with correct parameters`() {
         val resolver = DocumentStatusResolver.Builder()
-            .withVerifySignature(mockVerifySignature)
+            .withVerifyJwtSignature(mockVerifySignature)
+            .withVerifyCwtSignature(mockVerifyCwtSignature)
             .withKtorHttpClientFactory(mockHttpClientFactory)
             .withAllowedClockSkew(15.minutes)
             .withExtractor(mockExtractor)
@@ -98,7 +107,8 @@ class DocumentStatusResolverBuilderTest {
         assertIs<DocumentStatusResolverImpl>(resolver)
 
         // Verify that the fields were set correctly
-        assertSame(mockVerifySignature, resolver.verifySignature)
+        assertSame(mockVerifySignature, resolver.verifyJwtSignature)
+        assertSame(mockVerifyCwtSignature, resolver.verifyCwtSignature)
         assertSame(mockHttpClientFactory, resolver.ktorHttpClientFactory)
         assertEquals(15.minutes, resolver.allowedClockSkew)
         assertSame(mockExtractor, resolver.extractor)
@@ -107,7 +117,8 @@ class DocumentStatusResolverBuilderTest {
     @Test
     fun `invoke with lambda should create properly configured resolver`() = runTest {
         val resolver = DocumentStatusResolver {
-            verifySignature = mockVerifySignature
+            verifyJwtSignature = mockVerifySignature
+            verifyCwtSignature = mockVerifyCwtSignature
             ktorHttpClientFactory = mockHttpClientFactory
             allowedClockSkew = 5.minutes
             extractor = mockExtractor
@@ -117,7 +128,8 @@ class DocumentStatusResolverBuilderTest {
         assertIs<DocumentStatusResolverImpl>(resolver)
 
         // Verify that the fields were set correctly
-        assertSame(mockVerifySignature, resolver.verifySignature)
+        assertSame(mockVerifySignature, resolver.verifyJwtSignature)
+        assertSame(mockVerifyCwtSignature, resolver.verifyCwtSignature)
         assertSame(mockHttpClientFactory, resolver.ktorHttpClientFactory)
         assertEquals(5.minutes, resolver.allowedClockSkew)
         assertSame(mockExtractor, resolver.extractor)
@@ -143,7 +155,7 @@ class DocumentStatusResolverBuilderTest {
         assertIs<DocumentStatusResolverImpl>(resolver)
 
         // Verify that the fields were set correctly
-        assertSame(mockVerifySignature, resolver.verifySignature)
+        assertSame(mockVerifySignature, resolver.verifyJwtSignature)
         assertSame(mockHttpClientFactory, resolver.ktorHttpClientFactory)
         assertEquals(3.minutes, resolver.allowedClockSkew)
         assertSame(DefaultStatusReferenceExtractor, resolver.extractor)

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverTest.kt
@@ -21,8 +21,10 @@ import eu.europa.ec.eudi.statium.GetStatusListToken
 import eu.europa.ec.eudi.statium.Status
 import eu.europa.ec.eudi.statium.StatusIndex
 import eu.europa.ec.eudi.statium.StatusReference
+import eu.europa.ec.eudi.statium.VerifyStatusListTokenCwtSignature
 import eu.europa.ec.eudi.statium.VerifyStatusListTokenJwtSignature
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
 import io.ktor.client.HttpClient
 import io.mockk.coEvery
 import io.mockk.every
@@ -49,7 +51,10 @@ class DocumentStatusResolverTest {
         uri = "https://example.com/status",
         index = StatusIndex(22)
     )
-    private val verifySignature = VerifyStatusListTokenJwtSignature { _, _ ->
+    private val verifyJwtSignature = VerifyStatusListTokenJwtSignature { _, _ ->
+        Result.success(Unit)
+    }
+    private val verifyCwtSignature = VerifyStatusListTokenCwtSignature { _, _ ->
         Result.success(Unit)
     }
     private lateinit var mockHttpClientFactory: () -> HttpClient
@@ -58,6 +63,7 @@ class DocumentStatusResolverTest {
     fun setUp() {
         mockStatusReferenceExtractor = mockk<StatusReferenceExtractor>()
         mockDocument = mockk<IssuedDocument>()
+        every { mockDocument.format } returns SdJwtVcFormat("urn:eu.europa.ec.eudi:pid:1")
         mockGetStatusListToken = mockk()
         mockGetStatus = mockk()
         mockHttpClientFactory = mockk()
@@ -84,10 +90,11 @@ class DocumentStatusResolverTest {
 
         // Create resolver with mock extractor
         val resolver = DocumentStatusResolverImpl(
-            verifySignature,
-            0.minutes,
-            mockHttpClientFactory,
-            mockStatusReferenceExtractor,
+            verifyJwtSignature = verifyJwtSignature,
+            verifyCwtSignature = verifyCwtSignature,
+            allowedClockSkew = 0.minutes,
+            ktorHttpClientFactory = mockHttpClientFactory,
+            extractor = mockStatusReferenceExtractor,
         )
 
         // When
@@ -136,7 +143,7 @@ class DocumentStatusResolverTest {
             GetStatusListToken.Companion.usingJwt(
                 any(),  // clock
                 mockHttpClientFactory(),
-                verifySignature,
+                verifyJwtSignature,
                 any()   // allowedClockSkew
             )
         } returns mockGetStatusListToken
@@ -153,10 +160,11 @@ class DocumentStatusResolverTest {
 
         // Create resolver with mock extractor
         val resolver = DocumentStatusResolverImpl(
-            verifySignature,
-            0.minutes,
-            mockHttpClientFactory,
-            mockStatusReferenceExtractor
+            verifyJwtSignature = verifyJwtSignature,
+            verifyCwtSignature = verifyCwtSignature,
+            allowedClockSkew = 0.minutes,
+            ktorHttpClientFactory = mockHttpClientFactory,
+            extractor = mockStatusReferenceExtractor,
         )
 
         // When
@@ -167,7 +175,7 @@ class DocumentStatusResolverTest {
             GetStatusListToken.Companion.usingJwt(
                 any(),  // clock
                 mockHttpClientFactory(),
-                verifySignature,
+                verifyJwtSignature,
                 0.minutes
             )
         }
@@ -187,7 +195,7 @@ class DocumentStatusResolverTest {
             GetStatusListToken.Companion.usingJwt(
                 any(),  // clock
                 mockHttpClientFactory(),
-                verifySignature,
+                verifyJwtSignature,
                 any()   // allowedClockSkew
             )
         } returns mockGetStatusListToken
@@ -204,10 +212,11 @@ class DocumentStatusResolverTest {
 
         // Create resolver with custom clock skew
         val resolver = DocumentStatusResolverImpl(
-            verifySignature,
-            customClockSkew,
-            mockHttpClientFactory,
-            mockStatusReferenceExtractor
+            verifyJwtSignature = verifyJwtSignature,
+            verifyCwtSignature = verifyCwtSignature,
+            allowedClockSkew = customClockSkew,
+            ktorHttpClientFactory = mockHttpClientFactory,
+            extractor = mockStatusReferenceExtractor,
         )
 
         // When
@@ -218,7 +227,7 @@ class DocumentStatusResolverTest {
             GetStatusListToken.Companion.usingJwt(
                 any(),  // clock
                 mockHttpClientFactory(),
-                verifySignature,
+                verifyJwtSignature,
                 customClockSkew
             )
         }

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverTest.kt
@@ -240,7 +240,6 @@ class DocumentStatusResolverTest {
         
         // When
         val resolver = DocumentStatusResolver(
-            verifySignature = verifySignature,
             ktorHttpClientFactory = mockHttpClientFactory,
             allowedClockSkew = customClockSkew
         )

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EtsiCertificateChainTrustTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+class EtsiCertificateChainTrustTest {
+
+    private val isChainTrusted =
+        mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+    private val adapter = EtsiCertificateChainTrust(isChainTrusted)
+    private val chain = listOf(ecLeafSignedByIntermediateCertificate)
+    private val trustAnchor = TrustAnchor(rsaTrustedRootCertificate, null)
+
+    @Test
+    fun returnsTrueWhenChainIsTrusted() = runTest {
+        coEvery {
+            isChainTrusted.invoke(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+        } returns CertificationChainValidation.Trusted(trustAnchor)
+
+        assertTrue(adapter.isTrusted(chain))
+
+        coVerify {
+            isChainTrusted.invoke(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+        }
+    }
+
+    @Test
+    fun returnsFalseWhenChainIsNotTrusted() = runTest {
+        coEvery {
+            isChainTrusted.invoke(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+        } returns CertificationChainValidation.NotTrusted(Exception("not trusted"))
+
+        assertFalse(adapter.isTrusted(chain))
+    }
+
+    @Test
+    fun returnsFalseWhenContextReturnsNull() = runTest {
+        coEvery {
+            isChainTrusted.invoke(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+        } returns null
+
+        assertFalse(adapter.isTrusted(chain))
+    }
+
+    @Test
+    fun returnsFalseOnException() = runTest {
+        coEvery {
+            isChainTrusted.invoke(chain, VerificationContext.WalletRelyingPartyAccessCertificate)
+        } throws RuntimeException("network error")
+
+        assertFalse(adapter.isTrusted(chain))
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStoreTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EtsiReaderTrustStoreTest {
+
+    private val isChainTrusted =
+        mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val chain = listOf(ecLeafSignedByIntermediateCertificate)
+    private val trustAnchor = TrustAnchor(rsaTrustedRootCertificate, null)
+
+    @Test
+    fun validateCertificationTrustPathReturnsTrueWhenTrusted() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.Trusted(trustAnchor)
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(chain)
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateCertificationTrustPathReturnsFalseWhenNotTrusted() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.NotTrusted(RuntimeException("not trusted"))
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(chain)
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateCertificationTrustPathReturnsFalseWhenContextNotConfigured() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns null
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(chain)
+        assertFalse(result)
+    }
+
+    @Test
+    fun createCertificationTrustPathReturnsChainPlusTrustAnchorWhenTrusted() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.Trusted(trustAnchor)
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.createCertificationTrustPath(chain)
+        assertEquals(chain + trustAnchor.trustedCert, result)
+    }
+
+    @Test
+    fun createCertificationTrustPathReturnsNullWhenNotTrusted() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.NotTrusted(RuntimeException("not trusted"))
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.createCertificationTrustPath(chain)
+        assertNull(result)
+    }
+
+    @Test
+    fun createCertificationTrustPathReturnsNullWhenContextNotConfigured() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns null
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.createCertificationTrustPath(chain)
+        assertNull(result)
+    }
+
+    @Test
+    fun usesProvidedVerificationContext() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.Trusted(trustAnchor)
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.PID,
+            coroutineContext = testDispatcher,
+        )
+
+        store.validateCertificationTrustPath(chain)
+
+        coVerify { isChainTrusted.invoke(chain, VerificationContext.PID) }
+    }
+
+    @Test
+    fun usesProvidedCoroutineContext() {
+        val dispatcher = UnconfinedTestDispatcher()
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.Trusted(trustAnchor)
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = dispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(chain)
+        assertTrue(result)
+    }
+
+    @Test
+    fun asReaderTrustStoreExtensionCreatesInstance() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns
+                CertificationChainValidation.Trusted(trustAnchor)
+
+        val store = isChainTrusted.asReaderTrustStore()
+
+        assertIs<ReaderTrustStore>(store)
+        val result = store.validateCertificationTrustPath(chain)
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateReturnsFalseWhenIsChainTrustedThrows() {
+        coEvery { isChainTrusted.invoke(any(), any()) } throws RuntimeException("unexpected error")
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(chain)
+        assertFalse(result)
+    }
+
+    @Test
+    fun createReturnsNullWhenIsChainTrustedThrows() {
+        coEvery { isChainTrusted.invoke(any(), any()) } throws RuntimeException("unexpected error")
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.createCertificationTrustPath(chain)
+        assertNull(result)
+    }
+
+    @Test
+    fun validateReturnsFalseForEmptyChain() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns null
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.validateCertificationTrustPath(emptyList())
+        assertFalse(result)
+    }
+
+    @Test
+    fun createReturnsNullForEmptyChain() {
+        coEvery { isChainTrusted.invoke(any(), any()) } returns null
+
+        val store = EtsiReaderTrustStore(
+            isChainTrusted = isChainTrusted,
+            verificationContext = VerificationContext.WalletRelyingPartyAccessCertificate,
+            coroutineContext = testDispatcher,
+        )
+
+        val result = store.createCertificationTrustPath(emptyList())
+        assertNull(result)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrustTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.etsi1196x2.consultation.predicate
+import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.wallet.document.Document
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.logging.Logger
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.cert.TrustAnchor
+
+@RunWith(RobolectricTestRunner::class)
+class EvaluateIssuerTrustTest {
+
+    private val document = mockk<Document>()
+    private val credential = Credential.Str("test-credential-value")
+    private val logger = mockk<Logger>(relaxed = true)
+    private val verifier = mockk<CredentialTrustVerifier>()
+    private val trustAnchor = mockk<TrustAnchor>()
+
+    @Test
+    fun returnsNullWhenConfigIsNull() = runTest {
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = null,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertNull(result)
+        verify(exactly = 0) { document.format }
+    }
+
+    @Test
+    fun returnsNullWhenNoVerifierForFormat() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
+            credentialTrustVerifiers = emptyMap(),
+        )
+
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullWhenVerifierReturnsNull() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+        coEvery { verifier.verify(any(), any()) } returns null
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
+            credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+        )
+
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertNull(result)
+        coVerify { verifier.verify("test-credential-value", AttestationIdentifier.MDoc("test.doc")) }
+    }
+
+    @Test
+    fun returnsTrustedResultFromVerifier() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { verifier.verify(any(), any()) } returns trusted
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
+            credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+        )
+
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertEquals(trusted, result)
+    }
+
+    @Test
+    fun returnsNotTrustedWithInformPolicy() = runTest {
+        every { document.format } returns SdJwtVcFormat("test.vct")
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.INFORM),
+            credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+        )
+
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertEquals(notTrusted, result)
+    }
+
+    @Test(expected = IssuerNotTrustedException::class)
+    fun throwsIssuerNotTrustedWithEnforcePolicy() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
+            credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+        )
+
+        evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+    }
+
+    @Test
+    fun enforcePolicyUsesPerAttestationOverride() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val policy = TrustPolicy.build {
+            default(TrustPolicy.Action.ENFORCE)
+            forDocType("test.doc", TrustPolicy.Action.INFORM)
+        }
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = policy,
+            credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+        )
+
+        // Should NOT throw because per-attestation override is INFORM
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertEquals(notTrusted, result)
+    }
+
+    @Test
+    fun enforcePolicyUsesPerContextOverride() = runTest {
+        every { document.format } returns MsoMdocFormat("test.doc")
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifier.MDoc("test.doc").predicate,
+        )
+
+        val policy = TrustPolicy.build {
+            default(TrustPolicy.Action.ENFORCE)
+            forContext(VerificationContext.PID, TrustPolicy.Action.INFORM)
+        }
+
+        val config = IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = classifications,
+            trustPolicy = policy,
+            credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+        )
+
+        // Should NOT throw because per-context override for PID is INFORM
+        val result = evaluateIssuerTrust(
+            issuerTrustConfig = config,
+            document = document,
+            credential = credential,
+            logger = logger,
+        )
+
+        assertEquals(notTrusted, result)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/EvaluateIssuerTrustTest.kt
@@ -21,6 +21,7 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.etsi1196x2.consultation.predicate
 import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.wallet.document.Document
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
@@ -69,6 +70,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
             credentialTrustVerifiers = emptyMap(),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         val result = evaluateIssuerTrust(
@@ -91,6 +93,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
             credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         val result = evaluateIssuerTrust(
@@ -115,6 +118,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
             credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         val result = evaluateIssuerTrust(
@@ -139,6 +143,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.INFORM),
             credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         val result = evaluateIssuerTrust(
@@ -163,6 +168,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(TrustPolicy.Action.ENFORCE),
             credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         evaluateIssuerTrust(
@@ -190,6 +196,7 @@ class EvaluateIssuerTrustTest {
             classifications = null,
             trustPolicy = policy,
             credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         // Should NOT throw because per-attestation override is INFORM
@@ -224,6 +231,7 @@ class EvaluateIssuerTrustTest {
             classifications = classifications,
             trustPolicy = policy,
             credentialTrustVerifiers = mapOf(MsoMdocFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
 
         // Should NOT throw because per-context override for PID is INFORM

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+@RunWith(RobolectricTestRunner::class)
+class IssuerTrustConfigBuilderTest {
+
+    @Test
+    fun buildsConfigFromPreBuiltAttestation() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+        }.build()
+
+        assertEquals(mockAttestation, config.isChainTrustedForAttestation)
+        assertNull(config.classifications)
+    }
+
+    @Test
+    fun buildsConfigWithClassifications() {
+        val mockEudiw = mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.equalsTo(AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")),
+        )
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockEudiw)
+            classifications(classifications)
+        }.build()
+
+        assertNotNull(config.isChainTrustedForAttestation)
+        assertEquals(classifications, config.classifications)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun throwsWhenTrustSourceMissing() {
+        IssuerTrustConfigBuilder().build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun throwsWhenClassificationsMissingForEUDIW() {
+        val mockEudiw = mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+
+        IssuerTrustConfigBuilder().apply {
+            trustSource(mockEudiw)
+        }.build()
+    }
+
+    @Test
+    fun customVerifierIsIncluded() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+        val mockVerifier = mockk<CredentialTrustVerifier>()
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+            credentialTrustVerifier(MsoMdocFormat::class, mockVerifier)
+        }.build()
+
+        assertEquals(mockVerifier, config.credentialTrustVerifiers[MsoMdocFormat::class])
+        // Default verifiers for MsoMdoc (overridden) and SdJwtVc (default)
+        assertEquals(2, config.credentialTrustVerifiers.size)
+    }
+
+    @Test
+    fun defaultPolicyIsEnforce() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+        }.build()
+
+        val action = config.trustPolicy.resolve(
+            AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL"),
+            VerificationContext.PID,
+        )
+        assertEquals(TrustPolicy.Action.ENFORCE, action)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
@@ -22,6 +22,8 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
 import io.mockk.coEvery
@@ -109,5 +111,55 @@ class IssuerTrustConfigBuilderTest {
             VerificationContext.PID,
         )
         assertEquals(TrustPolicy.Action.ENFORCE, action)
+    }
+
+    @Test
+    fun defaultMetadataPolicyIsIgnoreSigned() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+        }.build()
+
+        assertEquals(IssuerMetadataPolicy.IgnoreSigned, config.issuerMetadataPolicy)
+    }
+
+    @Test
+    fun requireSignedMetadataWithEudiwSource() {
+        val mockEudiw = mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.equalsTo(AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")),
+        )
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockEudiw)
+            classifications(classifications)
+            requireSignedMetadata()
+        }.build()
+
+        assertTrue(config.issuerMetadataPolicy is IssuerMetadataPolicy.RequireSigned)
+    }
+
+    @Test
+    fun preferSignedMetadataWithCustomTrust() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+        val customTrust = mockk<CertificateChainTrust>()
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+            preferSignedMetadata(customTrust)
+        }.build()
+
+        assertTrue(config.issuerMetadataPolicy is IssuerMetadataPolicy.PreferSigned)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun requireSignedMetadataWithoutSourceOrCustomTrustThrows() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+
+        IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+            requireSignedMetadata()
+        }.build()
     }
 }

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilderTest.kt
@@ -22,7 +22,6 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
-import eu.europa.ec.eudi.openid4vci.CertificateChainTrust
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
@@ -47,6 +46,7 @@ class IssuerTrustConfigBuilderTest {
 
         val config = IssuerTrustConfigBuilder().apply {
             trustSource(mockAttestation)
+            ignoreSignedMetadata()
         }.build()
 
         assertEquals(mockAttestation, config.isChainTrustedForAttestation)
@@ -91,6 +91,7 @@ class IssuerTrustConfigBuilderTest {
         val config = IssuerTrustConfigBuilder().apply {
             trustSource(mockAttestation)
             credentialTrustVerifier(MsoMdocFormat::class, mockVerifier)
+            ignoreSignedMetadata()
         }.build()
 
         assertEquals(mockVerifier, config.credentialTrustVerifiers[MsoMdocFormat::class])
@@ -104,6 +105,7 @@ class IssuerTrustConfigBuilderTest {
 
         val config = IssuerTrustConfigBuilder().apply {
             trustSource(mockAttestation)
+            ignoreSignedMetadata()
         }.build()
 
         val action = config.trustPolicy.resolve(
@@ -114,11 +116,36 @@ class IssuerTrustConfigBuilderTest {
     }
 
     @Test
-    fun defaultMetadataPolicyIsIgnoreSigned() {
+    fun defaultMetadataPolicyIsRequireSigned() {
+        val mockEudiw = mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.equalsTo(AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")),
+        )
+
+        val config = IssuerTrustConfigBuilder().apply {
+            trustSource(mockEudiw)
+            classifications(classifications)
+        }.build()
+
+        assertTrue(config.issuerMetadataPolicy is IssuerMetadataPolicy.RequireSigned)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun defaultMetadataWithPreBuiltAttestationThrows() {
+        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+
+        IssuerTrustConfigBuilder().apply {
+            trustSource(mockAttestation)
+        }.build()
+    }
+
+    @Test
+    fun preBuiltAttestationWithIgnoreSignedMetadataSucceeds() {
         val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
 
         val config = IssuerTrustConfigBuilder().apply {
             trustSource(mockAttestation)
+            ignoreSignedMetadata()
         }.build()
 
         assertEquals(IssuerMetadataPolicy.IgnoreSigned, config.issuerMetadataPolicy)
@@ -141,20 +168,23 @@ class IssuerTrustConfigBuilderTest {
     }
 
     @Test
-    fun preferSignedMetadataWithCustomTrust() {
-        val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
-        val customTrust = mockk<CertificateChainTrust>()
+    fun ignoreSignedMetadataOverridesDefault() {
+        val mockEudiw = mockk<IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>>()
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.equalsTo(AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")),
+        )
 
         val config = IssuerTrustConfigBuilder().apply {
-            trustSource(mockAttestation)
-            preferSignedMetadata(customTrust)
+            trustSource(mockEudiw)
+            classifications(classifications)
+            ignoreSignedMetadata()
         }.build()
 
-        assertTrue(config.issuerMetadataPolicy is IssuerMetadataPolicy.PreferSigned)
+        assertEquals(IssuerMetadataPolicy.IgnoreSigned, config.issuerMetadataPolicy)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun requireSignedMetadataWithoutSourceOrCustomTrustThrows() {
+    fun requireSignedMetadataWithoutEudiwSourceThrows() {
         val mockAttestation = mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
 
         IssuerTrustConfigBuilder().apply {

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifierTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifierTest.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.toDataItem
+import org.multipaz.cose.Cose
+import org.multipaz.cose.CoseSign1
+import org.multipaz.cose.toCoseLabel
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.X509Cert
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.crypto.javaPrivateKey
+import org.multipaz.crypto.javaPublicKey
+import org.multipaz.crypto.javaX509Certificates
+import org.robolectric.RobolectricTestRunner
+import java.math.BigInteger
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import java.util.Base64
+import java.util.Date
+import kotlin.test.assertIs
+
+@RunWith(RobolectricTestRunner::class)
+class MsoMdocCredentialTrustVerifierTest {
+
+    private val attestationIdentifier = AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+    private val isChainTrusted =
+        mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+    private val verifier = MsoMdocCredentialTrustVerifier(isChainTrusted)
+
+    @Test
+    fun returnsNullForMalformedBase64() = runTest {
+        val result = verifier.verify("not-valid-base64!!!", attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullForMalformedCbor() = runTest {
+        val badCbor = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(byteArrayOf(0xFF.toByte(), 0x01))
+        val result = verifier.verify(badCbor, attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullForEmptyCredentialValue() = runTest {
+        val result = verifier.verify("", attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullWhenX5chainMissing() = runTest {
+        val coseSign1 = CoseSign1(
+            protectedHeaders = mapOf(
+                Cose.COSE_LABEL_ALG.toCoseLabel to
+                    Algorithm.ES256.coseAlgorithmIdentifier!!.toDataItem()
+            ),
+            unprotectedHeaders = emptyMap(),
+            signature = ByteArray(64),
+            payload = ByteArray(10),
+        )
+
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsTrustedForValidCredential() = runTest {
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val dsCert = createSelfSignedCert(dsKey, "CN=Test DS")
+        val x5chain = X509CertChain(listOf(dsCert))
+        val javaCerts = x5chain.javaX509Certificates
+
+        val coseSign1 = signCoseSign1(dsKey, x5chain)
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+
+        val trustAnchor = mockk<TrustAnchor>()
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { isChainTrusted.issuance(javaCerts, attestationIdentifier) } returns trusted
+
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.Trusted<TrustAnchor>>(result)
+        assertEquals(trustAnchor, result.trustAnchor)
+    }
+
+    @Test
+    fun returnsNotTrustedForUntrustedChain() = runTest {
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val dsCert = createSelfSignedCert(dsKey, "CN=Untrusted DS")
+        val x5chain = X509CertChain(listOf(dsCert))
+        val javaCerts = x5chain.javaX509Certificates
+
+        val coseSign1 = signCoseSign1(dsKey, x5chain)
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { isChainTrusted.issuance(javaCerts, attestationIdentifier) } returns notTrusted
+
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.NotTrusted>(result)
+        assertEquals(cause, result.cause)
+    }
+
+    @Test
+    fun returnsNullWhenIssuanceReturnsNull() = runTest {
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val dsCert = createSelfSignedCert(dsKey, "CN=Test DS")
+        val x5chain = X509CertChain(listOf(dsCert))
+        val javaCerts = x5chain.javaX509Certificates
+
+        val coseSign1 = signCoseSign1(dsKey, x5chain)
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+
+        coEvery { isChainTrusted.issuance(javaCerts, attestationIdentifier) } returns null
+
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullWhenSignatureInvalid() = runTest {
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val dsCert = createSelfSignedCert(dsKey, "CN=Test DS")
+        val x5chain = X509CertChain(listOf(dsCert))
+        val javaCerts = x5chain.javaX509Certificates
+
+        // Build a COSE_Sign1 with a bogus signature
+        val coseSign1 = CoseSign1(
+            protectedHeaders = mapOf(
+                Cose.COSE_LABEL_ALG.toCoseLabel to
+                    Algorithm.ES256.coseAlgorithmIdentifier!!.toDataItem()
+            ),
+            unprotectedHeaders = mapOf(
+                Cose.COSE_LABEL_X5CHAIN.toCoseLabel to x5chain.toDataItem()
+            ),
+            signature = ByteArray(64),
+            payload = ByteArray(10),
+        )
+
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+
+        val trustAnchor = mockk<TrustAnchor>()
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { isChainTrusted.issuance(javaCerts, attestationIdentifier) } returns trusted
+
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun handlesMultipleCertificatesInX5chain() = runTest {
+        val iacaKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+
+        val iacaCert = createSelfSignedCert(iacaKey, "CN=Test IACA")
+        val dsCert = createCert(dsKey, iacaKey, "CN=Test DS", "CN=Test IACA")
+
+        val x5chain = X509CertChain(listOf(dsCert, iacaCert))
+        val javaCerts = x5chain.javaX509Certificates
+
+        val coseSign1 = signCoseSign1(dsKey, x5chain)
+        val credentialValue = encodeAsStaticAuthData(coseSign1)
+
+        val trustAnchor = mockk<TrustAnchor>()
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { isChainTrusted.issuance(javaCerts, attestationIdentifier) } returns trusted
+
+        val result = verifier.verify(credentialValue, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.Trusted<TrustAnchor>>(result)
+        assertTrue(javaCerts.size == 2)
+    }
+
+    // -- helpers --
+
+    @Suppress("DEPRECATION")
+    private suspend fun signCoseSign1(
+        signingKey: EcPrivateKey,
+        x5chain: X509CertChain,
+    ): CoseSign1 {
+        val payload = ByteArray(10) { it.toByte() }
+        return Cose.coseSign1Sign(
+            key = signingKey,
+            dataToSign = payload,
+            includeDataInPayload = true,
+            signatureAlgorithm = Algorithm.ES256,
+            protectedHeaders = mapOf(
+                Cose.COSE_LABEL_ALG.toCoseLabel to
+                    Algorithm.ES256.coseAlgorithmIdentifier!!.toDataItem()
+            ),
+            unprotectedHeaders = mapOf(
+                Cose.COSE_LABEL_X5CHAIN.toCoseLabel to x5chain.toDataItem()
+            ),
+        )
+    }
+
+    private fun encodeAsStaticAuthData(coseSign1: CoseSign1): String {
+        val staticAuthData = buildCborMap {
+            put("issuerAuth", coseSign1.toDataItem())
+        }
+        val encoded = Cbor.encode(staticAuthData)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(encoded)
+    }
+
+    private fun createSelfSignedCert(
+        key: EcPrivateKey,
+        cn: String,
+    ): X509Cert {
+        val javaPublicKey = key.publicKey.javaPublicKey
+        val javaPrivateKey = key.javaPrivateKey
+        val issuer = org.bouncycastle.asn1.x500.X500Name(cn)
+        val notBefore = Date(System.currentTimeMillis() - 86400000L)
+        val notAfter = Date(System.currentTimeMillis() + 30 * 86400000L)
+        val builder = JcaX509v3CertificateBuilder(
+            issuer, BigInteger.ONE, notBefore, notAfter, issuer, javaPublicKey,
+        )
+        val signer = JcaContentSignerBuilder("SHA256WithECDSA").build(javaPrivateKey)
+        val javaCert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
+        return X509Cert(ByteString(javaCert.encoded))
+    }
+
+    private fun createCert(
+        subjectKey: EcPrivateKey,
+        signingKey: EcPrivateKey,
+        subjectCn: String,
+        issuerCn: String,
+    ): X509Cert {
+        val javaPublicKey = subjectKey.publicKey.javaPublicKey
+        val javaSigningPrivateKey = signingKey.javaPrivateKey
+        val issuer = org.bouncycastle.asn1.x500.X500Name(issuerCn)
+        val subject = org.bouncycastle.asn1.x500.X500Name(subjectCn)
+        val notBefore = Date(System.currentTimeMillis() - 86400000L)
+        val notAfter = Date(System.currentTimeMillis() + 30 * 86400000L)
+        val builder = JcaX509v3CertificateBuilder(
+            issuer, BigInteger.TWO, notBefore, notAfter, subject, javaPublicKey,
+        )
+        val signer = JcaContentSignerBuilder("SHA256WithECDSA").build(javaSigningPrivateKey)
+        val javaCert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
+        return X509Cert(ByteString(javaCert.encoded))
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.openid4vci.DeferredCredentialQueryOutcome
+import eu.europa.ec.eudi.openid4vci.IssuedCredential
+import eu.europa.ec.eudi.wallet.document.DeferredDocument
+import eu.europa.ec.eudi.wallet.document.DocumentManager
+import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import eu.europa.ec.eudi.wallet.document.Outcome
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.issue.openid4vci.DeferredIssueResult
+import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
+import eu.europa.ec.eudi.wallet.issue.openid4vci.ProcessDeferredOutcome
+import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.cert.TrustAnchor
+
+@RunWith(RobolectricTestRunner::class)
+class ProcessDeferredOutcomeTrustTest {
+
+    private val documentManager = mockk<DocumentManager>(relaxed = true)
+    private val walletKeyManager = mockk<WalletKeyManager>()
+    private val issuedDocument = mockk<IssuedDocument> {
+        every { id } returns "doc-id"
+        every { name } returns "Test Document"
+        every { format } returns SdJwtVcFormat("test.vct")
+    }
+    private val deferredDocument = mockk<DeferredDocument> {
+        every { id } returns "deferred-doc-id"
+        every { name } returns "Test Document"
+        every { format } returns SdJwtVcFormat("test.vct")
+    }
+
+    private val credential = Credential.Str("test-credential-value")
+    private val keyAlias = "key-alias-1"
+    private val issuedCredential = IssuedCredential.string("test-credential-value")
+    private val trustAnchor = mockk<TrustAnchor>()
+    private val verifier = mockk<CredentialTrustVerifier>()
+
+    private fun createOutcome(): DeferredCredentialQueryOutcome.Issued {
+        return mockk<DeferredCredentialQueryOutcome.Issued> {
+            every { credentials } returns listOf(issuedCredential)
+        }
+    }
+
+    private fun setupStoreIssuedDocument() {
+        every {
+            documentManager.storeIssuedDocument(any(), any())
+        } returns Outcome.success(issuedDocument)
+    }
+
+    private fun createConfig(action: TrustPolicy.Action): IssuerTrustConfig {
+        return IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(action),
+            credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+        )
+    }
+
+    private fun createProcessDeferredOutcome(
+        callback: OpenId4VciManager.OnResult<DeferredIssueResult>,
+        config: IssuerTrustConfig? = null,
+    ) = ProcessDeferredOutcome(
+        documentManager = documentManager,
+        walletKeyManager = walletKeyManager,
+        clientAttestationPopKeyId = null,
+        callback = callback,
+        deferredContext = null,
+        logger = null,
+        issuerTrustConfig = config,
+    )
+
+    @Test
+    fun storesDeferredDocumentWithTrustResult() = runTest {
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { verifier.verify(any(), any()) } returns trusted
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedResult: DeferredIssueResult? = null
+        val callback = OpenId4VciManager.OnResult<DeferredIssueResult> { capturedResult = it }
+        val config = createConfig(TrustPolicy.Action.INFORM)
+
+        createProcessDeferredOutcome(callback, config)
+            .process(deferredDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedResult",
+            capturedResult is DeferredIssueResult.DocumentIssued)
+        val documentIssued = capturedResult as DeferredIssueResult.DocumentIssued
+        assertEquals(trusted, documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+    }
+
+    @Test
+    fun storesDeferredWithNullTrustWhenNotConfigured() = runTest {
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedResult: DeferredIssueResult? = null
+        val callback = OpenId4VciManager.OnResult<DeferredIssueResult> { capturedResult = it }
+
+        createProcessDeferredOutcome(callback, config = null)
+            .process(deferredDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedResult",
+            capturedResult is DeferredIssueResult.DocumentIssued)
+        val documentIssued = capturedResult as DeferredIssueResult.DocumentIssued
+        assertNull(documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+    }
+
+    @Test
+    fun rejectsDeferredWithEnforceAndNotTrusted() = runTest {
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val outcome = createOutcome()
+        var capturedResult: DeferredIssueResult? = null
+        val callback = OpenId4VciManager.OnResult<DeferredIssueResult> { capturedResult = it }
+        val config = createConfig(TrustPolicy.Action.ENFORCE)
+
+        createProcessDeferredOutcome(callback, config)
+            .process(deferredDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentFailed but got $capturedResult",
+            capturedResult is DeferredIssueResult.DocumentFailed)
+        val documentFailed = capturedResult as DeferredIssueResult.DocumentFailed
+        assertTrue(documentFailed.cause is IssuerNotTrustedException)
+        // Document is NOT deleted - the exception propagates to the outer try/catch
+        verify(exactly = 0) { documentManager.deleteDocumentById(any()) }
+    }
+
+    @Test
+    fun storesDeferredWithInformAndNotTrusted() = runTest {
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedResult: DeferredIssueResult? = null
+        val callback = OpenId4VciManager.OnResult<DeferredIssueResult> { capturedResult = it }
+        val config = createConfig(TrustPolicy.Action.INFORM)
+
+        createProcessDeferredOutcome(callback, config)
+            .process(deferredDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedResult",
+            capturedResult is DeferredIssueResult.DocumentIssued)
+        val documentIssued = capturedResult as DeferredIssueResult.DocumentIssued
+        assertEquals(notTrusted, documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
@@ -27,7 +27,6 @@ import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
 import eu.europa.ec.eudi.wallet.issue.openid4vci.DeferredIssueResult
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.issue.openid4vci.ProcessDeferredOutcome
-import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -45,7 +44,6 @@ import java.security.cert.TrustAnchor
 class ProcessDeferredOutcomeTrustTest {
 
     private val documentManager = mockk<DocumentManager>(relaxed = true)
-    private val walletKeyManager = mockk<WalletKeyManager>()
     private val issuedDocument = mockk<IssuedDocument> {
         every { id } returns "doc-id"
         every { name } returns "Test Document"
@@ -89,8 +87,6 @@ class ProcessDeferredOutcomeTrustTest {
         config: IssuerTrustConfig? = null,
     ) = ProcessDeferredOutcome(
         documentManager = documentManager,
-        walletKeyManager = walletKeyManager,
-        clientAttestationPopKeyId = null,
         callback = callback,
         deferredContext = null,
         logger = null,

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessDeferredOutcomeTrustTest.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.wallet.trust
 import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.openid4vci.Credential
 import eu.europa.ec.eudi.openid4vci.DeferredCredentialQueryOutcome
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.openid4vci.IssuedCredential
 import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.DocumentManager
@@ -79,6 +80,7 @@ class ProcessDeferredOutcomeTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(action),
             credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
     }
 

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.openid4vci.IssuedCredential
+import eu.europa.ec.eudi.openid4vci.SubmissionOutcome
+import eu.europa.ec.eudi.wallet.document.DocumentId
+import eu.europa.ec.eudi.wallet.document.DocumentManager
+import eu.europa.ec.eudi.wallet.document.IssuedDocument
+import eu.europa.ec.eudi.wallet.document.Outcome
+import eu.europa.ec.eudi.wallet.document.UnsignedDocument
+import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.issue.openid4vci.DeferredContextFactory
+import eu.europa.ec.eudi.wallet.issue.openid4vci.IssueEvent
+import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
+import eu.europa.ec.eudi.wallet.issue.openid4vci.ProcessResponse
+import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.cert.TrustAnchor
+
+@RunWith(RobolectricTestRunner::class)
+class ProcessResponseTrustTest {
+
+    private val documentManager = mockk<DocumentManager>(relaxed = true)
+    private val deferredContextFactory = mockk<DeferredContextFactory>()
+    private val walletKeyManager = mockk<WalletKeyManager>()
+    private val issuedDocumentIds = mutableListOf<DocumentId>()
+    private val issuedDocument = mockk<IssuedDocument> {
+        every { id } returns "doc-id"
+        every { name } returns "Test Document"
+        every { format } returns SdJwtVcFormat("test.vct")
+    }
+    private val unsignedDocument = mockk<UnsignedDocument> {
+        every { id } returns "unsigned-doc-id"
+        every { name } returns "Test Document"
+        every { format } returns SdJwtVcFormat("test.vct")
+    }
+
+    private val credential = Credential.Str("test-credential-value")
+    private val keyAlias = "key-alias-1"
+    private val issuedCredential = IssuedCredential.string("test-credential-value")
+    private val trustAnchor = mockk<TrustAnchor>()
+    private val verifier = mockk<CredentialTrustVerifier>()
+
+    private fun createOutcome(): SubmissionOutcome.Success {
+        return mockk<SubmissionOutcome.Success> {
+            every { credentials } returns listOf(issuedCredential)
+        }
+    }
+
+    private fun setupStoreIssuedDocument() {
+        every {
+            documentManager.storeIssuedDocument(any(), any())
+        } returns Outcome.success(issuedDocument)
+    }
+
+    private fun createConfig(action: TrustPolicy.Action): IssuerTrustConfig {
+        return IssuerTrustConfig(
+            isChainTrustedForAttestation = mockk(),
+            classifications = null,
+            trustPolicy = TrustPolicy.uniform(action),
+            credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+        )
+    }
+
+    private fun createProcessResponse(
+        listener: OpenId4VciManager.OnResult<IssueEvent>,
+        config: IssuerTrustConfig? = null,
+    ) = ProcessResponse(
+        documentManager = documentManager,
+        deferredContextFactory = deferredContextFactory,
+        walletKeyManager = walletKeyManager,
+        clientAttestationPopKeyId = null,
+        listener = listener,
+        issuedDocumentIds = issuedDocumentIds,
+        logger = null,
+        issuerTrustConfig = config,
+    )
+
+    @Test
+    fun storesDocumentWithTrustResult() = runTest {
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { verifier.verify(any(), any()) } returns trusted
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedEvent: IssueEvent? = null
+        val listener = OpenId4VciManager.OnResult<IssueEvent> { capturedEvent = it }
+        val config = createConfig(TrustPolicy.Action.INFORM)
+
+        createProcessResponse(listener, config)
+            .processSubmittedRequest(unsignedDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedEvent",
+            capturedEvent is IssueEvent.DocumentIssued)
+        val documentIssued = capturedEvent as IssueEvent.DocumentIssued
+        assertEquals(trusted, documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+        assertTrue(issuedDocumentIds.contains("doc-id"))
+    }
+
+    @Test
+    fun storesDocumentWithNullTrustWhenNotConfigured() = runTest {
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedEvent: IssueEvent? = null
+        val listener = OpenId4VciManager.OnResult<IssueEvent> { capturedEvent = it }
+
+        createProcessResponse(listener, config = null)
+            .processSubmittedRequest(unsignedDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedEvent",
+            capturedEvent is IssueEvent.DocumentIssued)
+        val documentIssued = capturedEvent as IssueEvent.DocumentIssued
+        assertNull(documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+    }
+
+    @Test
+    fun rejectsDocumentWithEnforceAndNotTrusted() = runTest {
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+
+        val outcome = createOutcome()
+        var capturedEvent: IssueEvent? = null
+        val listener = OpenId4VciManager.OnResult<IssueEvent> { capturedEvent = it }
+        val config = createConfig(TrustPolicy.Action.ENFORCE)
+
+        createProcessResponse(listener, config)
+            .processSubmittedRequest(unsignedDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentFailed but got $capturedEvent",
+            capturedEvent is IssueEvent.DocumentFailed)
+        val documentFailed = capturedEvent as IssueEvent.DocumentFailed
+        assertTrue(documentFailed.cause is IssuerNotTrustedException)
+        verify { documentManager.deleteDocumentById("unsigned-doc-id") }
+        assertTrue(issuedDocumentIds.isEmpty())
+    }
+
+    @Test
+    fun storesDocumentWithInformAndNotTrusted() = runTest {
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { verifier.verify(any(), any()) } returns notTrusted
+        setupStoreIssuedDocument()
+
+        val outcome = createOutcome()
+        var capturedEvent: IssueEvent? = null
+        val listener = OpenId4VciManager.OnResult<IssueEvent> { capturedEvent = it }
+        val config = createConfig(TrustPolicy.Action.INFORM)
+
+        createProcessResponse(listener, config)
+            .processSubmittedRequest(unsignedDocument, listOf(keyAlias), outcome)
+
+        assertTrue("Expected DocumentIssued but got $capturedEvent",
+            capturedEvent is IssueEvent.DocumentIssued)
+        val documentIssued = capturedEvent as IssueEvent.DocumentIssued
+        assertEquals(notTrusted, documentIssued.issuerTrustResult)
+        assertEquals(issuedDocument, documentIssued.document)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
@@ -16,7 +16,10 @@
 package eu.europa.ec.eudi.wallet.trust
 
 import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
+import eu.europa.ec.eudi.openid4vci.ClientAuthentication
 import eu.europa.ec.eudi.openid4vci.Credential
+import eu.europa.ec.eudi.openid4vci.Issuer
 import eu.europa.ec.eudi.openid4vci.IssuedCredential
 import eu.europa.ec.eudi.openid4vci.SubmissionOutcome
 import eu.europa.ec.eudi.wallet.document.DocumentId
@@ -27,9 +30,9 @@ import eu.europa.ec.eudi.wallet.document.UnsignedDocument
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
 import eu.europa.ec.eudi.wallet.issue.openid4vci.DeferredContextFactory
 import eu.europa.ec.eudi.wallet.issue.openid4vci.IssueEvent
+import eu.europa.ec.eudi.wallet.issue.openid4vci.Offer
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.issue.openid4vci.ProcessResponse
-import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -40,6 +43,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.multipaz.storage.Storage
 import org.robolectric.RobolectricTestRunner
 import java.security.cert.TrustAnchor
 
@@ -48,8 +52,8 @@ class ProcessResponseTrustTest {
 
     private val documentManager = mockk<DocumentManager>(relaxed = true)
     private val deferredContextFactory = mockk<DeferredContextFactory>()
-    private val walletKeyManager = mockk<WalletKeyManager>()
     private val issuedDocumentIds = mutableListOf<DocumentId>()
+    private val deferredDocumentIds = mutableListOf<DocumentId>()
     private val issuedDocument = mockk<IssuedDocument> {
         every { id } returns "doc-id"
         every { name } returns "Test Document"
@@ -94,11 +98,17 @@ class ProcessResponseTrustTest {
     ) = ProcessResponse(
         documentManager = documentManager,
         deferredContextFactory = deferredContextFactory,
-        walletKeyManager = walletKeyManager,
         clientAttestationPopKeyId = null,
         listener = listener,
         issuedDocumentIds = issuedDocumentIds,
+        deferredDocumentIds = deferredDocumentIds,
         logger = null,
+        authorizedRequest = mockk<AuthorizedRequest>(relaxed = true),
+        issuer = mockk<Issuer>(relaxed = true),
+        documentToConfigurationMap = emptyMap(),
+        dpopKeyAlias = null,
+        issuanceMetadataStorage = mockk<Storage>(relaxed = true),
+        clientAuthentication = mockk<ClientAuthentication>(relaxed = true),
         issuerTrustConfig = config,
     )
 

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/ProcessResponseTrustTest.kt
@@ -20,6 +20,7 @@ import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
 import eu.europa.ec.eudi.openid4vci.ClientAuthentication
 import eu.europa.ec.eudi.openid4vci.Credential
 import eu.europa.ec.eudi.openid4vci.Issuer
+import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.openid4vci.IssuedCredential
 import eu.europa.ec.eudi.openid4vci.SubmissionOutcome
 import eu.europa.ec.eudi.wallet.document.DocumentId
@@ -89,6 +90,7 @@ class ProcessResponseTrustTest {
             classifications = null,
             trustPolicy = TrustPolicy.uniform(action),
             credentialTrustVerifiers = mapOf(SdJwtVcFormat::class to verifier),
+            issuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         )
     }
 

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifierTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifierTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.util.Base64 as NimbusBase64
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+import java.security.interfaces.ECPrivateKey
+import java.security.spec.ECGenParameterSpec
+import java.util.Date
+import kotlin.test.assertIs
+
+@RunWith(RobolectricTestRunner::class)
+class SdJwtVcCredentialTrustVerifierTest {
+
+    private val attestationIdentifier = AttestationIdentifier.SDJwtVc("VerifiablePortableDocumentA1")
+    private val isChainTrusted =
+        mockk<IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>>()
+    private val verifier = SdJwtVcCredentialTrustVerifier(isChainTrusted)
+
+    @Test
+    fun returnsTrustedForValidSdJwt() = runTest {
+        val keyPair = generateEcKeyPair()
+        val cert = createSelfSignedCert(keyPair, "CN=Test Issuer")
+        val sdJwt = buildSdJwt(keyPair, cert)
+
+        val trustAnchor = mockk<TrustAnchor>()
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { isChainTrusted.issuance(match { certs ->
+            certs.size == 1 && certs[0].encoded.contentEquals(cert.encoded)
+        }, attestationIdentifier) } returns trusted
+
+        val result = verifier.verify(sdJwt, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.Trusted<TrustAnchor>>(result)
+        assertEquals(trustAnchor, result.trustAnchor)
+    }
+
+    @Test
+    fun returnsNotTrustedForUntrustedChain() = runTest {
+        val keyPair = generateEcKeyPair()
+        val cert = createSelfSignedCert(keyPair, "CN=Untrusted Issuer")
+        val sdJwt = buildSdJwt(keyPair, cert)
+
+        val cause = IllegalStateException("not trusted")
+        val notTrusted = CertificationChainValidation.NotTrusted(cause)
+        coEvery { isChainTrusted.issuance(any(), eq(attestationIdentifier)) } returns notTrusted
+
+        val result = verifier.verify(sdJwt, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.NotTrusted>(result)
+        assertEquals(cause, result.cause)
+    }
+
+    @Test
+    fun returnsNullForMissingX5cHeader() = runTest {
+        val keyPair = generateEcKeyPair()
+        // Build a JWT without x5c header
+        val header = JWSHeader.Builder(JWSAlgorithm.ES256).build()
+        val claims = JWTClaimsSet.Builder()
+            .issuer("https://example.com")
+            .claim("vct", "VerifiablePortableDocumentA1")
+            .build()
+        val signedJwt = SignedJWT(header, claims)
+        signedJwt.sign(ECDSASigner(keyPair.private as ECPrivateKey))
+        val sdJwt = "${signedJwt.serialize()}~"
+
+        val result = verifier.verify(sdJwt, attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullForMalformedJwt() = runTest {
+        val result = verifier.verify("not-a-valid-jwt~", attestationIdentifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun handlesSdJwtWithDisclosures() = runTest {
+        val keyPair = generateEcKeyPair()
+        val cert = createSelfSignedCert(keyPair, "CN=Test Issuer")
+
+        // Build a SD-JWT with a disclosure segment
+        val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+            .x509CertChain(listOf(NimbusBase64.encode(cert.encoded)))
+            .build()
+        val claims = JWTClaimsSet.Builder()
+            .issuer("https://example.com")
+            .claim("vct", "VerifiablePortableDocumentA1")
+            .claim("_sd_alg", "sha-256")
+            .build()
+        val signedJwt = SignedJWT(header, claims)
+        signedJwt.sign(ECDSASigner(keyPair.private as ECPrivateKey))
+        // Append a fake disclosure and trailing tilde
+        val sdJwt = "${signedJwt.serialize()}~WyJzYWx0IiwiZ2l2ZW5fbmFtZSIsIkpvaG4iXQ~"
+
+        val trustAnchor = mockk<TrustAnchor>()
+        val trusted = CertificationChainValidation.Trusted(trustAnchor)
+        coEvery { isChainTrusted.issuance(match { certs ->
+            certs.size == 1 && certs[0].encoded.contentEquals(cert.encoded)
+        }, attestationIdentifier) } returns trusted
+
+        val result = verifier.verify(sdJwt, attestationIdentifier)
+
+        assertNotNull(result)
+        assertIs<CertificationChainValidation.Trusted<TrustAnchor>>(result)
+    }
+
+    // -- helpers --
+
+    private fun generateEcKeyPair() = KeyPairGenerator.getInstance("EC").apply {
+        initialize(ECGenParameterSpec("secp256r1"))
+    }.generateKeyPair()
+
+    private fun createSelfSignedCert(
+        keyPair: java.security.KeyPair,
+        cn: String,
+    ): X509Certificate {
+        val issuer = org.bouncycastle.asn1.x500.X500Name(cn)
+        val notBefore = Date(System.currentTimeMillis() - 86400000L)
+        val notAfter = Date(System.currentTimeMillis() + 30 * 86400000L)
+        val builder = JcaX509v3CertificateBuilder(
+            issuer, BigInteger.ONE, notBefore, notAfter, issuer, keyPair.public,
+        )
+        val signer = JcaContentSignerBuilder("SHA256WithECDSA").build(keyPair.private)
+        return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+    }
+
+    private fun buildSdJwt(
+        keyPair: java.security.KeyPair,
+        cert: X509Certificate,
+    ): String {
+        val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+            .x509CertChain(listOf(NimbusBase64.encode(cert.encoded)))
+            .build()
+        val claims = JWTClaimsSet.Builder()
+            .issuer("https://example.com")
+            .claim("vct", "VerifiablePortableDocumentA1")
+            .build()
+        val signedJwt = SignedJWT(header, claims)
+        signedJwt.sign(ECDSASigner(keyPair.private as ECPrivateKey))
+        return "${signedJwt.serialize()}~"
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/TrustPolicyTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/TrustPolicyTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.wallet.trust.TrustPolicy.Action.ENFORCE
+import eu.europa.ec.eudi.wallet.trust.TrustPolicy.Action.INFORM
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TrustPolicyTest {
+
+    @Test
+    fun uniformPolicyReturnsSameActionForAnyInput() {
+        val policy = TrustPolicy.uniform(ENFORCE)
+
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL"), VerificationContext.PID))
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.SDJwtVc("urn:example:vct"), VerificationContext.QEAA))
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.MDoc("any"), null))
+    }
+
+    @Test
+    fun builderDefaultIsUsedWhenNoSpecificMatch() {
+        val policy = TrustPolicy.build {
+            default(INFORM)
+        }
+
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL"), VerificationContext.PID))
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.SDJwtVc("urn:example:vct"), null))
+    }
+
+    @Test
+    fun forContextOverridesDefault() {
+        val policy = TrustPolicy.build {
+            default(ENFORCE)
+            forContext(VerificationContext.PID, INFORM)
+        }
+
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.MDoc("any"), VerificationContext.PID))
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.MDoc("any"), VerificationContext.QEAA))
+    }
+
+    @Test
+    fun forAttestationOverridesForContext() {
+        val mdoc = AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+        val policy = TrustPolicy.build {
+            default(ENFORCE)
+            forContext(VerificationContext.PID, ENFORCE)
+            forAttestation(mdoc, INFORM)
+        }
+
+        assertEquals(INFORM, policy.resolve(mdoc, VerificationContext.PID))
+    }
+
+    @Test
+    fun forDocTypeCreatesAttestationOverride() {
+        val policy = TrustPolicy.build {
+            default(ENFORCE)
+            forDocType("org.iso.18013.5.1.mDL", INFORM)
+        }
+
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL"), VerificationContext.PID))
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.MDoc("other"), VerificationContext.PID))
+    }
+
+    @Test
+    fun forVctCreatesAttestationOverride() {
+        val policy = TrustPolicy.build {
+            default(ENFORCE)
+            forVct("urn:eu:pid", INFORM)
+        }
+
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.SDJwtVc("urn:eu:pid"), VerificationContext.PID))
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.SDJwtVc("other"), VerificationContext.PID))
+    }
+
+    @Test
+    fun nullVerificationContextFallsToDefault() {
+        val policy = TrustPolicy.build {
+            default(ENFORCE)
+            forContext(VerificationContext.PID, INFORM)
+        }
+
+        assertEquals(ENFORCE, policy.resolve(AttestationIdentifier.MDoc("any"), null))
+    }
+
+    @Test
+    fun customFunInterfaceImplementationWorks() {
+        val policy = TrustPolicy { _, _ -> INFORM }
+
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.MDoc("any"), VerificationContext.PID))
+        assertEquals(INFORM, policy.resolve(AttestationIdentifier.SDJwtVc("any"), null))
+    }
+}


### PR DESCRIPTION
Integrates the `eudi-lib-kmp-etsi-1196x2` consultation library into wallet-core to support
trust verification using ETSI Trusted Lists (LoTE - ETSI TS 119 602) across the credential
lifecycle:

1. **Credential Issuance Trust** - Validates issuer certificate chains (COSE x5chain for
   MsoMdoc, JWT x5c for SD-JWT VC) after credential receipt and before storage. Configurable
   ENFORCE/INFORM trust policy per credential type or verification context.

2. **Signed Issuer Metadata Verification** - Verifies the x5c certificate chain in signed
   issuer metadata JWTs (`openidvci-issuer-metadata+jwt`) against WRPAC trust anchors.
   Three policies: RequireSigned (default), PreferSigned, IgnoreSigned.

3. **Revocation Status Trust** - Extends the document status resolver to verify that status
   list token signers (JWT x5c and CWT COSE_X509) are trusted. Adds CWT signature
   verification support (`VerifyStatusListTokenSignatureCwtX5c`). Trust-evaluating wrappers
   decorate the base signature verifiers with chain trust checks.

4. **Reader Authentication** -  `EtsiReaderTrustStore` as a drop-in replacement for
   `ReaderTrustStoreImpl`, delegating reader certificate chain validation to ETSI trusted
   lists using the WRPAC verification context.