### PR TITLE
LoTE enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,17 +647,16 @@ library directly (or any other trust framework).
 
 #### Dependencies
 
-The `etsi-1196x2-consultation` module is exposed as an `api` dependency from wallet-core, so
-consumers can reference its types (e.g., `SupportedLists`, `AttestationClassifications`) directly.
-The `etsi-119602-consultation` module is bundled internally as `implementation` — consumers do
-**not** need to declare it. The `configureEtsiTrust` DSL accepts plain strings for LoTE URLs,
-avoiding any dependency on `etsi-119602` types in consumer code.
+Both ETSI consultation modules are exposed as `api` dependencies from wallet-core, so
+consumers can reference their types directly:
+
+- `etsi-1196x2-consultation` — base consultation types (`SupportedLists`, `AttestationClassifications`, `IsChainTrustedForEUDIW`, etc.)
+- `etsi-119602-consultation` — `Uri` type used in `configureEtsiTrust` DSL
 
 ```groovy
 dependencies {
     implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0-SNAPSHOT"
-    // etsi-1196x2-consultation types (SupportedLists, AttestationClassifications, etc.)
-    // are available transitively — no additional ETSI dependency needed
+    // Both ETSI modules are available transitively — no additional dependency needed
 }
 ```
 
@@ -673,9 +672,9 @@ val config = EudiWalletConfig {
     configureEtsiTrust {
         // Required: LoTE download URLs
         loteLocations(SupportedLists(
-            pidProviders = "https://trust.example.eu/pid-providers.jwt",
-            wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
-            // pubEaaProviders = "https://trust.example.eu/pub-eaa-providers.jwt",
+            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
+            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
+            pubEaaProviders = Uri("https://trust.example.eu/pub-eaa-providers.jwt")
         ))
 
         // Required: map credential types to ETSI verification contexts
@@ -1077,8 +1076,8 @@ val config = EudiWalletConfig {
     // Centralized ETSI trust — builds the full LoTE pipeline internally
     configureEtsiTrust {
         loteLocations(SupportedLists(
-            pidProviders = "https://trust.example.eu/pid-providers.jwt",
-            wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
+            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
+            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
         ))
         classifications(AttestationClassifications(
             pids = AttestationIdentifierPredicate.any(setOf(

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ wallet-core library with custom SecureArea implementations.
 
 #### Reader Authentication Policy
 
-The `configureReaderAuthPolicy` method controls how reader authentication results affect document
+The reader authentication policy controls how reader authentication results affect document
 disclosure during proximity (BLE/NFC) and DCAPI presentations. This works in conjunction with the
 `ReaderTrustStore` configured via `configureReaderTrustStore`.
 
@@ -328,13 +328,31 @@ happens based on the verification result:
 Per ISO 18013-5, when all documents are excluded due to reader authentication failure, the wallet
 returns a DeviceResponse with status 10 (General Error) instead of an empty success response.
 
-**Example:**
+The reader auth policy can be set in two ways, for flexibility:
+
+**Inside the ETSI reader trust DSL** (when using `configureEtsiTrust`):
 
 ```kotlin
-val config = EudiWalletConfig()
-    .configureReaderTrustStore(listOf(trustedReaderCertificate))
-    .configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+val config = EudiWalletConfig {
+    configureEtsiTrust { /* ... */ }
+    configureReaderTrustStore {
+        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    }
+}
 ```
+
+**As a standalone call** (when using certificate-based or custom `ReaderTrustStore`):
+
+```kotlin
+val config = EudiWalletConfig {
+    configureReaderTrustStore(listOf(trustedReaderCertificate))
+    configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+}
+```
+
+The standalone `configureReaderAuthPolicy()` method remains available for users who use the
+certificate-based `configureReaderTrustStore(certificates)` overloads or a custom `ReaderTrustStore`,
+since those paths don't have a DSL block.
 
 > **Note:** If a verifier includes reader authentication in its request but its certificate is not in
 > the configured `ReaderTrustStore`, the document will be excluded from the response when using
@@ -610,38 +628,109 @@ status** (status list token signer trust), and **signed issuer metadata** verifi
 enables dynamic trust anchor resolution from LoTE (ETSI TS 119 602) instead of static
 certificate lists.
 
+The recommended approach is to use `configureEtsiTrust` to centralize the LoTE trust
+infrastructure in the core. This builds the entire trust pipeline internally — HTTP client,
+file cache, JWT signature verification, trust anchor provisioning, and caching — from a
+small set of high-level configuration knobs. Each trust area (`configureIssuerTrust`,
+`configureDocumentStatusResolver`, `configureReaderTrustStore`) inherits the shared trust
+source automatically and only needs area-specific settings (policies, clock skew, etc.).
+
 Each trust verification feature is independently configurable and opt-in. When not configured,
 the library behaves as before (credentials stored without trust checks, status resolved with
 standard signature verification, reader authentication via static certificate lists or
 disabled, unsigned metadata only).
 
-The design is **protocol-agnostic** — wallet-core defines integration contracts, and the developer
-composes trust validation using the
+For advanced use cases, the design remains **protocol-agnostic** — the per-area builders still
+accept explicit `trustSource()` calls, allowing developers to compose trust validation using the
 [eudi-lib-kmp-etsi1196x2](https://github.com/eu-digital-identity-wallet/eudi-lib-kmp-etsi-1196x2)
 library directly (or any other trust framework).
 
 #### Dependencies
 
-The core consultation module (`etsi-1196x2-consultation`) is already included transitively via
-wallet-core. For LoTE support, add the corresponding module to your app's dependencies:
+The `etsi-1196x2-consultation` module is exposed as an `api` dependency from wallet-core. The
+`etsi-119602-consultation` module is bundled as `implementation` (not transitive) — consumers
+that need its types (e.g., `Uri`, `VerifyJwtSignature`) must declare it explicitly:
+
+- `etsi-1196x2-consultation` — base consultation types (`SupportedLists`, `AttestationClassifications`, `IsChainTrustedForEUDIW`, etc.) — transitive via wallet-core
+- `etsi-119602-consultation` — LoTE loading infrastructure (`Uri`, `VerifyJwtSignature`, `LoadLoTEAndPointers.Constraints`) — **must be declared by consumer**
 
 ```groovy
 dependencies {
-    // wallet-core (already includes etsi-1196x2-consultation transitively)
     implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0-SNAPSHOT"
-
-    // For LoTE (List of Trusted Entities) support — ETSI TS 119 602
-    implementation "eu.europa.ec.eudi:etsi-119602-consultation:0.3.0-alpha.5-SNAPSHOT"
+    // Required for configureEtsiTrust DSL types (Uri, etc.)
+    implementation "eu.europa.ec.eudi:etsi-119602-consultation:0.3.0-alpha.5"
 }
 ```
 
-#### Setting Up Trust Anchor Resolution (LoTE)
+#### Centralized Trust Configuration (`configureEtsiTrust`)
 
-Set up trust anchor resolution from Lists of Trusted Entities (ETSI TS 119 602):
+The `configureEtsiTrust` DSL centralizes the entire LoTE pipeline setup into a few high-level
+knobs. The core builds the HTTP client, file cache, JWT signature verifier, trust anchor
+provisioner, and in-memory cache internally. Each trust area inherits the shared trust source
+and classifications automatically.
+
+```kotlin
+val config = EudiWalletConfig {
+    configureEtsiTrust {
+        // Required: LoTE download URLs
+        loteLocations(SupportedLists(
+            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
+            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
+            // pubEaaProviders = Uri("https://trust.example.eu/pub-eaa-providers.jwt"),
+        ))
+
+        // Required: map credential types to ETSI verification contexts
+        classifications(AttestationClassifications(
+            pids = AttestationIdentifierPredicate.any(setOf(
+                AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+                AttestationIdentifier.SDJwtVc("urn:eudi:pid:1"),
+            )),
+            pubEAAs = AttestationIdentifierPredicate.equalsTo(
+                AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+            ),
+        ))
+
+        // Optional: all have sensible defaults
+        fileCacheExpiration(24.hours)    // how long LoTE files are cached on disk
+        cacheTtl(20.minutes)             // how long trust anchors are cached in memory
+        relaxCertificateProfiles()       // strip endEntityProfile constraints (DEV/testing)
+        relaxPkixRevocation()            // disable PKIX revocation checks (DEV/testing)
+        // jwtSignatureVerifier(custom)  // override built-in JWT verifier
+        // loteConstraints(...)          // control LoTE pointer following
+    }
+
+    // Each area inherits trust source + classifications from configureEtsiTrust.
+    // Only area-specific settings are needed:
+    configureIssuerTrust {
+        policy { default(TrustPolicy.Action.ENFORCE) }
+    }
+    configureDocumentStatusResolver {
+        clockSkew(5)
+    }
+    configureReaderTrustStore {
+        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    }
+}
+```
+
+> **JWT Signature Verification:** The core includes a built-in `VerifyJwtSignature`
+> implementation that extracts the `x5c` certificate chain from the LoTE JWT header and
+> verifies the signature using the leaf certificate's public key (EC and RSA supported).
+> To override this, pass a custom verifier via `jwtSignatureVerifier()`.
+>
+> **DEV/Testing knobs:** `relaxCertificateProfiles()` strips `endEntityProfile` constraints
+> from all provider types, useful when DEV certificates don't fully conform to ETSI profile
+> requirements. `relaxPkixRevocation()` disables CRL/OCSP revocation checks when endpoints
+> are not available in the test environment.
+
+#### Advanced: Manual Trust Anchor Resolution (LoTE)
+
+For advanced use cases where you need full control over the LoTE pipeline, you can build
+the trust source manually using the ETSI library directly and pass it to the per-area
+builders via `trustSource()`:
 
 ```kotlin
 // 1. Set up LoTE loading with file cache
-// HttpClient() auto-discovers the ktor-client-android engine at runtime
 val httpClient = HttpClient()
 val loadLoTE = LoadSingleLoTEWithFileCache(
     cacheDirectory = Path(context.cacheDir.path, "lote-cache"),
@@ -659,102 +748,37 @@ val loadLoTEAndPointers = LoadLoTEAndPointers(
 // 3. Build trust anchor provisioner with EU defaults
 val provisionTrustAnchors = ProvisionTrustAnchorsFromLoTEs.eudiwJvm(loadLoTEAndPointers)
 
-// 4. Configure LoTE URLs for the provider types you need
-val loteLocations = SupportedLists(
-    pidProviders = "https://trust.example.eu/pid-providers.jwt",
-    wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
-    // pubEaaProviders = "https://trust.example.eu/pub-eaa-providers.jwt",
-    // qeaProviders = "https://trust.example.eu/qeaa-providers.jwt",
-)
-
-// 5. Create cached trust validator
-// DisposableContainer manages the lifecycle of cached trust anchors.
-// Create it at Application scope and call dispose() when no longer needed.
+// 4. Create cached trust validator
 val disposableScope = DisposableContainer()
 val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
 
-// Use isChainTrusted for issuer trust, metadata verification, status resolution, and reader auth (see below)
+// 5. Pass to each area explicitly
+val config = EudiWalletConfig {
+    configureIssuerTrust {
+        trustSource(isChainTrusted)
+        classifications(myClassifications)
+        policy { default(TrustPolicy.Action.ENFORCE) }
+    }
+    configureDocumentStatusResolver {
+        clockSkew(5)
+        configureTrust {
+            trustSource(isChainTrusted)
+            classifications(myClassifications)
+        }
+    }
+    configureReaderTrustStore(isChainTrusted)
+}
 
-// When shutting down (e.g. Application.onTerminate()):
+// On shutdown:
 // disposableScope.dispose()
 ```
 
-> **VerifyJwtSignature:** The ETSI library requires a `VerifyJwtSignature` implementation to
-> verify the cryptographic signature of downloaded LoTE JWT documents before trusting their
-> contents. The signing keys vary by deployment (EU production, national lists, acceptance
-> environments). The library provides only a `NotValidating` test stub — **do not use it in
-> production**.
-
-The following example shows how to implement `VerifyJwtSignature` using Nimbus JWT to verify
-the LoTE JWT signature against a list of trusted signing certificates:
-
-```kotlin
-// Trusted certificates for LoTE JWT signature verification
-// (e.g., EU Commission's LoTE signing certificate)
-val loteTrustedCertificates: List<X509Certificate> = listOf(/* your trusted certs */)
-
-val myJwtVerifier = VerifyJwtSignature { jwt ->
-    try {
-        val signedJwt = SignedJWT.parse(jwt)
-
-        // Extract x5c certificate chain from JWT header
-        val x5cChain = signedJwt.header.x509CertChain
-            ?: return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
-                IllegalStateException("Missing x5c in LoTE JWT header")
-            )
-        val chainCerts = x5cChain.mapNotNull { X509CertUtils.parse(it.decode()) }
-        if (chainCerts.isEmpty()) {
-            return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
-                IllegalStateException("No valid certificates in x5c")
-            )
-        }
-
-        // Verify JWT signature using the signing certificate's public key
-        val signingCert = chainCerts.first()
-        val verifier = when (val key = signingCert.publicKey) {
-            is ECPublicKey -> ECDSAVerifier(key)
-            is RSAPublicKey -> RSASSAVerifier(key)
-            else -> return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
-                IllegalStateException("Unsupported key type: ${key.javaClass.name}")
-            )
-        }
-        if (!signedJwt.verify(verifier)) {
-            return@VerifyJwtSignature VerifyJwtSignature.Outcome.NotVerified(
-                IllegalStateException("JWT signature verification failed")
-            )
-        }
-
-        // Validate signing certificate against trusted certificates
-        // Try direct trust first (subject DN + serial number match)
-        val directlyTrusted = loteTrustedCertificates.any { trusted ->
-            trusted.subjectX500Principal == signingCert.subjectX500Principal &&
-                trusted.serialNumber == signingCert.serialNumber
-        }
-        if (directlyTrusted) {
-            return@VerifyJwtSignature VerifyJwtSignature.Outcome.Verified(jwt)
-        }
-
-        // Fall back to PKIX chain validation
-        val certPath = CertificateFactory.getInstance("X.509").generateCertPath(chainCerts)
-        val trustAnchors = loteTrustedCertificates.map { TrustAnchor(it, null) }.toSet()
-        val params = PKIXParameters(trustAnchors).apply { isRevocationEnabled = false }
-        CertPathValidator.getInstance("PKIX").validate(certPath, params)
-
-        VerifyJwtSignature.Outcome.Verified(jwt)
-    } catch (e: Exception) {
-        VerifyJwtSignature.Outcome.NotVerified(e)
-    }
-}
-```
->
-> **Lifecycle:** `DisposableContainer` replaces `useResources` for Android. While `useResources`
-> is a scoping block that disposes resources when the block exits (suitable for short-lived
-> operations), Android apps need long-lived trust caches. Create a `DisposableContainer` at
-> Application scope and call `dispose()` during shutdown to release cached resources.
+> **Lifecycle:** When building the pipeline manually, `DisposableContainer` manages cached
+> resources. Create it at Application scope and call `dispose()` during shutdown. When using
+> `configureEtsiTrust`, the core manages the lifecycle internally.
 >
 > **HTTP Client:** `HttpClient()` with no explicit engine auto-discovers `ktor-client-android` at
-> runtime (already included as a `runtimeOnly` dependency by wallet-core). You can also pass a
-> custom `HttpClient` if you need specific configuration (logging, timeouts, etc.).
+> runtime (already included as a `runtimeOnly` dependency by wallet-core).
 
 #### Issuer Trust Verification
 
@@ -763,14 +787,16 @@ Built-in verifiers handle both MsoMdoc and SD-JWT VC formats, and custom verifie
 registered for additional formats. When issuer trust is not configured, verification is skipped
 entirely and credentials are stored as before.
 
-Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWalletConfig`:
+Enable issuer trust verification via the `configureIssuerTrust` DSL on `EudiWalletConfig`.
+When `configureEtsiTrust` is also used, `trustSource()` and `classifications()` are inherited
+automatically — only policy and metadata settings are needed:
 
 ```kotlin
 val walletConfig = EudiWalletConfig {
-    // ... other configuration ...
+    configureEtsiTrust { /* ... */ }
+
     configureIssuerTrust {
-        trustSource(isChainTrusted) // from LoTE setup above
-        classifications(myClassifications) // AttestationClassifications from ETSI library
+        // trustSource() and classifications() inherited from configureEtsiTrust
         policy {
             default(TrustPolicy.Action.ENFORCE)
             forContext(VerificationContext.EAA("experimental"), TrustPolicy.Action.INFORM)
@@ -782,8 +808,19 @@ val walletConfig = EudiWalletConfig {
 }
 ```
 
+When not using `configureEtsiTrust`, provide the trust source explicitly:
+
+```kotlin
+configureIssuerTrust {
+    trustSource(isChainTrusted) // manually built IsChainTrustedForEUDIW
+    classifications(myClassifications) // AttestationClassifications from ETSI library
+    policy { default(TrustPolicy.Action.ENFORCE) }
+}
+```
+
 - **`trustSource`** -- sets the trust anchor source. Accepts a `ComposeChainTrust`,
   `IsChainTrustedForEUDIW`, or a pre-built `IsChainTrustedForAttestation`.
+  Optional when `configureEtsiTrust` is configured.
 - **`classifications`** -- required when using `ComposeChainTrust` or `IsChainTrustedForEUDIW`
   as the trust source. Maps credential types to verification contexts.
 - **`policy`** -- configures how the wallet acts on trust results (see below).
@@ -911,19 +948,36 @@ The document status resolver can optionally verify that the signer of status lis
 or CWT) is trusted according to ETSI trusted lists. This adds an additional layer of trust
 beyond the default cryptographic signature verification (x5c/COSE_X509).
 
-Configure status list trust within the `configureDocumentStatusResolver` DSL:
+Configure status list trust within the `configureDocumentStatusResolver` DSL. When
+`configureEtsiTrust` is used, the trust source and classifications are inherited — only
+clock skew and optional policy overrides are needed:
 
 ```kotlin
 val walletConfig = EudiWalletConfig {
+    configureEtsiTrust { /* ... */ }
+
     configureDocumentStatusResolver {
         clockSkew(5) // minutes
+        // Trust source and classifications inherited from configureEtsiTrust.
+        // Optionally override policy:
         configureTrust {
-            trustSource(isChainTrusted) // same LoTE trust source
-            classifications(myClassifications)
             policy {
                 default(TrustPolicy.Action.INFORM)
             }
         }
+    }
+}
+```
+
+When not using `configureEtsiTrust`, provide the trust source explicitly inside `configureTrust`:
+
+```kotlin
+configureDocumentStatusResolver {
+    clockSkew(5)
+    configureTrust {
+        trustSource(isChainTrusted) // manually built trust source
+        classifications(myClassifications)
+        policy { default(TrustPolicy.Action.INFORM) }
     }
 }
 ```
@@ -946,17 +1000,38 @@ signature verification without ETSI trust chain validation.
 reader certificate chain validation to the ETSI library's `IsChainTrustedForEUDIW`. It
 uses the `WalletRelyingPartyAccessCertificate` (WRPAC) verification context by default.
 
-Configure it via `configureReaderTrustStore` on `EudiWalletConfig`, alongside the other
-trust features:
+**Using centralized ETSI trust** (recommended): The DSL block inherits the trust source from
+`configureEtsiTrust` and allows setting the reader authentication policy in the same place:
+
+```kotlin
+val config = EudiWalletConfig {
+    configureEtsiTrust { /* ... */ }
+
+    configureReaderTrustStore {
+        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    }
+}
+```
+
+**Using a manually built trust source**: Pass `IsChainTrustedForEUDIW` directly. The reader
+auth policy is set separately via `configureReaderAuthPolicy()`:
 
 ```kotlin
 val config = EudiWalletConfig {
     configureReaderTrustStore(isChainTrusted)
+    configureReaderAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
 }
 ```
 
-This takes priority over certificate-based configuration. The legacy overloads that accept
-raw `X509Certificate` lists remain available for static trust anchors.
+**Using static certificates**: The overloads that accept `X509Certificate` lists remain
+available. The reader auth policy is also set separately:
+
+```kotlin
+val config = EudiWalletConfig {
+    configureReaderTrustStore(listOf(trustedCert1, trustedCert2))
+    configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+}
+```
 
 For advanced use cases requiring a specific verification context, create an
 `EtsiReaderTrustStore` explicitly:
@@ -986,26 +1061,9 @@ wallet.setReaderTrustStore(EtsiReaderTrustStore(isChainTrusted))
 
 The following example shows a complete `EudiWallet` setup with issuer trust verification,
 signed metadata verification, revocation status trust, and reader authentication — all
-using the same ETSI trust source:
+using `configureEtsiTrust` to centralize the shared LoTE infrastructure:
 
 ```kotlin
-// Application-scoped — create once, dispose on shutdown
-val disposableScope = DisposableContainer()
-val isChainTrusted = provisionTrustAnchors.cached(disposableScope, loteLocations, ttl = 10.minutes)
-
-// Attestation classifications map credential types to ETSI verification contexts
-val classifications = AttestationClassifications(
-    pids = AttestationIdentifierPredicate.any(
-        setOf(
-            AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
-            AttestationIdentifier.SDJwtVc("urn:eudi:pid:1"),
-        )
-    ),
-    pubEAAs = AttestationIdentifierPredicate.equalsTo(
-        AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
-    ),
-)
-
 val config = EudiWalletConfig {
     configureOpenId4Vci {
         withIssuerUrl("https://issuer.example.com")
@@ -1017,34 +1075,44 @@ val config = EudiWalletConfig {
         withSchemes("openid4vp", "eudi-openid4vp", "mdoc-openid4vp")
     }
 
-    // Issuer trust verification (credential issuance)
+    // Centralized ETSI trust — builds the full LoTE pipeline internally
+    configureEtsiTrust {
+        loteLocations(SupportedLists(
+            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
+            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
+        ))
+        classifications(AttestationClassifications(
+            pids = AttestationIdentifierPredicate.any(setOf(
+                AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+                AttestationIdentifier.SDJwtVc("urn:eudi:pid:1"),
+            )),
+            pubEAAs = AttestationIdentifierPredicate.equalsTo(
+                AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+            ),
+        ))
+        // DEV/testing relaxations (omit in production):
+        // relaxCertificateProfiles()
+        // relaxPkixRevocation()
+    }
+
+    // Issuer trust — trust source + classifications inherited from configureEtsiTrust
     // Signed metadata verification defaults to RequireSigned
     configureIssuerTrust {
-        trustSource(isChainTrusted)
-        classifications(classifications)
         policy {
             default(TrustPolicy.Action.ENFORCE)
         }
     }
 
-    // Revocation status trust verification
+    // Revocation status trust — trust source + classifications inherited
     configureDocumentStatusResolver {
         clockSkew(5)
-        configureTrust {
-            trustSource(isChainTrusted)
-            classifications(classifications)
-            policy {
-                default(TrustPolicy.Action.INFORM)
-            }
-        }
     }
 
-    // Reader authentication with ETSI trusted lists (same trust source)
-    configureReaderTrustStore(isChainTrusted)
+    // Reader authentication — trust source inherited, policy set inline
+    configureReaderTrustStore {
+        readerAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+    }
 }
-
-// On shutdown:
-// disposableScope.dispose()
 ```
 
 ### Issue document using OpenID4VCI

--- a/README.md
+++ b/README.md
@@ -647,16 +647,19 @@ library directly (or any other trust framework).
 
 #### Dependencies
 
-Both ETSI consultation modules are exposed as `api` dependencies from wallet-core, so
-consumers can reference their types directly:
+The `etsi-1196x2-consultation` module is exposed as an `api` dependency from wallet-core,
+so consumers can reference its types directly (`SupportedLists`, `AttestationClassifications`,
+`IsChainTrustedForEUDIW`, etc.).
 
-- `etsi-1196x2-consultation` — base consultation types (`SupportedLists`, `AttestationClassifications`, `IsChainTrustedForEUDIW`, etc.)
-- `etsi-119602-consultation` — `Uri` type used in `configureEtsiTrust` DSL
+The `etsi-119602-consultation` module (which provides the `Uri` type used in `configureEtsiTrust`
+DSL) is **not** transitively available due to an upstream packaging issue. Consumers must
+declare it explicitly:
 
 ```groovy
 dependencies {
-    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0-SNAPSHOT"
-    // Both ETSI modules are available transitively — no additional dependency needed
+    implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.29.0-SNAPSHOT"
+    // Required explicitly — Uri type is not transitive from wallet-core
+    implementation "eu.europa.ec.eudi:eudi-lib-kmp-etsi-119602-consultation:${VERSION}"
 }
 ```
 
@@ -711,10 +714,13 @@ val config = EudiWalletConfig {
 }
 ```
 
-> **JWT Signature Verification:** The core includes a built-in `VerifyJwtSignature`
-> implementation that extracts the `x5c` certificate chain from the LoTE JWT header and
-> verifies the signature using the leaf certificate's public key (EC and RSA supported).
-> To override this, pass a custom verifier via `jwtSignatureVerifier()`.
+> **LoTE JWT Verification:** The built-in `LoteJwtVerifier` only performs **cryptographic
+> signature verification** — it extracts the `x5c` chain from the JWT header and verifies
+> the JWS signature using the leaf certificate's public key (EC and RSA supported). It does
+> **not** perform certificate chain validation (PKIX), CRL/OCSP revocation checking, or
+> certificate profile constraint checks on the signing certificate. These additional trust
+> checks will be added in a future release. To provide a custom implementation with
+> thorough verification, pass it via `jwtSignatureVerifier()`.
 >
 > **DEV/Testing knobs:** `relaxCertificateProfiles()` strips `endEntityProfile` constraints
 > from all provider types, useful when DEV certificates don't fully conform to ETSI profile

--- a/README.md
+++ b/README.md
@@ -647,18 +647,17 @@ library directly (or any other trust framework).
 
 #### Dependencies
 
-The `etsi-1196x2-consultation` module is exposed as an `api` dependency from wallet-core. The
-`etsi-119602-consultation` module is bundled as `implementation` (not transitive) — consumers
-that need its types (e.g., `Uri`, `VerifyJwtSignature`) must declare it explicitly:
-
-- `etsi-1196x2-consultation` — base consultation types (`SupportedLists`, `AttestationClassifications`, `IsChainTrustedForEUDIW`, etc.) — transitive via wallet-core
-- `etsi-119602-consultation` — LoTE loading infrastructure (`Uri`, `VerifyJwtSignature`, `LoadLoTEAndPointers.Constraints`) — **must be declared by consumer**
+The `etsi-1196x2-consultation` module is exposed as an `api` dependency from wallet-core, so
+consumers can reference its types (e.g., `SupportedLists`, `AttestationClassifications`) directly.
+The `etsi-119602-consultation` module is bundled internally as `implementation` — consumers do
+**not** need to declare it. The `configureEtsiTrust` DSL accepts plain strings for LoTE URLs,
+avoiding any dependency on `etsi-119602` types in consumer code.
 
 ```groovy
 dependencies {
     implementation "eu.europa.ec.eudi:eudi-lib-android-wallet-core:0.26.0-SNAPSHOT"
-    // Required for configureEtsiTrust DSL types (Uri, etc.)
-    implementation "eu.europa.ec.eudi:etsi-119602-consultation:0.3.0-alpha.5"
+    // etsi-1196x2-consultation types (SupportedLists, AttestationClassifications, etc.)
+    // are available transitively — no additional ETSI dependency needed
 }
 ```
 
@@ -674,9 +673,9 @@ val config = EudiWalletConfig {
     configureEtsiTrust {
         // Required: LoTE download URLs
         loteLocations(SupportedLists(
-            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
-            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
-            // pubEaaProviders = Uri("https://trust.example.eu/pub-eaa-providers.jwt"),
+            pidProviders = "https://trust.example.eu/pid-providers.jwt",
+            wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
+            // pubEaaProviders = "https://trust.example.eu/pub-eaa-providers.jwt",
         ))
 
         // Required: map credential types to ETSI verification contexts
@@ -1078,8 +1077,8 @@ val config = EudiWalletConfig {
     // Centralized ETSI trust — builds the full LoTE pipeline internally
     configureEtsiTrust {
         loteLocations(SupportedLists(
-            pidProviders = Uri("https://trust.example.eu/pid-providers.jwt"),
-            wrpacProviders = Uri("https://trust.example.eu/wrpac-providers.jwt"),
+            pidProviders = "https://trust.example.eu/pid-providers.jwt",
+            wrpacProviders = "https://trust.example.eu/wrpac-providers.jwt",
         ))
         classifications(AttestationClassifications(
             pids = AttestationIdentifierPredicate.any(setOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.1"
 androidx-credentials = "1.6.0"
 androidx-credentials-registry = "1.0.0-alpha04"
 appcompat = "1.7.1"
@@ -65,6 +65,7 @@ eudi-lib-jvm-openid4vci-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-openid4v
 eudi-lib-jvm-siop-openid4vp-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-openid4vp-kt", version.ref = "eudi-lib-jvm-openid4vp-kt" }
 eudi-lib-jvm-sdjwt-kt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-sdjwt-kt", version.ref = "eudi-lib-jvm-sdjwt-kt" }
 eudi-lib-kmp-etsi1196x2-consultation = { module = "eu.europa.ec.eudi:etsi-1196x2-consultation", version.ref = "eudi-lib-kmp-etsi1196x2" }
+eudi-lib-kmp-etsi119602-consultation = { module = "eu.europa.ec.eudi:etsi-119602-consultation", version.ref = "eudi-lib-kmp-etsi1196x2" }
 eudi-lib-kmp-statium = { module = "eu.europa.ec.eudi:eudi-lib-kmp-statium-android", version.ref = "eudi-lib-kmp-statium" }
 json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ test-runner = "1.6.2"
 testng = "7.11.0"
 upokecenter-cbor = "4.5.6"
 zxing-core = "3.5.3"
-eudi-lib-kmp-etsi1196x2="0.3.0-alpha.5"
+eudi-lib-kmp-etsi1196x2="0.4.0-alpha.1-SNAPSHOT"
 
 [libraries]
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidx-credentials" }

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 
     // ETSI Trusted Lists
     api(libs.eudi.lib.kmp.etsi1196x2.consultation)
+    implementation(libs.eudi.lib.kmp.etsi119602.consultation)
 
     // Digital Credential API
     implementation(libs.androidx.credentials)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -44,6 +44,10 @@ import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
 import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolver
 import eu.europa.ec.eudi.wallet.transactionLogging.TransactionLogger
 import eu.europa.ec.eudi.wallet.trust.EtsiReaderTrustStore
+import eu.europa.ec.eudi.wallet.trust.EtsiTrustProvider
+import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
+import eu.europa.ec.eudi.wallet.trust.asReaderTrustStore
+import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolverConfigBuilder
 import eu.europa.ec.eudi.wallet.transactionLogging.presentation.TransactionsDecorator
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpManager
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.dcql.DcqlRequestProcessor
@@ -362,6 +366,25 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
             ensureStrongBoxIsSupported(loggerToUse)
             ensureUserAuthIsSupported(loggerToUse)
 
+            // Build ETSI trust provider if configured
+            val etsiTrustProvider = config.etsiTrustConfig?.let {
+                EtsiTrustProvider(config = it, context = context, logger = loggerToUse)
+            }
+            val etsiSource = etsiTrustProvider?.isChainTrusted
+            val etsiClassifications = config.etsiTrustConfig?.classifications
+
+            // Resolve deferred issuer trust config
+            config.issuerTrustConfig = config.issuerTrustBlock?.let { block ->
+                IssuerTrustConfigBuilder().apply(block).build(etsiSource, etsiClassifications)
+            }
+
+            // Resolve deferred status resolver config
+            config.statusResolverBlock?.let { block ->
+                val builder = DocumentStatusResolverConfigBuilder().apply(block)
+                config.documentStatusResolverClockSkew = builder.clockSkew
+                config.statusListTrustConfig = builder.buildTrustConfig(etsiSource, etsiClassifications)
+            }
+
             // Create shared issuance metadata storage (used by both the wrapper and OpenId4VciManager)
             val issuanceMetadataStorage = config.openId4VciConfig?.issuanceMetadataStorage ?: run {
                 val storagePath = File(
@@ -390,7 +413,14 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                         } else manager
                     }
 
-            val readerTrustStoreToUse = (readerTrustStore ?: defaultReaderTrustStore)?.also {
+            val readerTrustStoreToUse = (readerTrustStore
+                ?: config.readerTrustStore
+                ?: if (config.useEtsiReaderTrust && etsiSource != null) {
+                    etsiSource.asReaderTrustStore()
+                } else null
+                ?: config.readerTrustedCertificates?.let { certificates ->
+                    ReaderTrustStoreImpl(certificates, profileValidation = { _, _ -> true })
+                })?.also {
                 if (it is EtsiReaderTrustStore) it.logger = loggerToUse
             }
 
@@ -475,18 +505,6 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                 context.noBackupFilesDir.path,
                 "${config.documentManagerIdentifier}.db"
             ).absolutePath
-
-        /**
-         * Get the default [ReaderTrustStore] instance based on the configuration.
-         * A custom [ReaderTrustStore] set via [EudiWalletConfig.configureReaderTrustStore]
-         * takes priority over certificate-based configuration.
-         * @return the default [ReaderTrustStore] instance
-         */
-        @get:JvmSynthetic
-        internal val defaultReaderTrustStore: ReaderTrustStore?
-            get() = config.readerTrustStore ?: config.readerTrustedCertificates?.let { certificates ->
-                ReaderTrustStoreImpl(certificates, profileValidation = { _, _ -> true })
-            }
 
         /**
          * Get the default [Storage] instance based on the configuration

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -375,7 +375,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
             // Resolve deferred issuer trust config
             config.issuerTrustConfig = config.issuerTrustBlock?.let { block ->
-                IssuerTrustConfigBuilder().apply(block).build(etsiSource, etsiClassifications)
+                IssuerTrustConfigBuilder().apply(block).build(etsiSource, etsiClassifications, loggerToUse)
             }
 
             // Resolve deferred status resolver config

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -368,7 +368,12 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
             // Build ETSI trust provider if configured
             val etsiTrustProvider = config.etsiTrustConfig?.let {
-                EtsiTrustProvider(config = it, context = context, logger = loggerToUse)
+                EtsiTrustProvider(
+                    config = it,
+                    context = context,
+                    logger = loggerToUse,
+                    ktorHttpClientFactory = ktorHttpClientFactory,
+                )
             }
             val etsiSource = etsiTrustProvider?.isChainTrusted
             val etsiClassifications = config.etsiTrustConfig?.classifications

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -31,6 +31,8 @@ import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpConfig
 import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolverConfigBuilder
+import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfig
+import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
@@ -397,6 +399,23 @@ class EudiWalletConfig {
         this.readerTrustStore = isChainTrusted.asReaderTrustStore()
     }
 
+    internal var useEtsiReaderTrust: Boolean = false
+        private set
+
+    /**
+     * Configure the [ReaderTrustStore] using the ETSI trust source from [configureEtsiTrust].
+     *
+     * Creates an [eu.europa.ec.eudi.wallet.trust.EtsiReaderTrustStore] that delegates
+     * reader certificate chain validation to the centrally configured ETSI trust source.
+     * Requires [configureEtsiTrust] to be called.
+     *
+     * @return the [EudiWalletConfig] instance
+     * @see configureEtsiTrust
+     */
+    fun configureReaderTrustStore() = apply {
+        this.useEtsiReaderTrust = true
+    }
+
     /**
      * The reader authentication enforcement policy for proximity and DCAPI presentations.
      * This determines how the wallet handles reader authentication results when generating
@@ -485,9 +504,12 @@ class EudiWalletConfig {
     }
 
     var documentStatusResolverClockSkew: Duration = Duration.ZERO
-        private set
+        internal set
 
     internal var statusListTrustConfig: StatusListTrustConfig? = null
+        internal set
+
+    internal var statusResolverBlock: (DocumentStatusResolverConfigBuilder.() -> Unit)? = null
         private set
 
     /**
@@ -501,6 +523,10 @@ class EudiWalletConfig {
     /**
      * Configure the document status resolver with clock skew and optional ETSI trust verification
      * for status list token signers.
+     *
+     * When [configureEtsiTrust] is also called, `trustSource()` and `classifications()` inside
+     * the `configureTrust` block are optional — they default to the centrally configured
+     * ETSI trust source. Explicit calls override the defaults.
      *
      * Example:
      * ```
@@ -519,13 +545,12 @@ class EudiWalletConfig {
      * @param block configuration block applied to the [DocumentStatusResolverConfigBuilder]
      * @return the [EudiWalletConfig] instance
      * @see DocumentStatusResolverConfigBuilder
+     * @see configureEtsiTrust
      */
     fun configureDocumentStatusResolver(
         block: DocumentStatusResolverConfigBuilder.() -> Unit,
     ) = apply {
-        val builder = DocumentStatusResolverConfigBuilder().apply(block)
-        this.documentStatusResolverClockSkew = builder.clockSkew
-        this.statusListTrustConfig = builder.buildTrustConfig()
+        this.statusResolverBlock = block
     }
 
     var zkSystemRepository: ZkSystemRepository? = null
@@ -542,6 +567,9 @@ class EudiWalletConfig {
     }
 
     internal var issuerTrustConfig: IssuerTrustConfig? = null
+        internal set
+
+    internal var issuerTrustBlock: (IssuerTrustConfigBuilder.() -> Unit)? = null
         private set
 
     /**
@@ -549,14 +577,67 @@ class EudiWalletConfig {
      * Trust verification occurs after issuance, before storage. When not configured,
      * trust verification is skipped entirely.
      *
+     * When [configureEtsiTrust] is also called, `trustSource()` and `classifications()`
+     * are optional — they default to the centrally configured ETSI trust source.
+     * Explicit calls override the defaults.
+     *
      * @param block configuration block applied to the [IssuerTrustConfigBuilder]
      * @return the [EudiWalletConfig] instance
      * @see IssuerTrustConfigBuilder
+     * @see configureEtsiTrust
      */
     fun configureIssuerTrust(
         block: IssuerTrustConfigBuilder.() -> Unit,
     ) = apply {
-        this.issuerTrustConfig = IssuerTrustConfigBuilder().apply(block).build()
+        this.issuerTrustBlock = block
+    }
+
+    internal var etsiTrustConfig: EtsiTrustConfig? = null
+        private set
+
+    /**
+     * Configure the ETSI LoTE (List of Trusted Entities) trust infrastructure.
+     *
+     * This centralizes the trust source configuration so it can be shared across all
+     * trust verification areas (issuer trust, status list trust, reader authentication).
+     * The core builds the underlying trust pipeline internally from the provided parameters.
+     *
+     * When this is configured, [configureIssuerTrust], [configureDocumentStatusResolver],
+     * and [configureReaderTrustStore] no longer require explicit `trustSource()` and
+     * `classifications()` calls — they default to the central ETSI trust source.
+     *
+     * Each trust area still needs to be explicitly enabled via its own `configure*` call.
+     *
+     * Example:
+     * ```
+     * configureEtsiTrust {
+     *     loteLocations(SupportedLists(
+     *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
+     *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
+     *     ))
+     *     classifications(AttestationClassifications(
+     *         pids = AttestationIdentifierPredicate.any(setOf(
+     *             AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+     *         )),
+     *     ))
+     *     // Optional:
+     *     relaxCertificateProfiles()
+     * }
+     * configureIssuerTrust {
+     *     policy { default(TrustPolicy.Action.INFORM) }
+     * }
+     * configureDocumentStatusResolver { }
+     * configureReaderTrustStore()
+     * ```
+     *
+     * @param block configuration block applied to the [EtsiTrustConfigBuilder]
+     * @return the [EudiWalletConfig] instance
+     * @see EtsiTrustConfigBuilder
+     */
+    fun configureEtsiTrust(
+        block: EtsiTrustConfigBuilder.() -> Unit,
+    ) = apply {
+        this.etsiTrustConfig = EtsiTrustConfigBuilder().apply(block).build()
     }
 
     companion object {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -672,8 +672,8 @@ class EudiWalletConfig {
      * ```
      * configureEtsiTrust {
      *     loteLocations(SupportedLists(
-     *         pidProviders = "https://trustedlist.../PIDProviders.jwt",
-     *         wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
+     *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
+     *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
      *     ))
      *     classifications(AttestationClassifications(
      *         pids = AttestationIdentifierPredicate.any(setOf(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -672,8 +672,8 @@ class EudiWalletConfig {
      * ```
      * configureEtsiTrust {
      *     loteLocations(SupportedLists(
-     *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
-     *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
+     *         pidProviders = "https://trustedlist.../PIDProviders.jwt",
+     *         wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
      *     ))
      *     classifications(AttestationClassifications(
      *         pids = AttestationIdentifierPredicate.any(setOf(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -35,6 +35,7 @@ import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfig
 import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
+import eu.europa.ec.eudi.wallet.trust.ReaderTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import eu.europa.ec.eudi.wallet.trust.asReaderTrustStore
 import java.security.cert.TrustAnchor
@@ -334,8 +335,12 @@ class EudiWalletConfig {
         private set
 
     /**
-     * Configure the built-in [ReaderTrustStore]. This allows to set the reader trusted
-     * certificates for the reader trust store.
+     * Configure the built-in [ReaderTrustStore] with a list of trusted certificates.
+     *
+     * Example:
+     * ```
+     * configureReaderTrustStore(listOf(certificate1, certificate2))
+     * ```
      *
      * @param readerTrustedCertificates the reader trusted certificates
      * @return the [EudiWalletConfig] instance
@@ -345,8 +350,12 @@ class EudiWalletConfig {
     }
 
     /**
-     * Configure the built-in [ReaderTrustStore]. This allows to set the reader trusted
-     * certificates for the reader trust store.
+     * Configure the built-in [ReaderTrustStore] with trusted certificates.
+     *
+     * Example:
+     * ```
+     * configureReaderTrustStore(certificate1, certificate2)
+     * ```
      *
      * @param readerTrustedCertificates the reader trusted certificates
      * @return the [EudiWalletConfig] instance
@@ -356,9 +365,12 @@ class EudiWalletConfig {
     }
 
     /**
-     * Configure the built-in [ReaderTrustStore].
-     * This allows to set the reader trusted certificates for the reader trust store.
-     * The certificates are loaded from the raw resources.
+     * Configure the built-in [ReaderTrustStore] with certificates loaded from raw resources.
+     *
+     * Example:
+     * ```
+     * configureReaderTrustStore(context, R.raw.reader_cert_1, R.raw.reader_cert_2)
+     * ```
      *
      * @param context the context
      * @param certificateRes the reader trusted certificates raw resources
@@ -390,6 +402,12 @@ class EudiWalletConfig {
      * [VerificationContext.WalletRelyingPartyAccessCertificate][eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext.WalletRelyingPartyAccessCertificate]
      * verification context. This takes priority over certificate-based configuration.
      *
+     * Example:
+     * ```
+     * val composeChainTrust: IsChainTrustedForEUDIW<...> = // from ETSI library
+     * configureReaderTrustStore(composeChainTrust)
+     * ```
+     *
      * @param isChainTrusted the ETSI chain trust validator
      * @return the [EudiWalletConfig] instance
      */
@@ -409,11 +427,30 @@ class EudiWalletConfig {
      * reader certificate chain validation to the centrally configured ETSI trust source.
      * Requires [configureEtsiTrust] to be called.
      *
+     * Example with default policy ([ReaderAuthPolicy.EnforceIfPresent]):
+     * ```
+     * configureReaderTrustStore { }
+     * ```
+     *
+     * Example requiring reader authentication for all presentations:
+     * ```
+     * configureReaderTrustStore {
+     *     readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+     * }
+     * ```
+     *
+     * @param block configuration block applied to the [ReaderTrustConfigBuilder]
      * @return the [EudiWalletConfig] instance
      * @see configureEtsiTrust
+     * @see ReaderTrustConfigBuilder
+     * @see ReaderAuthPolicy
      */
-    fun configureReaderTrustStore() = apply {
+    fun configureReaderTrustStore(
+        block: ReaderTrustConfigBuilder.() -> Unit,
+    ) = apply {
         this.useEtsiReaderTrust = true
+        val builder = ReaderTrustConfigBuilder().apply(block)
+        builder.readerAuthPolicy?.let { this.readerAuthPolicy = it }
     }
 
     /**
@@ -580,6 +617,29 @@ class EudiWalletConfig {
      * When [configureEtsiTrust] is also called, `trustSource()` and `classifications()`
      * are optional — they default to the centrally configured ETSI trust source.
      * Explicit calls override the defaults.
+     *
+     * Example with [configureEtsiTrust] (trust source inherited):
+     * ```
+     * configureIssuerTrust {
+     *     policy {
+     *         default(TrustPolicy.Action.ENFORCE)
+     *     }
+     *     // requireSignedMetadata() is the default — verifies signed issuer metadata JWTs
+     *     // ignoreSignedMetadata() to skip metadata signature checks
+     * }
+     * ```
+     *
+     * Example with explicit trust source:
+     * ```
+     * configureIssuerTrust {
+     *     trustSource(myComposeChainTrust)
+     *     classifications(myClassifications)
+     *     policy {
+     *         default(TrustPolicy.Action.INFORM)
+     *         forContext(VerificationContext.PID, TrustPolicy.Action.ENFORCE)
+     *     }
+     * }
+     * ```
      *
      * @param block configuration block applied to the [IssuerTrustConfigBuilder]
      * @return the [EudiWalletConfig] instance

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
@@ -256,8 +256,6 @@ class DocumentStatusResolverImpl(
             logger?.d(TAG, "resolveStatus: result=$status")
             status
         }
-    }.also {result ->
-        logger?.d(TAG, "resolveStatus: also=$result")
     }
 
         private fun withJwtVerifier(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolver.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
 import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import io.ktor.client.HttpClient
@@ -255,9 +256,11 @@ class DocumentStatusResolverImpl(
             logger?.d(TAG, "resolveStatus: result=$status")
             status
         }
+    }.also {result ->
+        logger?.d(TAG, "resolveStatus: also=$result")
     }
 
-    private fun withJwtVerifier(
+        private fun withJwtVerifier(
         verifier: VerifyStatusListTokenJwtSignature,
         format: SdJwtVcFormat,
     ): VerifyStatusListTokenJwtSignature {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/DocumentStatusResolverConfigBuilder.kt
@@ -15,8 +15,12 @@
  */
 package eu.europa.ec.eudi.wallet.statium
 
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfigBuilder
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -75,5 +79,30 @@ class DocumentStatusResolverConfigBuilder {
      */
     internal fun buildTrustConfig(): StatusListTrustConfig? {
         return trustConfigBuilder?.build()
+    }
+
+    /**
+     * Builds the [StatusListTrustConfig], using the provided defaults for trust source and
+     * classifications when they have not been explicitly set inside [configureTrust].
+     *
+     * When [configureTrust] was not called but ETSI defaults are available, a default
+     * [StatusListTrustConfig] is created automatically using the provided defaults.
+     *
+     * @param defaultSource default EUDIW trust source from [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureEtsiTrust]
+     * @param defaultClassifications default classifications from [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureEtsiTrust]
+     * @return the built [StatusListTrustConfig], or null if no trust source is available
+     */
+    internal fun buildTrustConfig(
+        defaultSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>?,
+        defaultClassifications: AttestationClassifications?,
+    ): StatusListTrustConfig? {
+        return if (trustConfigBuilder != null) {
+            trustConfigBuilder!!.build(defaultSource, defaultClassifications)
+        } else if (defaultSource != null && defaultClassifications != null) {
+            // Auto-create with ETSI defaults when configureTrust was not called
+            StatusListTrustConfigBuilder().build(defaultSource, defaultClassifications)
+        } else {
+            null
+        }
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/StatusListNotTrustedException.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/StatusListNotTrustedException.kt
@@ -20,8 +20,9 @@ package eu.europa.ec.eudi.wallet.statium
  * [trust policy][eu.europa.ec.eudi.wallet.trust.TrustPolicy] action is
  * [ENFORCE][eu.europa.ec.eudi.wallet.trust.TrustPolicy.Action.ENFORCE].
  *
- * @param cause the underlying cause from the trust evaluation
+ * @param message description of the trust failure
+ * @param cause the underlying cause from the trust evaluation, if available
  */
-class StatusListNotTrustedException(cause: Throwable) : Exception(
-    "Status list token signer certificate chain is not trusted", cause
+class StatusListNotTrustedException(message: String, cause: Throwable? = null) : Exception(
+    message, cause
 )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
@@ -62,19 +62,19 @@ internal class TrustEvaluatingCwtSignatureVerifier(
         val certs = extractX5cFromCwt(statusListToken)
         logger?.d(TAG, "CWT: x5chain has ${certs.size} certs, leaf=${certs.firstOrNull()?.subjectX500Principal}")
 
-        // Evaluate trust via ETSI
+        // Evaluate trust via ETSI (revocation context for status list tokens)
         val trustResult = trustConfig.isChainTrustedForAttestation
-            .issuance(certs, attestationIdentifier)
+            .revocation(certs, attestationIdentifier)
         logger?.d(TAG, "CWT: trustResult=$trustResult for attestation=$attestationIdentifier")
 
         // Resolve verification context from classifications
         val verificationContext = trustConfig.classifications
             ?.classify(attestationIdentifier)
             ?.fold(
-                ifPid = VerificationContext.PID,
-                ifPubEaa = VerificationContext.PubEAA,
-                ifQEaa = VerificationContext.QEAA,
-                ifEaa = { useCase -> VerificationContext.EAA(useCase) },
+                ifPid = VerificationContext.PIDStatus,
+                ifPubEaa = VerificationContext.PubEAAStatus,
+                ifQEaa = VerificationContext.QEAAStatus,
+                ifEaa = { useCase -> VerificationContext.EAAStatus(useCase) },
             )
         logger?.d(TAG, "CWT: verificationContext=$verificationContext")
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingCwtSignatureVerifier.kt
@@ -81,9 +81,23 @@ internal class TrustEvaluatingCwtSignatureVerifier(
         // Apply policy
         val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
         logger?.d(TAG, "CWT: policy action=$action")
-        if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
-            logger?.e(TAG, "CWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
-            throw StatusListNotTrustedException(trustResult.cause)
+        if (action == TrustPolicy.Action.ENFORCE) {
+            when {
+                trustResult == null -> {
+                    logger?.e(TAG, "CWT: ENFORCE + null trustResult → throwing")
+                    throw StatusListNotTrustedException(
+                        "No trust anchors available for attestation=$attestationIdentifier " +
+                            "(verificationContext=$verificationContext)"
+                    )
+                }
+                trustResult is CertificationChainValidation.NotTrusted -> {
+                    logger?.e(TAG, "CWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
+                    throw StatusListNotTrustedException(
+                        "Status list token signer certificate chain is not trusted",
+                        trustResult.cause,
+                    )
+                }
+            }
         }
     }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
@@ -57,19 +57,19 @@ internal class TrustEvaluatingJwtSignatureVerifier(
         val certs = extractX5cFromJwt(statusListToken)
         logger?.d(TAG, "JWT: x5c chain has ${certs.size} certs, leaf=${certs.firstOrNull()?.subjectX500Principal}")
 
-        // Evaluate trust via ETSI
+        // Evaluate trust via ETSI (revocation context for status list tokens)
         val trustResult = trustConfig.isChainTrustedForAttestation
-            .issuance(certs, attestationIdentifier)
+            .revocation(certs, attestationIdentifier)
         logger?.d(TAG, "JWT: trustResult=$trustResult for attestation=$attestationIdentifier")
 
         // Resolve verification context from classifications
         val verificationContext = trustConfig.classifications
             ?.classify(attestationIdentifier)
             ?.fold(
-                ifPid = VerificationContext.PID,
-                ifPubEaa = VerificationContext.PubEAA,
-                ifQEaa = VerificationContext.QEAA,
-                ifEaa = { useCase -> VerificationContext.EAA(useCase) },
+                ifPid = VerificationContext.PIDStatus,
+                ifPubEaa = VerificationContext.PubEAAStatus,
+                ifQEaa = VerificationContext.QEAAStatus,
+                ifEaa = { useCase -> VerificationContext.EAAStatus(useCase) },
             )
         logger?.d(TAG, "JWT: verificationContext=$verificationContext")
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/statium/TrustEvaluatingJwtSignatureVerifier.kt
@@ -76,9 +76,23 @@ internal class TrustEvaluatingJwtSignatureVerifier(
         // Apply policy
         val action = trustConfig.trustPolicy.resolve(attestationIdentifier, verificationContext)
         logger?.d(TAG, "JWT: policy action=$action")
-        if (action == TrustPolicy.Action.ENFORCE && trustResult is CertificationChainValidation.NotTrusted) {
-            logger?.e(TAG, "JWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
-            throw StatusListNotTrustedException(trustResult.cause)
+        if (action == TrustPolicy.Action.ENFORCE) {
+            when {
+                trustResult == null -> {
+                    logger?.e(TAG, "JWT: ENFORCE + null trustResult → throwing")
+                    throw StatusListNotTrustedException(
+                        "No trust anchors available for attestation=$attestationIdentifier " +
+                            "(verificationContext=$verificationContext)"
+                    )
+                }
+                trustResult is CertificationChainValidation.NotTrusted -> {
+                    logger?.e(TAG, "JWT: ENFORCE + NotTrusted → throwing", trustResult.cause)
+                    throw StatusListNotTrustedException(
+                        "Status list token signer certificate chain is not trusted",
+                        trustResult.cause,
+                    )
+                }
+            }
         }
     }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiReaderTrustStore.kt
@@ -33,14 +33,14 @@ import kotlin.coroutines.CoroutineContext
  *
  * Delegates reader certificate chain validation to the ETSI library's
  * [IsChainTrustedForEUDIW], enabling dynamic trust anchor resolution
- * from LoTE (ETSI TS 119 602) and/or LOTL (ETSI TS 119 612).
+ * from LoTE (ETSI TS 119 602)
  *
  * This is a drop-in replacement for
  * [eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl] — configure it
  * via [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureReaderTrustStore] or
  * [eu.europa.ec.eudi.wallet.EudiWallet.setReaderTrustStore].
  *
- * @param isChainTrusted the ETSI chain trust validator (supports LoTE, LOTL, or combined sources)
+ * @param isChainTrusted the ETSI chain trust validator (supports LoTE, or combined sources)
  * @param verificationContext the EUDI verification context for reader authentication
  *        (defaults to [VerificationContext.WalletRelyingPartyAccessCertificate])
  * @param coroutineContext the coroutine context for the sync/async bridge

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
@@ -69,8 +69,8 @@ data class EtsiTrustConfig(
  * ```
  * configureEtsiTrust {
  *     loteLocations(SupportedLists(
- *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
- *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
+ *         pidProviders = "https://trustedlist.../PIDProviders.jwt",
+ *         wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
  *     ))
  *     classifications(AttestationClassifications(
  *         pids = AttestationIdentifierPredicate.any(setOf(
@@ -86,7 +86,7 @@ data class EtsiTrustConfig(
  */
 class EtsiTrustConfigBuilder {
 
-    private var loteLocations: SupportedLists<Uri>? = null
+    private var loteLocations: SupportedLists<String>? = null
     private var classifications: AttestationClassifications? = null
     private var fileCacheExpiration: Duration = EtsiTrustConfig.DEFAULT_FILE_CACHE_EXPIRATION
     private var cacheTtl: Duration = EtsiTrustConfig.DEFAULT_CACHE_TTL
@@ -97,11 +97,19 @@ class EtsiTrustConfigBuilder {
         LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers
 
     /**
-     * Sets the LoTE download locations.
+     * Sets the LoTE download locations as string URLs.
      *
-     * @param locations the supported lists with LoTE URLs
+     * Example:
+     * ```
+     * loteLocations(SupportedLists(
+     *     pidProviders = "https://trustedlist.../PIDProviders.jwt",
+     *     wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
+     * ))
+     * ```
+     *
+     * @param locations the supported lists with LoTE URL strings
      */
-    fun loteLocations(locations: SupportedLists<Uri>) {
+    fun loteLocations(locations: SupportedLists<String>) {
         this.loteLocations = locations
     }
 
@@ -189,7 +197,7 @@ class EtsiTrustConfigBuilder {
             "classifications must be provided via classifications()"
         }
         return EtsiTrustConfig(
-            loteLocations = locations,
+            loteLocations = locations.toUri(),
             classifications = cls,
             fileCacheExpiration = fileCacheExpiration,
             cacheTtl = cacheTtl,
@@ -197,6 +205,18 @@ class EtsiTrustConfigBuilder {
             relaxPkixRevocation = relaxPkixRevocation,
             customJwtSignatureVerifier = customJwtSignatureVerifier,
             loteConstraints = loteConstraints,
+        )
+    }
+
+    private companion object {
+        fun SupportedLists<String>.toUri() = SupportedLists(
+            pidProviders = pidProviders?.let(::Uri),
+            walletProviders = walletProviders?.let(::Uri),
+            wrpacProviders = wrpacProviders?.let(::Uri),
+            wrprcProviders = wrprcProviders?.let(::Uri),
+            pubEaaProviders = pubEaaProviders?.let(::Uri),
+            qeaProviders = qeaProviders?.let(::Uri),
+            eaaProviders = eaaProviders.mapValues { (_, v) -> Uri(v) },
         )
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi119602.Uri
+import eu.europa.ec.eudi.etsi119602.consultation.LoadLoTEAndPointers
+import eu.europa.ec.eudi.etsi119602.consultation.LotEMeta
+import eu.europa.ec.eudi.etsi119602.consultation.VerifyJwtSignature
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.SupportedLists
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Configuration for the ETSI LoTE (List of Trusted Entities) trust infrastructure.
+ *
+ * This centralizes the LoTE pipeline parameters so that the core can build the
+ * [eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW] trust source
+ * internally, eliminating the need for consumers to construct the ETSI library
+ * plumbing themselves.
+ *
+ * @property loteLocations the LoTE download locations (e.g., PID, PubEAA, WRPAC provider URLs)
+ * @property classifications attestation classifications mapping credential types to verification contexts
+ * @property fileCacheExpiration how long downloaded LoTE files are cached on disk (default: 24 hours)
+ * @property cacheTtl how long the in-memory trust anchor cache is valid (default: 20 minutes)
+ * @property relaxCertificateProfiles whether to strip end-entity profile constraints (for DEV/testing)
+ * @property relaxPkixRevocation whether to disable PKIX revocation checking (for DEV/testing)
+ * @property customJwtSignatureVerifier optional custom JWT signature verifier for LoTE JWTs;
+ *   when null, the core uses its built-in [LoteJwtSignatureVerifier]
+ * @property loteConstraints controls whether additional LoTE pointers are followed
+ */
+data class EtsiTrustConfig(
+    val loteLocations: SupportedLists<Uri>,
+    val classifications: AttestationClassifications,
+    val fileCacheExpiration: Duration = DEFAULT_FILE_CACHE_EXPIRATION,
+    val cacheTtl: Duration = DEFAULT_CACHE_TTL,
+    val relaxCertificateProfiles: Boolean = false,
+    val relaxPkixRevocation: Boolean = false,
+    val customJwtSignatureVerifier: VerifyJwtSignature? = null,
+    val loteConstraints: LoadLoTEAndPointers.Constraints = LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers,
+) {
+    companion object {
+        val DEFAULT_FILE_CACHE_EXPIRATION: Duration = 24.hours
+        val DEFAULT_CACHE_TTL: Duration = 20.minutes
+    }
+}
+
+/**
+ * DSL builder for constructing an [EtsiTrustConfig].
+ *
+ * [loteLocations] and [classifications] are required. All other settings have sensible defaults.
+ *
+ * Example:
+ * ```
+ * configureEtsiTrust {
+ *     loteLocations(SupportedLists(
+ *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
+ *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
+ *     ))
+ *     classifications(AttestationClassifications(
+ *         pids = AttestationIdentifierPredicate.any(setOf(
+ *             AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+ *         )),
+ *     ))
+ *     // Optional:
+ *     relaxCertificateProfiles()
+ *     fileCacheExpiration(12.hours)
+ *     cacheTtl(10.minutes)
+ * }
+ * ```
+ */
+class EtsiTrustConfigBuilder {
+
+    private var loteLocations: SupportedLists<Uri>? = null
+    private var classifications: AttestationClassifications? = null
+    private var fileCacheExpiration: Duration = EtsiTrustConfig.DEFAULT_FILE_CACHE_EXPIRATION
+    private var cacheTtl: Duration = EtsiTrustConfig.DEFAULT_CACHE_TTL
+    private var relaxCertificateProfiles: Boolean = false
+    private var relaxPkixRevocation: Boolean = false
+    private var customJwtSignatureVerifier: VerifyJwtSignature? = null
+    private var loteConstraints: LoadLoTEAndPointers.Constraints =
+        LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers
+
+    /**
+     * Sets the LoTE download locations.
+     *
+     * @param locations the supported lists with LoTE URLs
+     */
+    fun loteLocations(locations: SupportedLists<Uri>) {
+        this.loteLocations = locations
+    }
+
+    /**
+     * Sets the attestation classifications mapping credential types to verification contexts.
+     *
+     * @param classifications the attestation classifications
+     */
+    fun classifications(classifications: AttestationClassifications) {
+        this.classifications = classifications
+    }
+
+    /**
+     * Sets how long downloaded LoTE files are cached on disk.
+     *
+     * @param duration the file cache expiration duration (default: 24 hours)
+     */
+    fun fileCacheExpiration(duration: Duration) {
+        this.fileCacheExpiration = duration
+    }
+
+    /**
+     * Sets how long the in-memory trust anchor cache is valid.
+     *
+     * @param duration the cache TTL duration (default: 20 minutes)
+     */
+    fun cacheTtl(duration: Duration) {
+        this.cacheTtl = duration
+    }
+
+    /**
+     * Relaxes certificate profile checks for all provider types.
+     *
+     * When enabled, `endEntityProfile` constraints are stripped from all verification
+     * contexts. Use this for DEV/testing environments where certificates may not
+     * fully conform to ETSI profile requirements.
+     */
+    fun relaxCertificateProfiles() {
+        this.relaxCertificateProfiles = true
+    }
+
+    /**
+     * Disables PKIX revocation checking during certificate chain validation.
+     *
+     * When enabled, `isRevocationEnabled` is set to `false` on the PKIX parameters.
+     * Use this for DEV/testing environments where CRL/OCSP endpoints may not be available.
+     */
+    fun relaxPkixRevocation() {
+        this.relaxPkixRevocation = true
+    }
+
+    /**
+     * Sets a custom JWT signature verifier for LoTE JWTs.
+     *
+     * When not set, the core uses its built-in [LoteJwtSignatureVerifier] that
+     * verifies JWT signatures using the `x5c` certificate chain from the JWT header.
+     *
+     * @param verifier the custom JWT signature verifier
+     */
+    fun jwtSignatureVerifier(verifier: VerifyJwtSignature) {
+        this.customJwtSignatureVerifier = verifier
+    }
+
+    /**
+     * Controls whether additional LoTE pointers are followed when loading.
+     *
+     * @param constraints the LoTE loading constraints
+     *   (default: [LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers])
+     */
+    fun loteConstraints(constraints: LoadLoTEAndPointers.Constraints) {
+        this.loteConstraints = constraints
+    }
+
+    /**
+     * Builds the [EtsiTrustConfig] from the current builder state.
+     *
+     * @return a validated [EtsiTrustConfig]
+     * @throws IllegalArgumentException if [loteLocations] or [classifications] are not set
+     */
+    internal fun build(): EtsiTrustConfig {
+        val locations = requireNotNull(loteLocations) {
+            "loteLocations must be provided via loteLocations()"
+        }
+        val cls = requireNotNull(classifications) {
+            "classifications must be provided via classifications()"
+        }
+        return EtsiTrustConfig(
+            loteLocations = locations,
+            classifications = cls,
+            fileCacheExpiration = fileCacheExpiration,
+            cacheTtl = cacheTtl,
+            relaxCertificateProfiles = relaxCertificateProfiles,
+            relaxPkixRevocation = relaxPkixRevocation,
+            customJwtSignatureVerifier = customJwtSignatureVerifier,
+            loteConstraints = loteConstraints,
+        )
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
@@ -41,7 +41,7 @@ import kotlin.time.Duration.Companion.minutes
  * @property relaxCertificateProfiles whether to strip end-entity profile constraints (for DEV/testing)
  * @property relaxPkixRevocation whether to disable PKIX revocation checking (for DEV/testing)
  * @property customJwtSignatureVerifier optional custom JWT signature verifier for LoTE JWTs;
- *   when null, the core uses its built-in [LoteJwtSignatureVerifier]
+ *   when null, the core uses its built-in [LoteJwtVerifier]
  * @property loteConstraints controls whether additional LoTE pointers are followed
  */
 data class EtsiTrustConfig(
@@ -164,7 +164,7 @@ class EtsiTrustConfigBuilder {
     /**
      * Sets a custom JWT signature verifier for LoTE JWTs.
      *
-     * When not set, the core uses its built-in [LoteJwtSignatureVerifier] that
+     * When not set, the core uses its built-in [LoteJwtVerifier] that
      * verifies JWT signatures using the `x5c` certificate chain from the JWT header.
      *
      * @param verifier the custom JWT signature verifier

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.wallet.trust
 
-import eu.europa.ec.eudi.etsi119602.Uri
+import eu.europa.ec.eudi.etsi119602.datamodel.Uri
 import eu.europa.ec.eudi.etsi119602.consultation.LoadLoTEAndPointers
 import eu.europa.ec.eudi.etsi119602.consultation.LotEMeta
 import eu.europa.ec.eudi.etsi119602.consultation.VerifyJwtSignature
@@ -69,8 +69,8 @@ data class EtsiTrustConfig(
  * ```
  * configureEtsiTrust {
  *     loteLocations(SupportedLists(
- *         pidProviders = "https://trustedlist.../PIDProviders.jwt",
- *         wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
+ *         pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
+ *         wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
  *     ))
  *     classifications(AttestationClassifications(
  *         pids = AttestationIdentifierPredicate.any(setOf(
@@ -86,7 +86,7 @@ data class EtsiTrustConfig(
  */
 class EtsiTrustConfigBuilder {
 
-    private var loteLocations: SupportedLists<String>? = null
+    private var loteLocations: SupportedLists<Uri>? = null
     private var classifications: AttestationClassifications? = null
     private var fileCacheExpiration: Duration = EtsiTrustConfig.DEFAULT_FILE_CACHE_EXPIRATION
     private var cacheTtl: Duration = EtsiTrustConfig.DEFAULT_CACHE_TTL
@@ -97,19 +97,19 @@ class EtsiTrustConfigBuilder {
         LoadLoTEAndPointers.Constraints.DoNotLoadOtherPointers
 
     /**
-     * Sets the LoTE download locations as string URLs.
+     * Sets the LoTE download locations.
      *
      * Example:
      * ```
      * loteLocations(SupportedLists(
-     *     pidProviders = "https://trustedlist.../PIDProviders.jwt",
-     *     wrpacProviders = "https://trustedlist.../WRPACProviders.jwt",
+     *     pidProviders = Uri("https://trustedlist.../PIDProviders.jwt"),
+     *     wrpacProviders = Uri("https://trustedlist.../WRPACProviders.jwt"),
      * ))
      * ```
      *
-     * @param locations the supported lists with LoTE URL strings
+     * @param locations the supported lists with LoTE URLs
      */
-    fun loteLocations(locations: SupportedLists<String>) {
+    fun loteLocations(locations: SupportedLists<Uri>) {
         this.loteLocations = locations
     }
 
@@ -197,7 +197,7 @@ class EtsiTrustConfigBuilder {
             "classifications must be provided via classifications()"
         }
         return EtsiTrustConfig(
-            loteLocations = locations.toUri(),
+            loteLocations = locations,
             classifications = cls,
             fileCacheExpiration = fileCacheExpiration,
             cacheTtl = cacheTtl,
@@ -205,18 +205,6 @@ class EtsiTrustConfigBuilder {
             relaxPkixRevocation = relaxPkixRevocation,
             customJwtSignatureVerifier = customJwtSignatureVerifier,
             loteConstraints = loteConstraints,
-        )
-    }
-
-    private companion object {
-        fun SupportedLists<String>.toUri() = SupportedLists(
-            pidProviders = pidProviders?.let(::Uri),
-            walletProviders = walletProviders?.let(::Uri),
-            wrpacProviders = wrpacProviders?.let(::Uri),
-            wrprcProviders = wrprcProviders?.let(::Uri),
-            pubEaaProviders = pubEaaProviders?.let(::Uri),
-            qeaProviders = qeaProviders?.let(::Uri),
-            eaaProviders = eaaProviders.mapValues { (_, v) -> Uri(v) },
         )
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
@@ -57,6 +57,7 @@ internal class EtsiTrustProvider(
     config: EtsiTrustConfig,
     context: Context,
     logger: Logger? = null,
+    ktorHttpClientFactory: (() -> HttpClient)? = null,
 ) {
     private val disposableContainer = DisposableContainer()
 
@@ -73,17 +74,17 @@ internal class EtsiTrustProvider(
             "relaxProfiles=${config.relaxCertificateProfiles}, " +
             "relaxPkixRevocation=${config.relaxPkixRevocation}")
 
-        // 1. HTTP client (auto-discovers ktor-client-android at runtime)
-        val httpClient = HttpClient()
+        // HTTP client (use injected factory or default)
+        val httpClient = ktorHttpClientFactory?.invoke() ?: HttpClient()
 
-        // 2. LoTE loader with file cache
+        // LoTE loader with file cache
         val loadLoTE = LoadSingleLoTEWithFileCache(
             cacheDirectory = Path(context.cacheDir.path, "lote-cache"),
             downloadSingleLoTE = DownloadSingleLoTE(httpClient),
             fileCacheExpiration = config.fileCacheExpiration,
         )
 
-        // 3. LoTE pointer loading + JWT verification
+        // LoTE pointer loading + JWT verification
         val jwtVerifier = config.customJwtSignatureVerifier
             ?: LoteJwtSignatureVerifier(logger)
         val loadLoTEAndPointers = LoadLoTEAndPointers(
@@ -92,7 +93,7 @@ internal class EtsiTrustProvider(
             loadLoTE = loadLoTE,
         )
 
-        // 4. Trust anchor provisioner
+        // Trust anchor provisioner
         val svcTypePerCtx = if (config.relaxCertificateProfiles) {
             relaxProfiles(SupportedLists.eu())
         } else {
@@ -113,7 +114,7 @@ internal class EtsiTrustProvider(
             )
         }
 
-        // 5. Cached chain trust validator
+        // Cached chain trust validator
         isChainTrusted = provisionTrustAnchors.cached(
             disposableContainer,
             config.loteLocations,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
@@ -86,7 +86,7 @@ internal class EtsiTrustProvider(
 
         // LoTE pointer loading + JWT verification
         val jwtVerifier = config.customJwtSignatureVerifier
-            ?: LoteJwtSignatureVerifier(logger)
+            ?: LoteJwtVerifier(logger)
         val loadLoTEAndPointers = LoadLoTEAndPointers(
             constraints = config.loteConstraints,
             verifyJwtSignature = jwtVerifier,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustProvider.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import android.content.Context
+import eu.europa.ec.eudi.etsi119602.consultation.DownloadSingleLoTE
+import eu.europa.ec.eudi.etsi119602.consultation.LoadLoTEAndPointers
+import eu.europa.ec.eudi.etsi119602.consultation.LoadSingleLoTEWithFileCache
+import eu.europa.ec.eudi.etsi119602.consultation.LotEMeta
+import eu.europa.ec.eudi.etsi119602.consultation.ProvisionTrustAnchorsFromLoTEs
+import eu.europa.ec.eudi.etsi119602.consultation.VerifyJwtSignature
+import eu.europa.ec.eudi.etsi119602.consultation.eu
+import eu.europa.ec.eudi.etsi119602.consultation.eudiwJvm
+import eu.europa.ec.eudi.etsi1196x2.consultation.DisposableContainer
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.etsi1196x2.consultation.SupportedLists
+import eu.europa.ec.eudi.etsi1196x2.consultation.ValidateCertificateChainUsingPKIXJvm
+import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.logging.Logger
+import io.ktor.client.HttpClient
+import kotlinx.io.files.Path
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * Internal provider that constructs the full ETSI LoTE trust pipeline from an [EtsiTrustConfig].
+ *
+ * This encapsulates the construction of:
+ * - HTTP client for downloading LoTEs
+ * - File cache for downloaded LoTEs
+ * - JWT signature verification for LoTE JWTs
+ * - Trust anchor provisioning from LoTEs
+ * - Cached chain trust validator
+ *
+ * The resulting [isChainTrusted] can be used as the shared trust source across all
+ * trust verification areas (issuer trust, status list trust, reader authentication).
+ *
+ * @param config the ETSI trust configuration
+ * @param context the Android context (used for cache directory)
+ * @param logger optional logger for diagnostic output
+ */
+internal class EtsiTrustProvider(
+    config: EtsiTrustConfig,
+    context: Context,
+    logger: Logger? = null,
+) {
+    private val disposableContainer = DisposableContainer()
+
+    /**
+     * The shared chain trust validator constructed from the LoTE infrastructure.
+     * This implements [IsChainTrustedForEUDIW] and can be used with all trust areas.
+     */
+    val isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>
+
+    init {
+        logger?.d(TAG, "Initializing ETSI trust provider: " +
+            "cacheTtl=${config.cacheTtl}, " +
+            "fileCacheExpiration=${config.fileCacheExpiration}, " +
+            "relaxProfiles=${config.relaxCertificateProfiles}, " +
+            "relaxPkixRevocation=${config.relaxPkixRevocation}")
+
+        // 1. HTTP client (auto-discovers ktor-client-android at runtime)
+        val httpClient = HttpClient()
+
+        // 2. LoTE loader with file cache
+        val loadLoTE = LoadSingleLoTEWithFileCache(
+            cacheDirectory = Path(context.cacheDir.path, "lote-cache"),
+            downloadSingleLoTE = DownloadSingleLoTE(httpClient),
+            fileCacheExpiration = config.fileCacheExpiration,
+        )
+
+        // 3. LoTE pointer loading + JWT verification
+        val jwtVerifier = config.customJwtSignatureVerifier
+            ?: LoteJwtSignatureVerifier(logger)
+        val loadLoTEAndPointers = LoadLoTEAndPointers(
+            constraints = config.loteConstraints,
+            verifyJwtSignature = jwtVerifier,
+            loadLoTE = loadLoTE,
+        )
+
+        // 4. Trust anchor provisioner
+        val svcTypePerCtx = if (config.relaxCertificateProfiles) {
+            relaxProfiles(SupportedLists.eu())
+        } else {
+            SupportedLists.eu()
+        }
+        val provisionTrustAnchors = if (config.relaxPkixRevocation) {
+            ProvisionTrustAnchorsFromLoTEs.eudiwJvm(
+                loadLoTEAndPointers = loadLoTEAndPointers,
+                svcTypePerCtx = svcTypePerCtx,
+                pkix = ValidateCertificateChainUsingPKIXJvm(
+                    customization = { isRevocationEnabled = false }
+                ),
+            )
+        } else {
+            ProvisionTrustAnchorsFromLoTEs.eudiwJvm(
+                loadLoTEAndPointers = loadLoTEAndPointers,
+                svcTypePerCtx = svcTypePerCtx,
+            )
+        }
+
+        // 5. Cached chain trust validator
+        isChainTrusted = provisionTrustAnchors.cached(
+            disposableContainer,
+            config.loteLocations,
+            ttl = config.cacheTtl,
+        )
+
+        logger?.d(TAG, "ETSI trust provider initialized")
+    }
+
+    private companion object {
+        const val TAG = "EtsiTrust"
+
+        /**
+         * Relaxes certificate profile checks by stripping `endEntityProfile` from all
+         * provider types. Used for DEV/testing environments.
+         */
+        fun relaxProfiles(
+            eu: SupportedLists<LotEMeta<VerificationContext>>,
+        ): SupportedLists<LotEMeta<VerificationContext>> {
+            fun LotEMeta<VerificationContext>.relax() = copy(
+                svcTypePerCtx = svcTypePerCtx.mapValues { (_, v) ->
+                    v.copy(endEntityProfile = null)
+                }
+            )
+            return eu.copy(
+                pidProviders = eu.pidProviders?.relax(),
+                walletProviders = eu.walletProviders?.relax(),
+                wrpacProviders = eu.wrpacProviders?.relax(),
+                wrprcProviders = eu.wrprcProviders?.relax(),
+                pubEaaProviders = eu.pubEaaProviders?.relax(),
+                qeaProviders = eu.qeaProviders?.relax(),
+                eaaProviders = eu.eaaProviders.mapValues { (_, v) -> v.relax() },
+            )
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -210,8 +210,8 @@ class IssuerTrustConfigBuilder {
             ?: TrustPolicy.uniform(TrustPolicy.Action.ENFORCE)
 
         val defaultVerifiers = mapOf<KClass<out DocumentFormat>, CredentialTrustVerifier>(
-            MsoMdocFormat::class to MsoMdocCredentialTrustVerifier(attestation),
-            SdJwtVcFormat::class to SdJwtVcCredentialTrustVerifier(attestation),
+            MsoMdocFormat::class to MsoMdocCredentialTrustVerifier(attestation, logger),
+            SdJwtVcFormat::class to SdJwtVcCredentialTrustVerifier(attestation, logger),
         )
         val verifiers = defaultVerifiers + customVerifiers
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -173,12 +173,32 @@ class IssuerTrustConfigBuilder {
      * @throws IllegalArgumentException if no trust source is configured, or if classifications
      *   are missing when required by the trust source type
      */
-    internal fun build(): IssuerTrustConfig {
+    internal fun build(): IssuerTrustConfig = build(null, null)
+
+    /**
+     * Builds the [IssuerTrustConfig], using the provided defaults for trust source and
+     * classifications when they have not been explicitly set via [trustSource] / [classifications].
+     *
+     * This is used by [eu.europa.ec.eudi.wallet.EudiWallet.Builder] to inject the centrally
+     * configured ETSI trust source from [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureEtsiTrust].
+     *
+     * @param defaultSource default EUDIW trust source if [trustSource] was not called
+     * @param defaultClassifications default classifications if [classifications] was not called
+     * @return a validated [IssuerTrustConfig]
+     * @throws IllegalArgumentException if no trust source is available
+     */
+    internal fun build(
+        defaultSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>?,
+        defaultClassifications: AttestationClassifications?,
+    ): IssuerTrustConfig {
+        val effectiveEudiwSource = eudiwSource ?: defaultSource
+        val effectiveClassifications = classifications ?: defaultClassifications
+
         val attestation = preBuiltAttestation ?: run {
-            val eudiw = requireNotNull(eudiwSource) {
+            val eudiw = requireNotNull(effectiveEudiwSource) {
                 "A trust source must be provided via trustSource()"
             }
-            val cls = requireNotNull(classifications) {
+            val cls = requireNotNull(effectiveClassifications) {
                 "AttestationClassifications must be provided when using IsChainTrustedForEUDIW as trust source"
             }
             IsChainTrustedForAttestation(eudiw, cls)
@@ -193,23 +213,25 @@ class IssuerTrustConfigBuilder {
         )
         val verifiers = defaultVerifiers + customVerifiers
 
-        val issuerMetadataPolicy = buildIssuerMetadataPolicy()
+        val issuerMetadataPolicy = buildIssuerMetadataPolicy(effectiveEudiwSource)
 
         return IssuerTrustConfig(
             isChainTrustedForAttestation = attestation,
-            classifications = classifications,
+            classifications = effectiveClassifications,
             trustPolicy = trustPolicy,
             credentialTrustVerifiers = verifiers,
             issuerMetadataPolicy = issuerMetadataPolicy,
         )
     }
 
-    private fun buildIssuerMetadataPolicy(): IssuerMetadataPolicy =
+    private fun buildIssuerMetadataPolicy(
+        effectiveSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>? = eudiwSource,
+    ): IssuerMetadataPolicy =
         when (metadataPolicyMode) {
             MetadataPolicyMode.IGNORE -> IssuerMetadataPolicy.IgnoreSigned
             MetadataPolicyMode.REQUIRE,
             MetadataPolicyMode.PREFER -> {
-                val source = eudiwSource
+                val source = effectiveSource
                     ?: throw IllegalArgumentException(
                         "Signed metadata verification requires an IsChainTrustedForEUDIW trust source. " +
                             "Call ignoreSignedMetadata() to opt out."

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/IssuerTrustConfigBuilder.kt
@@ -25,6 +25,7 @@ import eu.europa.ec.eudi.openid4vci.IssuerTrust
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.logging.Logger
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 import kotlin.reflect.KClass
@@ -190,6 +191,7 @@ class IssuerTrustConfigBuilder {
     internal fun build(
         defaultSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>?,
         defaultClassifications: AttestationClassifications?,
+        logger: Logger? = null,
     ): IssuerTrustConfig {
         val effectiveEudiwSource = eudiwSource ?: defaultSource
         val effectiveClassifications = classifications ?: defaultClassifications
@@ -213,7 +215,7 @@ class IssuerTrustConfigBuilder {
         )
         val verifiers = defaultVerifiers + customVerifiers
 
-        val issuerMetadataPolicy = buildIssuerMetadataPolicy(effectiveEudiwSource)
+        val issuerMetadataPolicy = buildIssuerMetadataPolicy(effectiveEudiwSource, logger)
 
         return IssuerTrustConfig(
             isChainTrustedForAttestation = attestation,
@@ -226,6 +228,7 @@ class IssuerTrustConfigBuilder {
 
     private fun buildIssuerMetadataPolicy(
         effectiveSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>? = eudiwSource,
+        logger: Logger? = null,
     ): IssuerMetadataPolicy =
         when (metadataPolicyMode) {
             MetadataPolicyMode.IGNORE -> IssuerMetadataPolicy.IgnoreSigned
@@ -236,7 +239,9 @@ class IssuerTrustConfigBuilder {
                         "Signed metadata verification requires an IsChainTrustedForEUDIW trust source. " +
                             "Call ignoreSignedMetadata() to opt out."
                     )
-                val issuerTrust = IssuerTrust.ByCertificateChain(EtsiCertificateChainTrust(source))
+                val issuerTrust = IssuerTrust.ByCertificateChain(
+                    EtsiCertificateChainTrust(source, logger)
+                )
                 if (metadataPolicyMode == MetadataPolicyMode.REQUIRE) {
                     IssuerMetadataPolicy.RequireSigned(issuerTrust)
                 } else {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/LoteJwtSignatureVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/LoteJwtSignatureVerifier.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import com.nimbusds.jose.JWSVerifier
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import com.nimbusds.jose.crypto.RSASSAVerifier
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.etsi119602.consultation.VerifyJwtSignature
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+import java.util.Base64
+
+/**
+ * JWT signature verifier for LoTE (List of Trusted Entities) JWTs.
+ *
+ * Verifies the JWS signature of LoTE JWTs by:
+ * Parsing the JWT compact serialization
+ * Extracting the `x5c` certificate chain from the JWS header
+ * Verifying the signature using the leaf certificate's public key
+ *
+ *
+ * @param logger optional logger for diagnostic output
+ */
+internal class LoteJwtSignatureVerifier(
+    private val logger: Logger? = null,
+) : VerifyJwtSignature {
+
+    override suspend fun invoke(jwt: String): VerifyJwtSignature.Outcome {
+        return try {
+            val signedJwt = SignedJWT.parse(jwt)
+            val header = signedJwt.header
+
+            val x5cChain = header.x509CertChain
+            if (x5cChain.isNullOrEmpty()) {
+                return VerifyJwtSignature.Outcome.NotVerified(
+                    IllegalArgumentException("JWT header does not contain x5c certificate chain")
+                )
+            }
+
+            // Build X509Certificate from the leaf (first) x5c entry
+            val leafCertBytes = x5cChain[0].decode()
+            val certFactory = CertificateFactory.getInstance("X.509")
+            val leafCert = certFactory.generateCertificate(
+                ByteArrayInputStream(leafCertBytes)
+            ) as X509Certificate
+
+            logger?.d(TAG, "Verifying LoTE JWT signature: alg=${header.algorithm}, " +
+                "leaf=${leafCert.subjectX500Principal}")
+
+            // Acknowledge any critical headers declared in the JWT (e.g., "sigT")
+            // so nimbus doesn't reject the signature for unrecognized crit params
+            val deferredCritHeaders = header.criticalParams ?: emptySet()
+
+            // Create verifier based on the key type
+            val verifier: JWSVerifier = when (val publicKey = leafCert.publicKey) {
+                is ECPublicKey -> ECDSAVerifier(publicKey, deferredCritHeaders)
+                is RSAPublicKey -> RSASSAVerifier(publicKey, deferredCritHeaders)
+                else -> return VerifyJwtSignature.Outcome.NotVerified(
+                    UnsupportedOperationException("Unsupported key type: ${publicKey.algorithm}")
+                )
+            }
+
+            if (signedJwt.verify(verifier)) {
+                logger?.d(TAG, "LoTE JWT signature verified successfully")
+                VerifyJwtSignature.Outcome.Verified(jwt)
+            } else {
+                logger?.d(TAG, "LoTE JWT signature verification failed")
+                VerifyJwtSignature.Outcome.NotVerified(
+                    SecurityException("JWT signature verification failed")
+                )
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            logger?.e(TAG, "LoTE JWT verification error: ${e.message}", e)
+            VerifyJwtSignature.Outcome.NotVerified(e)
+        }
+    }
+
+    private companion object {
+        const val TAG = "LoteJwtVerifier"
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/LoteJwtVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/LoteJwtVerifier.kt
@@ -31,17 +31,21 @@ import java.security.interfaces.RSAPublicKey
 import java.util.Base64
 
 /**
- * JWT signature verifier for LoTE (List of Trusted Entities) JWTs.
+ * Default LoTE JWT verifier.
  *
- * Verifies the JWS signature of LoTE JWTs by:
- * Parsing the JWT compact serialization
- * Extracting the `x5c` certificate chain from the JWS header
- * Verifying the signature using the leaf certificate's public key
+ * This implementation **only verifies the JWS cryptographic signature** using the leaf
+ * certificate's public key from the `x5c` header. It does **not** perform:
+ * - Certificate chain validation (PKIX)
+ * - CRL / OCSP revocation checking on the signing certificate
+ * - Certificate policy or profile constraint checks
  *
+ * These additional trust checks will be added in a future release. In the meantime,
+ * provide a custom [VerifyJwtSignature] implementation via
+ * [EtsiTrustConfig.Builder.jwtSignatureVerifier] if thorough verification is required.
  *
  * @param logger optional logger for diagnostic output
  */
-internal class LoteJwtSignatureVerifier(
+internal class LoteJwtVerifier(
     private val logger: Logger? = null,
 ) : VerifyJwtSignature {
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/MsoMdocCredentialTrustVerifier.kt
@@ -18,6 +18,9 @@ package eu.europa.ec.eudi.wallet.trust
 import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
 import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForAttestation
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import org.multipaz.cbor.Cbor
 import org.multipaz.cose.Cose
 import org.multipaz.cose.toCoseLabel
@@ -39,45 +42,43 @@ import java.util.Base64
  */
 internal class MsoMdocCredentialTrustVerifier(
     private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+    private val logger: Logger? = null,
 ) : CredentialTrustVerifier {
 
     override suspend fun verify(
         credentialValue: String,
         attestationIdentifier: AttestationIdentifier,
     ): CertificationChainValidation<TrustAnchor>? = runCatching {
-        //  Base64url-decode the credential string
+        // Base64url-decode the credential string
         val credentialBytes = Base64.getUrlDecoder().decode(credentialValue)
 
-        //  Parse issuerAuth from StaticAuthData
+        // Parse issuerAuth from StaticAuthData
         val issuerAuthBytes = StaticAuthDataParser(credentialBytes)
             .parse()
             .issuerAuth
 
-        //  Decode COSE_Sign1 from issuerAuth
+        // Decode COSE_Sign1 from issuerAuth
         val coseSign1 = Cbor.decode(issuerAuthBytes).asCoseSign1
 
-        //  Extract x5chain from unprotected headers (COSE label 33)
+        // Extract x5chain from unprotected headers (COSE label 33)
         val x5chainDataItem = coseSign1.unprotectedHeaders[Cose.COSE_LABEL_X5CHAIN.toCoseLabel]
-            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL A: no x5chain in COSE headers"); return@runCatching null }
+            ?: run { logger?.d(TAG, "No x5chain in COSE unprotected headers"); return@runCatching null }
         val x5chain = x5chainDataItem.asX509CertChain
 
-        //  Convert to List<X509Certificate> (JVM extension)
+        // Convert to List<X509Certificate> (JVM extension)
         val javaCerts = x5chain.javaX509Certificates
-        android.util.Log.d("IssuerTrust", "VERIFIER: x5chain has ${javaCerts.size} certs, leaf=${javaCerts.firstOrNull()?.subjectX500Principal}")
+        logger?.d(TAG, "x5chain has ${javaCerts.size} certs, leaf=${javaCerts.firstOrNull()?.subjectX500Principal}")
         require(javaCerts.isNotEmpty()) { "x5chain must contain at least one certificate" }
 
-        //  Evaluate trust via the ETSI library
-        android.util.Log.d("IssuerTrust", "VERIFIER: calling isChainTrusted.issuance()...")
+        // Evaluate trust via the ETSI library
         val trustResult = isChainTrusted.issuance(javaCerts, attestationIdentifier)
-            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL B: issuance() returned null"); return@runCatching null }
+            ?: run { logger?.d(TAG, "issuance() returned null"); return@runCatching null }
 
-        android.util.Log.d("IssuerTrust", "VERIFIER: trustResult=$trustResult")
-
-        //  Verify COSE signature using the leaf certificate's public key
+        // Verify COSE signature using the leaf certificate's public key
         val leafCert = x5chain.certificates.first()
         val algIdentifier = coseSign1.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]
             ?.asNumber?.toInt()
-            ?: run { android.util.Log.w("IssuerTrust", "VERIFIER NULL C: no algorithm in COSE headers"); return@runCatching null }
+            ?: run { logger?.d(TAG, "No algorithm in COSE protected headers"); return@runCatching null }
         val algorithm = Algorithm.fromCoseAlgorithmIdentifier(algIdentifier)
 
         Cose.coseSign1Check(
@@ -89,6 +90,10 @@ internal class MsoMdocCredentialTrustVerifier(
 
         trustResult
     }.onFailure { e ->
-        android.util.Log.e("IssuerTrust", "MsoMdocCredentialTrustVerifier failed", e)
+        logger?.e(TAG, "MsoMdoc credential trust verification failed", e)
     }.getOrNull()
+
+    companion object {
+        private const val TAG = "MdocIssuerTrust"
+    }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderTrustConfigBuilder.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
+
+/**
+ * DSL builder for configuring reader trust and authentication policy when using
+ * the centralized ETSI trust source from
+ * [configureEtsiTrust][eu.europa.ec.eudi.wallet.EudiWalletConfig.configureEtsiTrust].
+ *
+ * Example:
+ * ```
+ * configureReaderTrustStore {
+ *     readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+ * }
+ * ```
+ */
+class ReaderTrustConfigBuilder {
+
+    internal var readerAuthPolicy: ReaderAuthPolicy? = null
+        private set
+
+    /**
+     * Sets the reader authentication enforcement policy.
+     *
+     * This controls how reader authentication results affect document disclosure
+     * during proximity and DCAPI presentations.
+     *
+     * - [ReaderAuthPolicy.DoNotEnforce]: Reader authentication is evaluated but never blocks disclosure.
+     * - [ReaderAuthPolicy.EnforceIfPresent]: Documents are excluded when reader auth is present but fails (default).
+     * - [ReaderAuthPolicy.AlwaysRequire]: Documents are excluded unless reader auth is present and verified.
+     *
+     * @param policy the reader authentication enforcement policy
+     * @see ReaderAuthPolicy
+     */
+    fun readerAuthPolicy(policy: ReaderAuthPolicy) {
+        this.readerAuthPolicy = policy
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/SdJwtVcCredentialTrustVerifier.kt
@@ -22,6 +22,9 @@ import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
 import eu.europa.ec.eudi.sdjwt.vc.X509CertificateTrust
+import eu.europa.ec.eudi.wallet.internal.d
+import eu.europa.ec.eudi.wallet.internal.e
+import eu.europa.ec.eudi.wallet.logging.Logger
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 
@@ -37,6 +40,7 @@ import java.security.cert.X509Certificate
  */
 internal class SdJwtVcCredentialTrustVerifier(
     private val isChainTrusted: IsChainTrustedForAttestation<List<X509Certificate>, TrustAnchor>,
+    private val logger: Logger? = null,
 ) : CredentialTrustVerifier {
 
     override suspend fun verify(
@@ -47,8 +51,11 @@ internal class SdJwtVcCredentialTrustVerifier(
 
         // Create trust callback that captures the evaluation result
         val trust = X509CertificateTrust<List<X509Certificate>> { chain, _ ->
+            logger?.d(TAG, "x5c chain has ${chain.size} certs, leaf=${chain.firstOrNull()?.subjectX500Principal}")
             result = isChainTrusted.issuance(chain, attestationIdentifier)
-            result is CertificationChainValidation.Trusted
+            val trusted = result is CertificationChainValidation.Trusted
+            logger?.d(TAG, "issuance() trusted=$trusted")
+            trusted
         }
 
         // Create verifier with UsingX5c method
@@ -58,7 +65,13 @@ internal class SdJwtVcCredentialTrustVerifier(
             checkStatus = null
         )
 
-        verifier.verify(credentialValue).getOrNull()
+        verifier.verify(credentialValue)
+            .onFailure { e -> logger?.e(TAG, "SD-JWT VC credential trust verification failed", e) }
+            .getOrNull()
         return result
+    }
+
+    companion object {
+        private const val TAG = "SdJwtIssuerTrust"
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/StatusListTrustConfigBuilder.kt
@@ -116,14 +116,28 @@ class StatusListTrustConfigBuilder {
      * @throws IllegalArgumentException if no trust source is configured, or if classifications
      *   are missing when required by the trust source type
      */
-    internal fun build(): StatusListTrustConfig {
+    internal fun build(): StatusListTrustConfig = build(null, null)
+
+    /**
+     * Builds the [StatusListTrustConfig], using the provided defaults for trust source and
+     * classifications when they have not been explicitly set via [trustSource] / [classifications].
+     *
+     * @param defaultSource default EUDIW trust source if [trustSource] was not called
+     * @param defaultClassifications default classifications if [classifications] was not called
+     * @return a validated [StatusListTrustConfig]
+     * @throws IllegalArgumentException if no trust source is available
+     */
+    internal fun build(
+        defaultSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>?,
+        defaultClassifications: AttestationClassifications?,
+    ): StatusListTrustConfig {
+        val effectiveClassifications = classifications ?: defaultClassifications
+
         val attestation = preBuiltAttestation ?: run {
-            val eudiw = requireNotNull(eudiwSource) {
-                "A trust source must be provided via trustSource()"
-            }
-            val cls = requireNotNull(classifications) {
-                "AttestationClassifications must be provided when using IsChainTrustedForEUDIW as trust source"
-            }
+            val eudiw = eudiwSource ?: defaultSource
+                ?: error("A trust source must be provided via trustSource()")
+            val cls = effectiveClassifications
+                ?: error("AttestationClassifications must be provided when using IsChainTrustedForEUDIW as trust source")
             IsChainTrustedForAttestation(eudiw, cls)
         }
 
@@ -132,7 +146,7 @@ class StatusListTrustConfigBuilder {
 
         return StatusListTrustConfig(
             isChainTrustedForAttestation = attestation,
-            classifications = classifications,
+            classifications = effectiveClassifications,
             trustPolicy = trustPolicy,
         )
     }


### PR DESCRIPTION
Centralize ETSI LoTE trust assembly in wallet-core

Adds configureEtsiTrust { } DSL to EudiWalletConfig, allowing the core to build the full LoTE (List of Trusted Entities) pipeline internally — HTTP client, file cache, JWT signature verification, and cached trust anchor provisioning. Consumers no longer need to construct ETSI library plumbing themselves; they provide high-level parameters (LoTE URLs, classifications, relaxation flags) and the core handles the rest.

Key changes:
- LoteJwtSignatureVerifier.kt — built-in VerifyJwtSignature implementation using nimbus-jose-jwt, with proper crit header handling (e.g., sigT)
- EudiWalletConfig: configureIssuerTrust and configureDocumentStatusResolver now store builder lambdas (deferred); resolution happens in EudiWallet.Builder.build() where the ETSI trust source is available
- IssuerTrustConfigBuilder / StatusListTrustConfigBuilder / DocumentStatusResolverConfigBuilder: new build(defaultSource, defaultClassifications) overloads that fall back to centralized ETSI defaults when per-area trust source is not explicitly set.
- EudiWallet.Builder.build(): constructs EtsiTrustProvider, resolves deferred configs, wires ETSI reader trust store
- New configureReaderTrustStore() no-argument overload signals "use ETSI trust source"
- EudiWalletConfig: configureReaderTrustStore gains a (ReaderTrustConfigBuilder.() -> Unit) overload; the standalone configureReaderAuthPolicy() is preserved for certificate-based / custom ReaderTrustStore paths