### PR TITLE
Fix: revocation policy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,9 @@ val config = EudiWalletConfig {
 > **DEV/Testing knobs:** `relaxCertificateProfiles()` strips `endEntityProfile` constraints
 > from all provider types, useful when DEV certificates don't fully conform to ETSI profile
 > requirements. `relaxPkixRevocation()` disables CRL/OCSP revocation checks when endpoints
-> are not available in the test environment.
+> are not available in the test environment. When `relaxPkixRevocation()` is **not** called,
+> PKIX revocation checking is enabled and strict — certificate chain validation will fail if
+> a certificate is revoked or if the revocation status cannot be determined.
 
 #### Advanced: Manual Trust Anchor Resolution (LoTE)
 
@@ -1034,14 +1036,31 @@ val config = EudiWalletConfig {
 ```
 
 **Using static certificates**: The overloads that accept `X509Certificate` lists remain
-available. The reader auth policy is also set separately:
+available. The reader auth policy is set separately, and the certificate revocation checking
+policy can be configured via the `revocationPolicy` parameter (defaults to
+`RevocationPolicy.HardFail`):
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureReaderTrustStore(listOf(trustedCert1, trustedCert2))
+    configureReaderTrustStore(
+        listOf(trustedCert1, trustedCert2),
+        revocationPolicy = RevocationPolicy.SoftFail
+    )
     configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
 }
 ```
+
+The available revocation policies are:
+
+| Policy | Behavior |
+|---|---|
+| `RevocationPolicy.HardFail` | **(Default)** Validation fails if a certificate is revoked **or** if the CRL/OCSP responder cannot be reached. |
+| `RevocationPolicy.SoftFail` | Validation fails if a certificate is revoked, but tolerates CRL/OCSP unavailability. |
+| `RevocationPolicy.NoCheck` | No revocation checking is performed. |
+
+> **Note:** `RevocationPolicy` only applies to the static certificate-based `configureReaderTrustStore`
+> overloads. When using ETSI/LoTE-based trust (via `configureEtsiTrust`), revocation checking is
+> controlled by `relaxPkixRevocation()` inside the `configureEtsiTrust` block instead.
 
 For advanced use cases requiring a specific verification context, create an
 `EtsiReaderTrustStore` explicitly:

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -422,11 +422,17 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
             val readerTrustStoreToUse = (readerTrustStore
                 ?: config.readerTrustStore
-                ?: if (config.useEtsiReaderTrust && etsiSource != null) {
-                    etsiSource.asReaderTrustStore()
-                } else null
-                ?: config.readerTrustedCertificates?.let { certificates ->
-                    ReaderTrustStoreImpl(certificates, profileValidation = { _, _ -> true })
+                ?: when {
+                    config.useEtsiReaderTrust && etsiSource != null ->
+                        etsiSource.asReaderTrustStore()
+
+                    else -> config.readerTrustedCertificates?.let { certificates ->
+                        ReaderTrustStoreImpl(
+                            certificates,
+                            profileValidation = { _, _ -> true },
+                            revocationPolicy = config.revocationPolicy,
+                        )
+                    }
                 })?.also {
                 if (it is EtsiReaderTrustStore) it.logger = loggerToUse
             }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -391,8 +391,8 @@ class EudiWalletConfig {
      * @see RevocationPolicy
      */
     fun configureReaderTrustStore(
+        vararg readerTrustedCertificates: X509Certificate,
         revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
-        vararg readerTrustedCertificates: X509Certificate
     ) = apply {
         this.readerTrustedCertificates = readerTrustedCertificates.toList()
         this.revocationPolicy = revocationPolicy
@@ -422,8 +422,8 @@ class EudiWalletConfig {
      */
     fun configureReaderTrustStore(
         context: Context,
+        @RawRes vararg certificateRes: Int,
         revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
-        @RawRes vararg certificateRes: Int
     ) = apply {
         this.readerTrustedCertificates = certificateRes.map { context.getCertificate(it) }
         this.revocationPolicy = revocationPolicy

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -22,6 +22,7 @@ import androidx.annotation.RawRes
 import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.RevocationPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.EudiWalletConfig.Companion.DEFAULT_DOCUMENT_MANAGER_IDENTIFIER
@@ -500,6 +501,48 @@ class EudiWalletConfig {
      */
     fun configureReaderAuthPolicy(readerAuthPolicy: ReaderAuthPolicy) = apply {
         this.readerAuthPolicy = readerAuthPolicy
+    }
+
+    /**
+     * The certificate revocation checking policy used during reader authentication
+     * trust path validation.
+     *
+     * This controls how the wallet verifies whether a reader's certificate has been
+     * revoked when validating the certificate chain against the configured
+     * [ReaderTrustStore] (certificate-based path only; ETSI/LoTE-based trust stores
+     * use their own revocation logic).
+     *
+     * The available policies are:
+     * - [RevocationPolicy.NoCheck]: No revocation checking is performed.
+     * - [RevocationPolicy.HardFail]: Validation fails if a certificate is revoked
+     *   **or** if the CRL/OCSP responder cannot be reached (default).
+     * - [RevocationPolicy.SoftFail]: Validation fails if a certificate is revoked,
+     *   but tolerates CRL/OCSP unavailability.
+     *
+     * The default is [RevocationPolicy.HardFail].
+     *
+     * @see RevocationPolicy
+     * @see configureReaderTrustStore
+     */
+    var revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail
+        private set
+
+    /**
+     * Configure the certificate revocation checking policy for reader authentication.
+     *
+     * This policy applies when the [ReaderTrustStore] is built from trusted certificates
+     * (i.e. using [configureReaderTrustStore] with certificate lists or raw resources).
+     * It does **not** affect ETSI/LoTE-based trust stores, which handle revocation
+     * internally.
+     *
+     * @param revocationPolicy the revocation policy to use
+     * @return the [EudiWalletConfig] instance
+     *
+     * @see RevocationPolicy
+     * @see configureReaderTrustStore
+     */
+    fun configureRevocationPolicy(revocationPolicy: RevocationPolicy) = apply {
+        this.revocationPolicy = revocationPolicy
     }
 
     var userAuthenticationRequired: Boolean = true

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -344,47 +344,89 @@ class EudiWalletConfig {
     /**
      * Configure the built-in [ReaderTrustStore] with a list of trusted certificates.
      *
+     * The [revocationPolicy] controls certificate revocation checking (CRL/OCSP)
+     * during trust path validation. The default is [RevocationPolicy.HardFail].
+     * For ETSI/LoTE-based trust, use [configureEtsiTrust] with `relaxPkixRevocation()` instead.
+     *
      * Example:
      * ```
-     * configureReaderTrustStore(listOf(certificate1, certificate2))
+     * configureReaderTrustStore(
+     *     listOf(certificate1, certificate2),
+     *     revocationPolicy = RevocationPolicy.SoftFail
+     * )
      * ```
      *
      * @param readerTrustedCertificates the reader trusted certificates
+     * @param revocationPolicy the certificate revocation checking policy (default [RevocationPolicy.HardFail])
      * @return the [EudiWalletConfig] instance
+     * @see RevocationPolicy
      */
-    fun configureReaderTrustStore(readerTrustedCertificates: List<X509Certificate>) = apply {
+    @JvmOverloads
+    fun configureReaderTrustStore(
+        readerTrustedCertificates: List<X509Certificate>,
+        revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
+    ) = apply {
         this.readerTrustedCertificates = readerTrustedCertificates
+        this.revocationPolicy = revocationPolicy
     }
 
     /**
      * Configure the built-in [ReaderTrustStore] with trusted certificates.
      *
+     * The [revocationPolicy] controls certificate revocation checking (CRL/OCSP)
+     * during trust path validation. The default is [RevocationPolicy.HardFail].
+     * For ETSI/LoTE-based trust, use [configureEtsiTrust] with `relaxPkixRevocation()` instead.
+     *
      * Example:
      * ```
-     * configureReaderTrustStore(certificate1, certificate2)
+     * configureReaderTrustStore(
+     *     certificate1, certificate2,
+     *     revocationPolicy = RevocationPolicy.SoftFail
+     * )
      * ```
      *
      * @param readerTrustedCertificates the reader trusted certificates
+     * @param revocationPolicy the certificate revocation checking policy (default [RevocationPolicy.HardFail])
      * @return the [EudiWalletConfig] instance
+     * @see RevocationPolicy
      */
-    fun configureReaderTrustStore(vararg readerTrustedCertificates: X509Certificate) = apply {
+    fun configureReaderTrustStore(
+        revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
+        vararg readerTrustedCertificates: X509Certificate
+    ) = apply {
         this.readerTrustedCertificates = readerTrustedCertificates.toList()
+        this.revocationPolicy = revocationPolicy
     }
 
     /**
      * Configure the built-in [ReaderTrustStore] with certificates loaded from raw resources.
      *
+     * The [revocationPolicy] controls certificate revocation checking (CRL/OCSP)
+     * during trust path validation. The default is [RevocationPolicy.HardFail].
+     * For ETSI/LoTE-based trust, use [configureEtsiTrust] with `relaxPkixRevocation()` instead.
+     *
      * Example:
      * ```
-     * configureReaderTrustStore(context, R.raw.reader_cert_1, R.raw.reader_cert_2)
+     * configureReaderTrustStore(
+     *     context,
+     *     R.raw.reader_cert_1, R.raw.reader_cert_2,
+     *     revocationPolicy = RevocationPolicy.SoftFail
+     * )
      * ```
      *
      * @param context the context
      * @param certificateRes the reader trusted certificates raw resources
+     * @param revocationPolicy the certificate revocation checking policy (default [RevocationPolicy.HardFail])
      * @return the [EudiWalletConfig] instance
+     * @see RevocationPolicy
      */
-    fun configureReaderTrustStore(context: Context, @RawRes vararg certificateRes: Int) = apply {
+    fun configureReaderTrustStore(
+        context: Context,
+        revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
+        @RawRes vararg certificateRes: Int
+    ) = apply {
         this.readerTrustedCertificates = certificateRes.map { context.getCertificate(it) }
+        this.revocationPolicy = revocationPolicy
     }
 
     /**
@@ -507,10 +549,13 @@ class EudiWalletConfig {
      * The certificate revocation checking policy used during reader authentication
      * trust path validation.
      *
-     * This controls how the wallet verifies whether a reader's certificate has been
-     * revoked when validating the certificate chain against the configured
-     * [ReaderTrustStore] (certificate-based path only; ETSI/LoTE-based trust stores
-     * use their own revocation logic).
+     * This applies only when the [ReaderTrustStore] is built from static trusted
+     * certificates (via [configureReaderTrustStore] with certificate lists or raw
+     * resources). ETSI/LoTE-based trust stores handle revocation internally via
+     * [configureEtsiTrust] with `relaxPkixRevocation()`.
+     *
+     * Set this through the `revocationPolicy` parameter of the certificate-based
+     * [configureReaderTrustStore] overloads.
      *
      * The available policies are:
      * - [RevocationPolicy.NoCheck]: No revocation checking is performed.
@@ -526,24 +571,6 @@ class EudiWalletConfig {
      */
     var revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail
         private set
-
-    /**
-     * Configure the certificate revocation checking policy for reader authentication.
-     *
-     * This policy applies when the [ReaderTrustStore] is built from trusted certificates
-     * (i.e. using [configureReaderTrustStore] with certificate lists or raw resources).
-     * It does **not** affect ETSI/LoTE-based trust stores, which handle revocation
-     * internally.
-     *
-     * @param revocationPolicy the revocation policy to use
-     * @return the [EudiWalletConfig] instance
-     *
-     * @see RevocationPolicy
-     * @see configureReaderTrustStore
-     */
-    fun configureRevocationPolicy(revocationPolicy: RevocationPolicy) = apply {
-        this.revocationPolicy = revocationPolicy
-    }
 
     var userAuthenticationRequired: Boolean = true
         internal set // internal for setting the default value from the builder

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
@@ -69,10 +69,10 @@ class EudiWalletImpl internal constructor(
     }
 
     override fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>) =
-        setReaderTrustStore(ReaderTrustStore.getDefault(trustedReaderCertificates))
+        setReaderTrustStore(ReaderTrustStore.getDefault(trustedReaderCertificates, config.revocationPolicy))
 
     override fun setTrustedReaderCertificates(vararg rawRes: Int) =
-        setReaderTrustStore(ReaderTrustStore.getDefault(rawRes.map { context.getCertificate(it) }))
+        setReaderTrustStore(ReaderTrustStore.getDefault(rawRes.map { context.getCertificate(it) }, config.revocationPolicy))
 
     /**
      * Creates an instance of [OpenId4VciManager] for interacting with the OpenID for Verifiable Credential Issuance protocol.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/EtsiTrustConfig.kt
@@ -154,8 +154,12 @@ class EtsiTrustConfigBuilder {
     /**
      * Disables PKIX revocation checking during certificate chain validation.
      *
-     * When enabled, `isRevocationEnabled` is set to `false` on the PKIX parameters.
+     * When called, `isRevocationEnabled` is set to `false` on the PKIX parameters.
      * Use this for DEV/testing environments where CRL/OCSP endpoints may not be available.
+     *
+     * When this is **not** called (the default), PKIX revocation checking is enabled and
+     * strict — certificate chain validation will fail if a certificate is revoked or if
+     * the revocation status cannot be determined (CRL/OCSP unavailable).
      */
     fun relaxPkixRevocation() {
         this.relaxPkixRevocation = true


### PR DESCRIPTION
When configuring the ReaderTrustStore with a static List of certificates the RevocationPolicy can be configured by passing it as a parameter 