### PR TITLE
Fix: tolerate out-of-bounds array index in DCQL SD-JWT claim_path

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -22,7 +22,6 @@ import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.engagement.BleRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl
-import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.statium.Status
 import eu.europa.ec.eudi.wallet.dcapi.DCAPIManager
 import eu.europa.ec.eudi.wallet.dcapi.DCAPIRegistration
@@ -474,8 +473,9 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                 OpenId4VpManager(
                     config = openId4VpConfig,
                     requestProcessor = DcqlRequestProcessor(
-                        documentManager,
-                        readerTrustStore
+                        documentManager = documentManager,
+                        readerTrustStore = readerTrustStore,
+                        logger = loggerObj
                     ),
                     logger = loggerObj,
                     ktorHttpClientFactory = ktorHttpClientFactory

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
@@ -31,8 +31,10 @@ import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcFormat
+import eu.europa.ec.eudi.wallet.internal.e
 import eu.europa.ec.eudi.wallet.internal.generateJarmNonce
 import eu.europa.ec.eudi.wallet.internal.toRequesterAndTrust
+import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpReaderTrust
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpReaderTrustImpl
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpRequest
@@ -73,6 +75,7 @@ import org.multipaz.sdjwt.credential.SdJwtVcCredential
 class DcqlRequestProcessor(
     private val documentManager: DocumentManager,
     var openid4VpX509CertificateTrust: OpenId4VpReaderTrust,
+    private var logger: Logger? = null
 ) : RequestProcessor, ReaderTrustStoreAware {
 
     /**
@@ -139,6 +142,7 @@ class DcqlRequestProcessor(
                 multipleByQueryId = multipleByQueryId
             )
         } catch (e: Throwable) {
+            logger?.e(TAG, "DCQL process failed", e)
             RequestProcessor.ProcessedRequest.Failure(e)
         }
     }
@@ -271,8 +275,13 @@ class DcqlRequestProcessor(
      * wildcard per OpenID4VP §7.1.
      */
     private fun matchClaim(req: RequestedClaim, credClaims: List<Claim>): Claim? {
-        val direct = credClaims.findMatchingClaim(req)
-        if (direct != null) return direct
+        // Skip the credential when the requested array index is out of bounds
+        val matchedClaim = try {
+            credClaims.findMatchingClaim(req)
+        } catch (_: IndexOutOfBoundsException) {
+            null
+        }
+        if (matchedClaim != null) return matchedClaim
         return matchClaimViaSpecCorrectNullWildcard(req, credClaims)
     }
 
@@ -389,9 +398,12 @@ class DcqlRequestProcessor(
     }
 
     companion object {
+        private const val TAG = "DcqlRequestProcessor"
+
         operator fun invoke(
             documentManager: DocumentManager,
             readerTrustStore: ReaderTrustStore?,
+            logger: Logger? = null
         ): DcqlRequestProcessor {
             val openId4VpReaderTrust = OpenId4VpReaderTrustImpl(
                 readerTrustStore = readerTrustStore
@@ -399,6 +411,7 @@ class DcqlRequestProcessor(
             return DcqlRequestProcessor(
                 documentManager = documentManager,
                 openid4VpX509CertificateTrust = openId4VpReaderTrust,
+                logger = logger
             )
         }
     }

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorTest.kt
@@ -948,4 +948,151 @@ class DcqlRequestProcessorTest {
         }
         return DcqlRequestProcessor(documentManager, trust)
     }
+
+    /**
+     * SD-JWT processor backed by multiple documents — one per entry in
+     * [perCredentialClaims]. Used when a test needs the wallet to hold several
+     * candidate credentials for the same query.
+     */
+    private fun buildSdJwtProcessorWithDocuments(
+        vct: String,
+        perCredentialClaims: List<List<Claim>>,
+    ): DcqlRequestProcessor {
+        val issuedDocs = perCredentialClaims.map { claims ->
+            val credential = mockk<SecureAreaBoundCredential> {
+                coEvery { getClaims(documentTypeRepository = null) } returns claims
+            }
+            mockk<IssuedDocument> {
+                every { format } returns SdJwtVcFormat(vct) as DocumentFormat
+                coEvery { findCredential(now = any()) } returns credential
+            }
+        }
+        val documentManager = mockk<DocumentManager> {
+            every { getDocuments(predicate = any()) } returns issuedDocs
+            every { getDocuments(predicate = null) } returns issuedDocs
+        }
+        val trust = mockk<OpenId4VpReaderTrust> {
+            every { result } returns ReaderTrustResult.Pending
+            every { readerTrustStore } returns null
+            every { readerTrustStore = any() } returns Unit
+        }
+        return DcqlRequestProcessor(documentManager, trust)
+    }
+
+    /**
+     * When the verifier asks for an array index the credential doesn't have, the
+     * credential is filtered out.
+     *
+     * Wallet holds a single PID with `nationalities = ["DE", "FR"]`; the query asks
+     * for index 5. Expected: zero matches.
+     */
+    @Test
+    fun `sdjwt out-of-bounds array index produces no matches`(): Unit = runBlocking {
+        val vct = "urn:eudi:pid:1"
+
+        val dcql = DCQL(
+            credentials = Credentials(
+                listOf(
+                    CredentialQuery.sdJwtVc(
+                        id = QueryId("pid"),
+                        sdJwtVcMeta = DCQLMetaSdJwtVcExtensions(vctValues = listOf(vct)),
+                        requireCryptographicHolderBinding = false,
+                        claims = listOf(
+                            ClaimsQuery.sdJwtVc(
+                                id = ClaimId("nat_at_5"),
+                                path = ClaimPath(
+                                    listOf(
+                                        ClaimPathElement.Claim("nationalities"),
+                                        ClaimPathElement.ArrayElement(5),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            credentialSets = null,
+        )
+
+        val credentialClaims = listOf<Claim>(
+            jsonClaim(
+                vct = vct,
+                claimName = "nationalities",
+                value = buildJsonArray {
+                    add(JsonPrimitive("DE"))
+                    add(JsonPrimitive("FR"))
+                },
+            ),
+        )
+        val processor = buildSdJwtProcessor(vct = vct, credentialClaims = credentialClaims)
+
+        val processed = processor.process(buildOpenId4VpRequest(dcql))
+
+        val success = assertIs<ProcessedDcqlRequest>(processed)
+        assertNoMatches(success)
+    }
+
+    /**
+     * When two candidate credentials hold arrays of different sizes, only the one
+     * whose array contains the requested index should match — the shorter one is
+     * filtered out without taking the rest of the request down with it.
+     *
+     * PID-A has 1 nationality; PID-B has 2. The query asks for index 1; only PID-B
+     * survives.
+     */
+    @Test
+    fun `sdjwt out-of-bounds for one of two credentials drops only that one`(): Unit = runBlocking {
+        val vct = "urn:eudi:pid:1"
+
+        val dcql = DCQL(
+            credentials = Credentials(
+                listOf(
+                    CredentialQuery.sdJwtVc(
+                        id = QueryId("pid"),
+                        sdJwtVcMeta = DCQLMetaSdJwtVcExtensions(vctValues = listOf(vct)),
+                        requireCryptographicHolderBinding = false,
+                        claims = listOf(
+                            ClaimsQuery.sdJwtVc(
+                                id = ClaimId("nat_at_1"),
+                                path = ClaimPath(
+                                    listOf(
+                                        ClaimPathElement.Claim("nationalities"),
+                                        ClaimPathElement.ArrayElement(1),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            credentialSets = null,
+        )
+
+        val pidA = listOf<Claim>(
+            jsonClaim(
+                vct = vct,
+                claimName = "nationalities",
+                value = buildJsonArray { add(JsonPrimitive("DE")) },
+            ),
+        )
+        val pidB = listOf<Claim>(
+            jsonClaim(
+                vct = vct,
+                claimName = "nationalities",
+                value = buildJsonArray {
+                    add(JsonPrimitive("DE"))
+                    add(JsonPrimitive("FR"))
+                },
+            ),
+        )
+        val processor = buildSdJwtProcessorWithDocuments(
+            vct = vct,
+            perCredentialClaims = listOf(pidA, pidB),
+        )
+
+        val processed = processor.process(buildOpenId4VpRequest(dcql))
+
+        val success = assertIs<ProcessedDcqlRequest>(processed)
+        success.assertSingleMatch()
+    }
 }


### PR DESCRIPTION
When a DCQL `claim_path` asks for an index inside an array that the credential's array doesn't have (e.g. index 5 in a 2-element array), the whole request used to fail. 

The credential should just be skipped, and other credentials should still be checked.