### PR TITLE
Credential response encryption configurable in OpenId4VciManager.Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ val config = EudiWalletConfig()
         userAuthenticationRequired = true,
         // set userAuthenticationTimeout to 30 seconds
         userAuthenticationTimeout = 30_000.milliseconds,
-        // set useStrongBoxForKeys to true to use the the device's StrongBox if available
+        // set useStrongBoxForKeys to true to use the device's StrongBox if available
         // to store the keys
         useStrongBoxForKeys = true
     )

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ val config = EudiWalletConfig()
         // withDPopConfig(DPopConfig.Default) // This is the default
         // withDPopConfig(DPopConfig.Disabled) // To disable DPoP
         // withDPopConfig(customDPopConfig) // To use custom configuration
+
+        // Configure credential response encryption
+        // By default, encryption is REQUIRED with EC P-256 and RSA 2048
+        // withResponseEncryptionConfig(EncryptionSupportConfig(...))
     }
     // configuration for proximity presentation
     // the values below are the default values
@@ -1576,7 +1580,7 @@ defaults:
 val config = EudiWalletConfig()
     .configureOpenId4Vci {
         withIssuerUrl("https://issuer.com")
-        withClientId("client-id")
+        withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.AttestationBased)
         withAuthFlowRedirectionURI("eudi-openid4ci://authorize")
         // DPoP is enabled by default with DPopConfig.Default
         // No additional configuration needed
@@ -1599,7 +1603,7 @@ If you need to disable DPoP (not recommended for production):
 val config = EudiWalletConfig()
     .configureOpenId4Vci {
         withIssuerUrl("https://issuer.com")
-        withClientId("client-id")
+        withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.AttestationBased)
         withAuthFlowRedirectionURI("eudi-openid4ci://authorize")
         withDPopConfig(DPopConfig.Disabled)
     }
@@ -1621,7 +1625,7 @@ For advanced use cases, you can fully customize how DPoP keys are created and us
 val walletConfig = EudiWalletConfig()
     .configureOpenId4Vci {
         withIssuerUrl("https://issuer.example.com")
-        withClientId("wallet-client")
+        withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.AttestationBased)
 
         // Custom DPoP configuration
         withDPopConfig(
@@ -1643,6 +1647,41 @@ val walletConfig = EudiWalletConfig()
         )
     }
 ```
+
+#### Credential Response Encryption
+
+The library supports encrypting credential responses from the issuer, as defined in the
+[OpenID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) specification.
+This is configured via the `responseEncryptionConfig` property of `OpenId4VciManager.Config`.
+
+By default, credential response encryption is **required** (`CredentialResponseEncryptionPolicy.REQUIRED`)
+with EC P-256 and RSA 2048.
+
+##### Changing the encryption policy
+
+```kotlin
+
+val config = EudiWalletConfig()
+    .configureOpenId4Vci {
+        // ..............................
+
+        // Use encryption only if the issuer supports it (instead of requiring it)
+        withResponseEncryptionConfig(
+            EncryptionSupportConfig(
+                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
+                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
+                rsaConfig = RsaConfig(rcaKeySize = 2048),
+            )
+        )
+    }
+```
+
+The available policies are:
+
+- `CredentialResponseEncryptionPolicy.REQUIRED` (default) -- encryption must be used; issuance fails
+  if the issuer does not support it.
+- `CredentialResponseEncryptionPolicy.SUPPORTED` -- encryption is used when the issuer advertises
+  support for it, but issuance proceeds unencrypted otherwise.
 
 ### Transfer documents
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -440,7 +440,7 @@ class EudiWalletConfig {
         this.readerAuthPolicy = readerAuthPolicy
     }
 
-    var userAuthenticationRequired: Boolean = false
+    var userAuthenticationRequired: Boolean = true
         internal set // internal for setting the default value from the builder
     var userAuthenticationTimeout: Duration = 0.milliseconds
         private set
@@ -461,7 +461,7 @@ class EudiWalletConfig {
      * **Note**: when setting useStrongBoxForKeys to true, the device must support the StrongBox.
      *
      * The default values are:
-     * - userAuthenticationRequired: false
+     * - userAuthenticationRequired: true
      * - userAuthenticationTimeout: 0
      * - useStrongBoxForKeys: true if supported by the device
      *
@@ -471,7 +471,7 @@ class EudiWalletConfig {
      * @param useStrongBoxForKeys whether to use the strong box for keys
      */
     fun configureDocumentKeyCreation(
-        userAuthenticationRequired: Boolean = false,
+        userAuthenticationRequired: Boolean = true,
         userAuthenticationTimeout: Duration = 0.milliseconds,
         useStrongBoxForKeys: Boolean = true,
     ) = apply {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerCreator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssuerCreator.kt
@@ -17,21 +17,16 @@
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
 import android.content.Context
-import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.CIAuthorizationServerMetadata
 import eu.europa.ec.eudi.openid4vci.ClientAuthentication
 import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerId
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialOffer
-import eu.europa.ec.eudi.openid4vci.CredentialResponseEncryptionPolicy
-import eu.europa.ec.eudi.openid4vci.EcConfig
-import eu.europa.ec.eudi.openid4vci.EncryptionSupportConfig
 import eu.europa.ec.eudi.openid4vci.Issuer
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
 import eu.europa.ec.eudi.openid4vci.OpenId4VCIConfig
 import eu.europa.ec.eudi.openid4vci.ParUsage
-import eu.europa.ec.eudi.openid4vci.RsaConfig
 import eu.europa.ec.eudi.openid4vci.clientAttestationPOPJWSAlgs
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
@@ -205,11 +200,7 @@ internal class IssuerCreator(
         return OpenId4VCIConfig(
             clientAuthentication = auth,
             authFlowRedirectionURI = URI.create(authFlowRedirectionURI),
-            encryptionSupportConfig = EncryptionSupportConfig(
-                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
-                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
-                rsaConfig = RsaConfig(rcaKeySize = 2048)
-            ),
+            encryptionSupportConfig = responseEncryptionConfig,
             dPoPSigner = if (existingDpopKeyAlias != null) {
                 // Re-issuance: reuse existing DPoP key bound to the access token
                 val resolvedConfig = when (val cfg = dpopConfig) {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
@@ -19,8 +19,13 @@ package eu.europa.ec.eudi.wallet.issue.openid4vci
 import android.content.Context
 import android.net.Uri
 import androidx.annotation.IntDef
+import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadata
+import eu.europa.ec.eudi.openid4vci.CredentialResponseEncryptionPolicy
+import eu.europa.ec.eudi.openid4vci.EcConfig
+import eu.europa.ec.eudi.openid4vci.EncryptionSupportConfig
+import eu.europa.ec.eudi.openid4vci.RsaConfig
 import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.DocumentManager
@@ -439,6 +444,14 @@ interface OpenId4VciManager {
      *
      *           @see DPopConfig for configuration options
      * @property parUsage if PAR should be used
+     * @property responseEncryptionConfig configuration for credential response encryption.
+     *           Controls whether credential responses from the issuer are encrypted, and which
+     *           algorithms are supported.
+     *
+     *           **Default:** encryption required with EC P-256 and RSA 2048
+     *
+     *           @see EncryptionSupportConfig
+     *           @see CredentialResponseEncryptionPolicy
      */
     data class Config @JvmOverloads constructor(
         val issuerUrl: String,
@@ -448,6 +461,11 @@ interface OpenId4VciManager {
         val dpopConfig: DPopConfig = DPopConfig.Default,
         @ParUsage val parUsage: Int = IF_SUPPORTED,
         val issuanceMetadataStorage: Storage? = null,
+        val responseEncryptionConfig: EncryptionSupportConfig = EncryptionSupportConfig(
+            credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
+            ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
+            rsaConfig = RsaConfig(rcaKeySize = 2048),
+        ),
     ) {
         /**
          * PAR usage for the OpenId4Vci issuer
@@ -561,6 +579,12 @@ interface OpenId4VciManager {
             var parUsage: Int = IF_SUPPORTED
 
             var issuanceMetadataStorage: Storage? = null
+
+            var responseEncryptionConfig: EncryptionSupportConfig = EncryptionSupportConfig(
+                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
+                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
+                rsaConfig = RsaConfig(rcaKeySize = 2048),
+            )
 
             /**
              * Set the issuer url
@@ -715,6 +739,23 @@ interface OpenId4VciManager {
             }
 
             /**
+             * Sets the credential response encryption configuration.
+             *
+             * Controls whether and how credential responses from the issuer are encrypted.
+             * The configuration includes the encryption policy, EC key curve, and RSA key size.
+             *
+             * **Default:** [CredentialResponseEncryptionPolicy.REQUIRED] with EC P-256 and RSA 2048
+             *
+             * @param responseEncryptionConfig The [EncryptionSupportConfig] to use
+             * @return This builder instance for method chaining
+             * @see EncryptionSupportConfig
+             * @see CredentialResponseEncryptionPolicy
+             */
+            fun withResponseEncryptionConfig(responseEncryptionConfig: EncryptionSupportConfig) = apply {
+                this.responseEncryptionConfig = responseEncryptionConfig
+            }
+
+            /**
              * Build the [Config]
              * @return the [Config]
              */
@@ -731,7 +772,8 @@ interface OpenId4VciManager {
                     authFlowRedirectionURI = authFlowRedirectionURI,
                     dpopConfig = dpopConfig,
                     parUsage = parUsage,
-                    issuanceMetadataStorage = issuanceMetadataStorage
+                    issuanceMetadataStorage = issuanceMetadataStorage,
+                    responseEncryptionConfig = responseEncryptionConfig,
                 )
             }
         }

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderResponseEncryptionTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderResponseEncryptionTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.issue.openid4vci
+
+import com.nimbusds.jose.jwk.Curve
+import eu.europa.ec.eudi.openid4vci.CredentialResponseEncryptionPolicy
+import eu.europa.ec.eudi.openid4vci.EcConfig
+import eu.europa.ec.eudi.openid4vci.EncryptionSupportConfig
+import eu.europa.ec.eudi.openid4vci.RsaConfig
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.Test
+
+@RunWith(value = Parameterized::class)
+class OpenId4VciManagerConfigBuilderResponseEncryptionTest(
+    private val responseEncryptionConfig: EncryptionSupportConfig,
+) {
+
+    @Test
+    fun `ConfigBuilder sets the responseEncryptionConfig property correctly`() {
+        val builder = OpenId4VciManager.Config.Builder()
+            .withIssuerUrl("https://issuer.example.com")
+            .withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.None("testClientId"))
+            .withAuthFlowRedirectionURI("app://redirect")
+            .withResponseEncryptionConfig(responseEncryptionConfig)
+
+        val config = builder.build()
+
+        assertEquals(responseEncryptionConfig, config.responseEncryptionConfig)
+    }
+
+    companion object {
+
+        @Parameterized.Parameters(name = "{index}: responseEncryptionConfig={0}")
+        @JvmStatic
+        fun responseEncryptionArgs() = arrayListOf(
+            EncryptionSupportConfig(
+                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
+                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
+                rsaConfig = RsaConfig(rcaKeySize = 2048),
+            ),
+            EncryptionSupportConfig(
+                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
+                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
+                rsaConfig = RsaConfig(rcaKeySize = 2048),
+            ),
+            EncryptionSupportConfig(
+                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
+                ecConfig = EcConfig(ecKeyCurve = Curve.P_384),
+                rsaConfig = RsaConfig(rcaKeySize = 4096),
+            ),
+        )
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManagerConfigBuilderTest.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
+import eu.europa.ec.eudi.openid4vci.CredentialResponseEncryptionPolicy
 import eu.europa.ec.eudi.wallet.issue.openid4vci.dpop.DPopConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -97,5 +98,20 @@ class OpenId4VciManagerConfigBuilderTest {
         val config = builder.build()
 
         assertIs<DPopConfig.Disabled>(config.dpopConfig)
+    }
+
+    @Test
+    fun `ConfigBuilder uses REQUIRED as default responseEncryptionConfig policy`() {
+        val builder = OpenId4VciManager.Config.Builder()
+            .withIssuerUrl("https://issuer.example.com")
+            .withClientAuthenticationType(OpenId4VciManager.ClientAuthenticationType.AttestationBased)
+            .withAuthFlowRedirectionURI("app://redirect")
+
+        val config = builder.build()
+
+        assertEquals(
+            CredentialResponseEncryptionPolicy.REQUIRED,
+            config.responseEncryptionConfig.credentialResponseEncryptionPolicy
+        )
     }
 }


### PR DESCRIPTION
#### Credential Response Encryption

The library supports encrypting credential responses from the issuer, as defined in the
[OpenID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) specification.
This is configured via the `responseEncryptionConfig` property of `OpenId4VciManager.Config`.

By default, credential response encryption is **required** (`CredentialResponseEncryptionPolicy.REQUIRED`)
with EC P-256 and RSA 2048.

##### Changing the encryption policy

```kotlin

val config = EudiWalletConfig()
    .configureOpenId4Vci {
        // ..............................

        // Use encryption only if the issuer supports it (instead of requiring it)
        withResponseEncryptionConfig(
            EncryptionSupportConfig(
                credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
                ecConfig = EcConfig(ecKeyCurve = Curve.P_256),
                rsaConfig = RsaConfig(rcaKeySize = 2048),
            )
        )
    }
```

The available policies are:

- `CredentialResponseEncryptionPolicy.REQUIRED` (default) -- encryption must be used; issuance fails
  if the issuer does not support it.
- `CredentialResponseEncryptionPolicy.SUPPORTED` -- encryption is used when the issuer advertises
  support for it, but issuance proceeds unencrypted otherwise.