### PR TITLE
Zero Knowledge Proof Response Policy enhancement

### DIFF
--- a/transfer-manager/README.md
+++ b/transfer-manager/README.md
@@ -675,12 +675,10 @@ The `ZkResponsePolicy` determines behavior when ZK proof generation fails:
 
 | Policy | Behavior |
 |--------|----------|
-| `ZkResponsePolicy.Strict` | Aborts disclosure for the document. **Recommended for production.** |
-| `ZkResponsePolicy.FallbackToFullDisclosure` | Falls back to sending the full document. Current default for backwards compatibility. |
+| `ZkResponsePolicy.Strict` | Aborts disclosure for the document (default). |
+| `ZkResponsePolicy.FallbackToFullDisclosure` | Falls back to sending the full document. |
 
-> **Note:** The default policy is `FallbackToFullDisclosure` for backwards compatibility. This will
-> change to `Strict` in a future release. We recommend explicitly setting `ZkResponsePolicy.Strict`
-> in production to prevent unintended full document disclosure when proof generation fails.
+Integrators using `EudiWalletConfig` can set the policy via `configureZkResponsePolicy()`.
 
 When a ZK proof is successfully generated, the credential is **not consumed** — the credential policy
 (e.g., one-time-use limits) is not applied, since the actual credential key is never sent to the

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
@@ -95,8 +95,7 @@ interface TransferManager : TransferEvent.Listenable {
          * @param retrievalMethods
          * @param zkSystemRepository
          * @param zkResponsePolicy the ZK response policy to use when ZK proof generation fails.
-         * Defaults to [ZkResponsePolicy.FallbackToFullDisclosure] for backwards compatibility.
-         * Consider using [ZkResponsePolicy.Strict] for production to prevent unintended full disclosure.
+         * Defaults to [ZkResponsePolicy.Strict] to prevent unintended full disclosure.
          * @return a [TransferManagerImpl]
          */
         @JvmStatic
@@ -107,7 +106,7 @@ interface TransferManager : TransferEvent.Listenable {
             readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
             retrievalMethods: List<DeviceRetrievalMethod>? = null,
             zkSystemRepository: ZkSystemRepository? = null,
-            zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
+            zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
         ): TransferManager = TransferManagerImpl(context) {
             documentManager(documentManager)
             readerTrustStore?.let { readerTrustStore(it) }

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
@@ -335,7 +335,7 @@ class TransferManagerImpl @JvmOverloads constructor(
         var readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent
         var retrievalMethods: List<DeviceRetrievalMethod>? = null
         var zkSystemRepository: ZkSystemRepository? = null
-        var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
+        var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
 
         /**
          * Document manager instance that will be used to retrieve the requested documents
@@ -379,8 +379,7 @@ class TransferManagerImpl @JvmOverloads constructor(
 
         /**
          * ZK response policy that determines behavior when ZK proof generation fails.
-         * Defaults to [ZkResponsePolicy.FallbackToFullDisclosure] for backwards compatibility.
-         * Consider using [ZkResponsePolicy.Strict] for production to prevent unintended full disclosure.
+         * Defaults to [ZkResponsePolicy.Strict] to prevent unintended full disclosure.
          * @param zkResponsePolicy
          */
         fun zkResponsePolicy(zkResponsePolicy: ZkResponsePolicy) = apply {

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
@@ -74,7 +74,7 @@ class DeviceRequestProcessor(
     override var readerTrustStore: ReaderTrustStore? = null,
     private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
     private var zkSystemRepository: ZkSystemRepository? = null,
-    internal val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure,
+    internal val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
 ) : RequestProcessor, ReaderTrustStoreAware {
 
     /**

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
@@ -74,7 +74,7 @@ class ProcessedDeviceRequest(
     trustMetadata: TrustMetadata?,
     private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
     private val zkSystemRepository: ZkSystemRepository? = null,
-    private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
+    private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
 ) : RequestProcessor.ProcessedRequest.Success(
     presentmentData = presentmentData,
     requester = requester,

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/zkp/ZkResponsePolicy.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/zkp/ZkResponsePolicy.kt
@@ -22,15 +22,13 @@ package eu.europa.ec.eudi.iso18013.transfer.zkp
 sealed interface ZkResponsePolicy {
 
     /**
-     * Abort disclosure for the document if ZK proof generation fails.
-     * Recommended for production use to prevent unintended full document disclosure.
+     * Abort disclosure for the document if ZK proof generation fails (default).
+     * Prevents unintended full document disclosure.
      */
     data object Strict : ZkResponsePolicy
 
     /**
      * Fall back to full document disclosure if ZK proof generation fails.
-     * This is the current default for backwards compatibility and will be changed
-     * to [Strict] in a future release.
      */
     data object FallbackToFullDisclosure : ZkResponsePolicy
 }

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
@@ -86,7 +86,7 @@ class TransferManagerImplBuilderTest {
         assertNotNull(transferManager)
         assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
         assertEquals(
-            ZkResponsePolicy.FallbackToFullDisclosure,
+            ZkResponsePolicy.Strict,
             (transferManager.requestProcessor as DeviceRequestProcessor).zkResponsePolicy
         )
     }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -491,6 +491,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                         readerAuthPolicy = config.readerAuthPolicy,
                         privilegedAllowlist = privilegedAllowlist,
                         zkSystemRepository = config.zkSystemRepository,
+                        zkResponsePolicy = config.zkResponsePolicy,
                         logger = loggerObj
                     ),
                     logger = loggerObj
@@ -582,7 +583,8 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                     clearBleCache = config.clearBleCache
                 )
             ),
-            zkSystemRepository = config.zkSystemRepository
+            zkSystemRepository = config.zkSystemRepository,
+            zkResponsePolicy = config.zkResponsePolicy
         )
 
         /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -23,6 +23,7 @@ import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.EudiWalletConfig.Companion.DEFAULT_DOCUMENT_MANAGER_IDENTIFIER
 import eu.europa.ec.eudi.wallet.dcapi.DCAPIConfig
 import eu.europa.ec.eudi.wallet.document.DocumentExtensions.getDefaultCreateDocumentSettings
@@ -601,6 +602,34 @@ class EudiWalletConfig {
         zkSystemRepository: ZkSystemRepository
     ) = apply {
         this.zkSystemRepository = zkSystemRepository
+    }
+
+    /**
+     * The policy that determines behavior when ZK proof generation fails during
+     * response generation.
+     *
+     * The available policies are:
+     * - [ZkResponsePolicy.Strict]: Aborts disclosure for the document when ZK proof
+     *   generation fails, preventing unintended full document disclosure (default).
+     * - [ZkResponsePolicy.FallbackToFullDisclosure]: Falls back to sending the full
+     *   document when ZK proof generation fails.
+     *
+     * The default is [ZkResponsePolicy.Strict].
+     *
+     * @see ZkResponsePolicy
+     * @see configureZkp
+     */
+    var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
+        private set
+
+    /**
+     * Configure the [ZkResponsePolicy] for Zero-Knowledge Proof response generation.
+     *
+     * @param zkResponsePolicy the ZK response policy
+     * @return the [EudiWalletConfig] instance
+     */
+    fun configureZkResponsePolicy(zkResponsePolicy: ZkResponsePolicy) = apply {
+        this.zkResponsePolicy = zkResponsePolicy
     }
 
     internal var issuerTrustConfig: IssuerTrustConfig? = null

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -595,16 +595,6 @@ class EudiWalletConfig {
         private set
 
     /**
-     * Configure Zero-Knowledge Proofs (ZKP) support.
-     * This allows you to enable ZKP support by providing a [ZkSystemRepository].
-     */
-    fun configureZkp(
-        zkSystemRepository: ZkSystemRepository
-    ) = apply {
-        this.zkSystemRepository = zkSystemRepository
-    }
-
-    /**
      * The policy that determines behavior when ZK proof generation fails during
      * response generation.
      *
@@ -617,18 +607,26 @@ class EudiWalletConfig {
      * The default is [ZkResponsePolicy.Strict].
      *
      * @see ZkResponsePolicy
-     * @see configureZkp
      */
     var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
         private set
 
     /**
-     * Configure the [ZkResponsePolicy] for Zero-Knowledge Proof response generation.
+     * Configure Zero-Knowledge Proofs (ZKP) support.
+     * This allows you to enable ZKP support by providing a [ZkSystemRepository]
+     * and optionally set the [ZkResponsePolicy] that determines behavior when
+     * ZK proof generation fails. The default policy is [ZkResponsePolicy.Strict].
      *
-     * @param zkResponsePolicy the ZK response policy
+     * @param zkSystemRepository the ZK system repository
+     * @param zkResponsePolicy the ZK response policy (default [ZkResponsePolicy.Strict])
      * @return the [EudiWalletConfig] instance
      */
-    fun configureZkResponsePolicy(zkResponsePolicy: ZkResponsePolicy) = apply {
+    @JvmOverloads
+    fun configureZkp(
+        zkSystemRepository: ZkSystemRepository,
+        zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
+    ) = apply {
+        this.zkSystemRepository = zkSystemRepository
         this.zkResponsePolicy = zkResponsePolicy
     }
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIRequestProcessor.kt
@@ -28,6 +28,7 @@ import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequest
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.device.ProcessedDeviceRequest
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.internal.d
 import eu.europa.ec.eudi.wallet.internal.e
@@ -59,6 +60,7 @@ internal class DCAPIRequestProcessor(
     private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
     private val privilegedAllowlist: String,
     private var zkSystemRepository: ZkSystemRepository?,
+    private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
     private var logger: Logger? = null,
 ) : RequestProcessor, ReaderTrustStoreAware {
 
@@ -72,7 +74,8 @@ internal class DCAPIRequestProcessor(
             documentManager = documentManager,
             readerTrustStore = readerTrustStore,
             readerAuthPolicy = readerAuthPolicy,
-            zkSystemRepository = zkSystemRepository
+            zkSystemRepository = zkSystemRepository,
+            zkResponsePolicy = zkResponsePolicy
         ).process(deviceRequest) as? ProcessedDeviceRequest
             ?: return RequestProcessor.ProcessedRequest.Failure(
                 DCAPIException("DeviceRequestProcessor failed to produce a ProcessedDeviceRequest"),


### PR DESCRIPTION
- Set default ZkResponsePolicy to Strict

- policy configuration possible via `EudiWalletConfig.configureZkResponsePolicy()`