### PR TITLE
Fix - use identifier-based credential request when issuer returns credential identifiers

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
@@ -58,8 +58,14 @@ internal class SubmitRequest(
         offeredDocument: Offer.OfferedDocument,
         keyUnlockData: Map<KeyAlias, KeyUnlockData?>? = null,
     ): ResponseResult<SubmissionOutcome> {
-        val payload =
-            IssuanceRequestPayload.ConfigurationBased(offeredDocument.configurationIdentifier)
+        val configId = offeredDocument.configurationIdentifier
+        val payload = authorizedRequest.credentialIdentifiers
+            ?.get(configId)
+            ?.firstOrNull()
+            ?.let { credentialIdentifier ->
+                IssuanceRequestPayload.IdentifierBased(configId, credentialIdentifier)
+            }
+            ?: IssuanceRequestPayload.ConfigurationBased(configId)
         val signers = unsignedDocument.getPoPSigners().toList()
 
         val (updatedAuthorizedRequest, outcome) = when (config.clientAuthenticationType) {


### PR DESCRIPTION

When a Credential Issuer returns authorization_details containing credential_identifiers in its token response, OpenID4VCI requires the subsequent credential request to be identifier-based. SubmitRequest unconditionally built a configuration-based request, causing issuance to fail with "Authorization detail type of openid_credential require usage of credential identifiers in credential request".

Select the payload based on what the token endpoint authorized: use IdentifierBased when the current authorized request carries credential identifiers for the configuration, falling back to ConfigurationBased otherwise (preserving behavior for issuers that do not return them).