### PR TITLE
Fix missing DPoP header in offer-based issuance flow

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OfferResolver.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OfferResolver.kt
@@ -16,12 +16,20 @@
 
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
+import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.CredentialOffer
+import eu.europa.ec.eudi.openid4vci.DPoPUsage
+import eu.europa.ec.eudi.openid4vci.HttpsUrl
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataPolicy
+import eu.europa.ec.eudi.openid4vci.JwsAlgorithm
 import eu.europa.ec.eudi.openid4vci.OpenId4VCIConfig
+import eu.europa.ec.eudi.openid4vci.Signer
+import eu.europa.ec.eudi.wallet.issue.openid4vci.dpop.DPopConfig
 import io.ktor.client.HttpClient
 import org.jetbrains.annotations.VisibleForTesting
 import java.net.URI
+import eu.europa.ec.eudi.openid4vci.DPoPConfig as VciDPoPConfig
+import eu.europa.ec.eudi.openid4vci.ProvisionDPoPSigner as VciProvisionDPoPSigner
 
 internal class OfferResolver(
     private val config: OpenId4VciManager.Config,
@@ -34,11 +42,35 @@ internal class OfferResolver(
             is OpenId4VciManager.ClientAuthenticationType.None -> type.clientId
             is OpenId4VciManager.ClientAuthenticationType.AttestationBased -> type.clientId
         }
+        val dPoPUsage = when (val dpop = config.dpopConfig) {
+            DPopConfig.Disabled -> DPoPUsage.Never
+
+            DPopConfig.Default, is DPopConfig.Custom -> {
+                val algorithm = if (dpop is DPopConfig.Custom) {
+                    dpop.secureArea.supportedAlgorithms
+                        .firstOrNull { it.isSigning && it.joseAlgorithmIdentifier != null }
+                        ?.joseAlgorithmIdentifier ?: "ES256"
+                } else {
+                    "ES256"
+                }
+                DPoPUsage.IfSupported(
+                    VciDPoPConfig(
+                        object : VciProvisionDPoPSigner {
+                            override val popAlgorithm = JwsAlgorithm(algorithm)
+                            override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> {
+                                error("DPoP signer should not be invoked during offer resolution")
+                            }
+                        }
+                    )
+                )
+            }
+        }
         OpenId4VCIConfig(
             clientId = clientId,
             authFlowRedirectionURI = URI.create(config.authFlowRedirectionURI),
             encryptionSupportConfig = config.responseEncryptionConfig,
             issuerMetadataPolicy = issuerMetadataPolicy,
+            dPoPUsage = dPoPUsage,
         )
     }
 


### PR DESCRIPTION
  openid4vci 0.12.0 moved offer resolution from standalone
  CredentialOfferRequestResolver to CredentialOffer.resolve(),
  which now requires an OpenId4VCIConfig. The OfferResolver was
  adapted to supply one, but omitted dPoPUsage — defaulting to
  DPoPUsage.Never. This caused the resolved CredentialOffer to
  carry a null dPoP, so Issuer.make() skipped DPoP entirely
  and /token requests failed with 400 "DPoP proof is missing".

  Add dPoPUsage configuration to OfferResolver.resolveConfig