### PR TITLE
docs: frame single-session cycle as spec-conformant (ISO 18013-5)

### DIFF
--- a/transfer-manager/README.md
+++ b/transfer-manager/README.md
@@ -352,9 +352,9 @@ The response is produced via
 
 Finally, the wire response is sent with `TransferManager.sendResponse(response)`.
 
-> **Note:** Currently, only a single request-response cycle per session is supported.
-> Sending a response automatically terminates the presentation session. To perform another
-> exchange, a new session must be started.
+> **Note:** Each session supports a single request-response cycle. Sending a response
+> terminates the presentation session; start a new session to perform another exchange.
+> This is conformant with ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional exchanges optional, not required.
 
 #### Inspecting the request
 

--- a/transfer-manager/docs/transfer-manager/eu.europa.ec.eudi.iso18013.transfer/-transfer-manager-impl/send-response.md
+++ b/transfer-manager/docs/transfer-manager/eu.europa.ec.eudi.iso18013.transfer/-transfer-manager-impl/send-response.md
@@ -7,7 +7,7 @@ open override fun [sendResponse](send-response.md)(response: [Response](../../eu
 
 Sends the response bytes to the connected mdoc verifier and terminates the session.
 
-**Note:** Currently, only a single request-response cycle per session is supported. The response is sent with Constants.SESSION_DATA_STATUS_SESSION_TERMINATION, which signals the end of the session to the verifier. Although ISO 18013-5 permits multiple request-response exchanges within a single session, this library always terminates the session after the first response.
+**Note:** Each session supports a single request-response cycle. Sending a response terminates the presentation session; start a new session to perform another exchange. This is conformant with ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional exchanges optional, not required.
 
 To generate the response, use the [eu.europa.ec.eudi.iso18013.transfer.response.device.ProcessedDeviceRequest.generateResponse](../../eu.europa.ec.eudi.iso18013.transfer.response.device/-processed-device-request/generate-response.md) that is provided by the [eu.europa.ec.eudi.iso18013.transfer.TransferEvent.RequestReceived](../-transfer-event/-request-received/index.md) event.
 

--- a/transfer-manager/docs/transfer-manager/eu.europa.ec.eudi.iso18013.transfer/-transfer-manager/send-response.md
+++ b/transfer-manager/docs/transfer-manager/eu.europa.ec.eudi.iso18013.transfer/-transfer-manager/send-response.md
@@ -7,7 +7,7 @@ abstract fun [sendResponse](send-response.md)(response: [Response](../../eu.euro
 
 Sends response bytes to the connected reader and terminates the session.
 
-**Note:** Currently, only a single request-response cycle per session is supported. Calling this method sends the response along with a session termination signal, ending the presentation session. To perform another exchange, a new session must be started.
+**Note:** Each session supports a single request-response cycle. Sending a response terminates the presentation session; start a new session to perform another exchange. This is conformant with ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional exchanges optional, not required.
 
 To generate the response, use the [RequestProcessor.ProcessedRequest.Success.generateResponse](../../eu.europa.ec.eudi.iso18013.transfer.response/-request-processor/-processed-request/-success/generate-response.md) method.
 

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
@@ -58,9 +58,11 @@ interface TransferManager : TransferEvent.Listenable {
     /**
      * Sends response bytes to the connected reader and terminates the session.
      *
-     * **Note:** Currently, only a single request-response cycle per session is supported.
-     * Calling this method sends the response along with a session termination signal,
-     * ending the presentation session. To perform another exchange, a new session must be started.
+     * **Note:** Each session supports a single request-response cycle.
+     * Sending a response terminates the presentation session;
+     * start a new session to perform another exchange. This is conformant
+     * with ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional
+     * exchanges optional, not required.
      *
      * To generate the response, use the [RequestProcessor.ProcessedRequest.Success.generateResponse]
      * method.

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
@@ -238,11 +238,11 @@ class TransferManagerImpl @JvmOverloads constructor(
     /**
      * Sends the response bytes to the connected mdoc verifier and terminates the session.
      *
-     * **Note:** Currently, only a single request-response cycle per session is supported.
-     * The response is sent with [Constants.SESSION_DATA_STATUS_SESSION_TERMINATION], which
-     * signals the end of the session to the verifier. Although ISO 18013-5 permits multiple
-     * request-response exchanges within a single session, this library always terminates
-     * the session after the first response.
+     * **Note:** Each session supports a single request-response cycle.
+     * Sending a response terminates the presentation session;
+     * start a new session to perform another exchange. This is conformant
+     * with ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional
+     * exchanges optional, not required.
      *
      * To generate the response, use the [eu.europa.ec.eudi.iso18013.transfer.response.device.ProcessedDeviceRequest.generateResponse]
      * that is provided by the [eu.europa.ec.eudi.iso18013.transfer.TransferEvent.RequestReceived] event.


### PR DESCRIPTION
Rewords the session-termination note in transfer-manager docs to frame the
single request-response cycle per session as a deliberate, spec-conformant
design choice rather than a current limitation.

- Updates the `sendResponse` KDoc on `TransferManager` and `TransferManagerImpl`
- Updates `transfer-manager/README.md`
- Regenerates the corresponding Dokka GFM `send-response` pages
- Cites ISO/IEC 18013-5:2021 §9.1.1.4, which makes additional exchanges optional

Docs only — no functional changes.

Closes #361 