### PR TITLE
Fix false over-asking for indexed and wildcard claim paths

### DIFF
--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/WrpRegistrationValidator.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/WrpRegistrationValidator.kt
@@ -24,19 +24,15 @@ import java.security.cert.X509Certificate
 interface WrpRegistrationInfo
 
 /**
- * An attestation requested in a presentation request, used by the validator to determine whether the
- * request asks for more than the relying party registered.
+ * A document requested in a device request, used by the validator to determine whether the request
+ * asks for more than the relying party registered.
  *
- * @property format the requested attestation format, for example `mso_mdoc`
- * @property docType the ISO/IEC-mdoc document type, when the attestation is an mdoc
- * @property vctValues the SD-JWT VC type values, when the attestation is an SD-JWT VC
- * @property claimPaths the path pointers of the requested claims
+ * @property docType the requested document type
+ * @property nameSpaces the requested data element identifiers, per namespace
  */
-data class RequestedAttestationInfo(
-    val format: String,
-    val docType: String? = null,
-    val vctValues: List<String>? = null,
-    val claimPaths: List<List<String>> = emptyList()
+data class RequestedDocument(
+    val docType: String,
+    val nameSpaces: Map<String, Set<String>> = emptyMap()
 )
 
 /**
@@ -48,7 +44,7 @@ fun interface WrpRegistrationValidator {
     suspend fun validate(
         registrationCertificate: ByteArray?,
         readerAccessChain: List<X509Certificate>,
-        requestedAttestations: List<RequestedAttestationInfo>
+        requestedDocuments: List<RequestedDocument>
     ): WrpRegistrationInfo
 }
 

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
@@ -21,12 +21,11 @@ import eu.europa.ec.eudi.iso18013.transfer.internal.getValidIssuedMsoMdocDocumen
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.EU_WRPRC_REQUEST_INFO_KEY
-import eu.europa.ec.eudi.iso18013.transfer.response.MSO_MDOC_FORMAT
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
 import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
@@ -138,7 +137,7 @@ class DeviceRequestProcessor(
                 validator.validate(
                     registrationCertificate = certificates.firstOrNull(),
                     readerAccessChain = readerCertChain,
-                    requestedAttestations = parsedRequest.docRequests.map { it.toRequestedAttestationInfo() },
+                    requestedDocuments = parsedRequest.docRequests.map { it.toRequestedDocument() },
                 )
             }
 
@@ -162,17 +161,13 @@ class DeviceRequestProcessor(
 }
 
 /**
- * Projects a single ISO 18013-5 [DocRequest] onto the [RequestedAttestationInfo] used to check the
- * request against the relying party's registered scope. The mdoc claim paths take the
- * `[namespace, element]` form.
+ * Projects a single ISO 18013-5 [DocRequest] onto the [RequestedDocument] used to check the request
+ * against the relying party's registered scope.
  */
-internal fun DocRequest.toRequestedAttestationInfo(): RequestedAttestationInfo =
-    RequestedAttestationInfo(
-        format = MSO_MDOC_FORMAT,
+internal fun DocRequest.toRequestedDocument(): RequestedDocument =
+    RequestedDocument(
         docType = docType,
-        claimPaths = nameSpaces.flatMap { (namespace, elements) ->
-            elements.keys.map { element -> listOf(namespace, element) }
-        }
+        nameSpaces = nameSpaces.mapValues { (_, elements) -> elements.keys }
     )
 
 /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -470,7 +470,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
             // authentication, a reader trust store configured directly is therefore also used to
             // validate the registration certificate signer chain. Revocation status is checked only
             // against the ETSI Trusted Lists (registration certificate status context).
-            val wrpRegistrationValidator: WrpRegistrationValidator?
+            val wrpRegistrationValidator: DefaultWrpRegistrationValidator?
             val registrationCertificatePolicy: RegistrationCertificatePolicy?
             val resolvedRegistration: ResolvedWrpRegistration?
             if (config.wrpRegistrationPolicy == WrpRegistrationPolicy.Disabled) {
@@ -565,7 +565,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
             transferManager: TransferManager,
             readerTrustStore: ReaderTrustStore?,
             loggerObj: Logger,
-            registrationValidator: WrpRegistrationValidator? = null,
+            registrationValidator: DefaultWrpRegistrationValidator? = null,
             registrationCertificatePolicy: RegistrationCertificatePolicy? = null,
             resolvedRegistration: ResolvedWrpRegistration? = null,
         ): PresentationManagerImpl {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/ClaimPathElement.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/ClaimPathElement.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration
+
+/**
+ * An element of a claim path, following the OpenID4VP claims path pointer syntax (clause 7). A path is
+ * a list of these elements and selects a claim, or a set of claims, within an attestation.
+ *
+ * - [Claim] selects the member with the given name.
+ * - [ArrayElement] selects the given index of an array.
+ * - [AllArrayElements] selects every element of an array.
+ *
+ * In JSON a path is an array whose elements are a string, a non-negative integer, or `null`
+ * respectively. A path into an mdoc is always two [Claim] elements, the namespace and the data element
+ * identifier (clause 7.2).
+ */
+sealed interface ClaimPathElement {
+
+    /** Selects the member named [name]. */
+    data class Claim(val name: String) : ClaimPathElement {
+        override fun toString(): String = name
+    }
+
+    /** Selects the element at [index] of an array. */
+    data class ArrayElement(val index: Int) : ClaimPathElement {
+        init {
+            require(index >= 0) { "index must be non-negative" }
+        }
+
+        override fun toString(): String = index.toString()
+    }
+
+    /** Selects every element of an array. */
+    data object AllArrayElements : ClaimPathElement {
+        override fun toString(): String = "null"
+    }
+
+    /**
+     * Whether this element selects everything [that] selects. An element selects what an equal element
+     * selects, and [AllArrayElements] also selects what any [ArrayElement] selects. It does not select
+     * what a [Claim] selects: the wildcard applies to arrays only, and OpenID4VP clause 7.1.1 makes it
+     * an error against anything else.
+     */
+    fun covers(that: ClaimPathElement): Boolean = when (this) {
+        AllArrayElements -> when (that) {
+            AllArrayElements, is ArrayElement -> true
+            is Claim -> false
+        }
+
+        is ArrayElement, is Claim -> this == that
+    }
+}
+
+/**
+ * Whether this path selects everything [that] selects: it is not empty, it is no longer than [that],
+ * and each of its elements selects the element at the same position. A shorter path therefore selects
+ * the whole subtree below it, while an empty path selects nothing.
+ */
+internal fun List<ClaimPathElement>.covers(that: List<ClaimPathElement>): Boolean =
+    isNotEmpty() && size <= that.size && withIndex().all { (index, element) -> element.covers(that[index]) }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificate.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificate.kt
@@ -129,12 +129,11 @@ data class RegisteredCredential(
  * A claim the relying party is registered to request, identified by its path.
  * Corresponds to an entry of the WRPRC `claim` array.
  *
- * @property path the path pointer to the claim, following the OpenID4VP DCQL claims path syntax; a
- *   null element is the array wildcard
+ * @property path the path to the claim, following the OpenID4VP DCQL claims path syntax
  * @property values the expected values of the claim, when registered
  */
 data class RegisteredClaim(
-    val path: List<String?>,
+    val path: List<ClaimPathElement>,
     val values: List<String>? = null
 )
 
@@ -161,6 +160,19 @@ data class CredentialMeta(
     val vctValues: List<String>? = null,
     val doctypeValue: String? = null
 )
+
+/**
+ * The [CredentialMeta] for the given properties, or null when neither identifies an attestation type.
+ */
+internal fun credentialMetaOrNull(
+    doctypeValue: String? = null,
+    vctValues: List<String>? = null,
+): CredentialMeta? =
+    if (doctypeValue == null && vctValues.isNullOrEmpty()) {
+        null
+    } else {
+        CredentialMeta(vctValues = vctValues, doctypeValue = doctypeValue)
+    }
 
 /**
  * An intermediary presenting a request on behalf of the relying party. Corresponds to the WRPRC

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateClaimDtos.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateClaimDtos.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.wallet.registration
 
 import android.annotation.SuppressLint
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -69,17 +70,28 @@ internal fun CredentialDto.toProvidedAttestation(): ProvidedAttestation =
 
 private fun ClaimDto.toRegisteredClaim(): RegisteredClaim =
     RegisteredClaim(
-        path = path.map { it.contentOrNull },
+        path = path.map { it.toClaimPathElement() },
         values = values?.map { it.content },
     )
 
+/**
+ * Reads one element of a registered claim path: `null` is the array wildcard, a non-negative integer
+ * is an array index, and anything else is a claim name.
+ */
+private fun JsonPrimitive.toClaimPathElement(): ClaimPathElement = when {
+    this is JsonNull -> ClaimPathElement.AllArrayElements
+    !isString -> content.toIntOrNull()
+        ?.takeIf { it >= 0 }
+        ?.let { ClaimPathElement.ArrayElement(it) }
+        ?: ClaimPathElement.Claim(content)
+
+    else -> ClaimPathElement.Claim(content)
+}
+
 private fun JsonObject?.toCredentialMeta(): CredentialMeta? {
     if (this == null) return null
-    val vctValues = this["vct_values"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
-    val doctypeValue = this["doctype_value"]?.jsonPrimitive?.contentOrNull
-    return if (vctValues.isNullOrEmpty() && doctypeValue == null) {
-        null
-    } else {
-        CredentialMeta(vctValues = vctValues, doctypeValue = doctypeValue)
-    }
+    return credentialMetaOrNull(
+        doctypeValue = this["doctype_value"]?.jsonPrimitive?.contentOrNull,
+        vctValues = this["vct_values"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull },
+    )
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateResult.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateResult.kt
@@ -80,7 +80,7 @@ val RegistrationCertificateResult.requiresExplicitApproval: Boolean
 data class OverAskedClaim(
     val format: String,
     val meta: CredentialMeta? = null,
-    val path: List<String>
+    val path: List<ClaimPathElement>
 )
 
 /**
@@ -93,5 +93,5 @@ data class OverAskedClaim(
  */
 data class OverProvidedAttestation(
     val format: String,
-    val meta: CredentialMeta? = null,
+    val meta: CredentialMeta? = null
 )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerOverProviding.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerOverProviding.kt
@@ -24,9 +24,9 @@ import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
  * `provides_attestations` scope.
  *
  * An offered attestation is reported when no registered provided attestation of the same format and
- * type covers it; a provided attestation with no declared type covers every attestation of that
- * format. When the registration declares no provided attestations, every offered attestation is
- * reported.
+ * type covers it. An attestation that does not identify its type is not matched on either side, since
+ * the type is mandatory. When the registration declares no provided attestations, every offered
+ * attestation is reported.
  */
 internal fun RegistrationCertificate.findOverProvidedAttestations(
     offered: List<OfferedAttestation>,
@@ -35,8 +35,8 @@ internal fun RegistrationCertificate.findOverProvidedAttestations(
 
 private fun ProvidedAttestation.covers(offered: OfferedAttestation): Boolean {
     if (format != offered.format) return false
-    val registeredMeta = meta ?: return true
-    val offeredMeta = offered.meta ?: return true
+    val registeredMeta = meta ?: return false
+    val offeredMeta = offered.meta ?: return false
     val docTypeMatch = registeredMeta.doctypeValue != null &&
         registeredMeta.doctypeValue == offeredMeta.doctypeValue
     val vctMatch = !registeredMeta.vctValues.isNullOrEmpty() &&

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DcqlRequestedAttestations.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DcqlRequestedAttestations.kt
@@ -15,30 +15,38 @@
  */
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
-
 import eu.europa.ec.eudi.openid4vp.Format
 import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.openid4vp.dcql.CredentialQuery
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.dcql.metaMsoMdoc
 import eu.europa.ec.eudi.openid4vp.dcql.metaSdJwtVc
+import eu.europa.ec.eudi.wallet.registration.credentialMetaOrNull
+import eu.europa.ec.eudi.wallet.registration.ClaimPathElement as RegistrationClaimPathElement
 
 /**
- * Projects the credential queries of a DCQL query onto a [RequestedAttestationInfo] list.
+ * Projects the credential queries of a DCQL query onto the requested attestations checked against the
+ * registered scope.
  */
-internal fun DCQL.toRequestedAttestationInfos(): List<RequestedAttestationInfo> =
-    credentials.value.map { it.toRequestedAttestationInfo() }
+internal fun DCQL.toRequestedAttestations(): List<RequestedAttestation> =
+    credentials.value.map { it.toRequestedAttestation() }
 
-private fun CredentialQuery.toRequestedAttestationInfo(): RequestedAttestationInfo {
-    val claimPaths = claims.orEmpty().map { claimsQuery ->
-        claimsQuery.path.value.mapNotNull { (it as? ClaimPathElement.Claim)?.name }
-    }
-
-    return RequestedAttestationInfo(
+private fun CredentialQuery.toRequestedAttestation(): RequestedAttestation {
+    val docType = if (format == Format.MsoMdoc) metaMsoMdoc?.doctypeValue?.value else null
+    val vctValues = if (format == Format.SdJwtVc) metaSdJwtVc?.vctValues else null
+    return RequestedAttestation(
         format = format.value,
-        docType = if (format == Format.MsoMdoc) metaMsoMdoc?.doctypeValue?.value else null,
-        vctValues = if (format == Format.SdJwtVc) metaSdJwtVc?.vctValues else null,
-        claimPaths = claimPaths,
+        meta = credentialMetaOrNull(doctypeValue = docType, vctValues = vctValues),
+        claimPaths = claims.orEmpty().map { claimsQuery ->
+            claimsQuery.path.value.map { it.toRegistrationClaimPathElement() }
+        },
     )
 }
+
+/** Projects a DCQL claim path element onto its registration equivalent, element for element. */
+private fun ClaimPathElement.toRegistrationClaimPathElement(): RegistrationClaimPathElement =
+    when (this) {
+        is ClaimPathElement.Claim -> RegistrationClaimPathElement.Claim(name)
+        is ClaimPathElement.ArrayElement -> RegistrationClaimPathElement.ArrayElement(index)
+        ClaimPathElement.AllArrayElements -> RegistrationClaimPathElement.AllArrayElements
+    }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationEvaluator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationEvaluator.kt
@@ -23,7 +23,6 @@ import eu.europa.ec.eudi.wallet.registration.RevocationOutcome
 import eu.europa.ec.eudi.wallet.registration.checkStatusListRevocation
 import eu.europa.ec.eudi.wallet.registration.validateCertificate
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import eu.europa.ec.eudi.statium.GetStatus
 import eu.europa.ec.eudi.statium.GetStatusListToken
 import eu.europa.ec.eudi.statium.Status
@@ -65,7 +64,7 @@ internal class DefaultWrpRegistrationEvaluator(
     override suspend fun evaluate(
         registration: RegistrationCertificate,
         accessCertificate: X509Certificate?,
-        requestedAttestations: List<RequestedAttestationInfo>,
+        requestedAttestations: List<RequestedAttestation>,
     ): RegistrationCertificateResult {
 
         registration.validateCertificate(accessCertificate, checkRevocation)?.let { failure ->
@@ -75,7 +74,7 @@ internal class DefaultWrpRegistrationEvaluator(
 
         // over-asking
         val overAskedClaims = registration.findOverAskedClaims(
-            requestedAttestations.map { it.toRequestedAttestation() },
+            requestedAttestations
         )
         logger?.d(
             TAG,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationValidator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationValidator.kt
@@ -16,12 +16,11 @@
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
-import eu.europa.ec.eudi.wallet.registration.CredentialMeta
 import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
 
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationInfo
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
 import java.security.cert.X509Certificate
 
 /**
@@ -40,7 +39,21 @@ internal class DefaultWrpRegistrationValidator(
     override suspend fun validate(
         registrationCertificate: ByteArray?,
         readerAccessChain: List<X509Certificate>,
-        requestedAttestations: List<RequestedAttestationInfo>,
+        requestedDocuments: List<RequestedDocument>
+    ): WrpRegistrationInfo = validateAttestations(
+        registrationCertificate = registrationCertificate,
+        readerAccessChain = readerAccessChain,
+        requested = requestedDocuments.map { it.toRequestedAttestation() },
+    )
+
+    /**
+     * Validates against requested attestations whose claim paths are already resolved, as the remote
+     * path produces them from the DCQL query.
+     */
+    internal suspend fun validateAttestations(
+        registrationCertificate: ByteArray?,
+        readerAccessChain: List<X509Certificate>,
+        requested: List<RequestedAttestation>
     ): WrpRegistrationInfo {
         val certificate = registrationCertificate
             ?: return RegistrationCertificateResult.Failed(RegistrationFailureReason.CERTIFICATE_ABSENT)
@@ -50,20 +63,11 @@ internal class DefaultWrpRegistrationValidator(
                 evaluator.evaluate(
                     registration = authentication.registration,
                     accessCertificate = readerAccessChain.firstOrNull(),
-                    requestedAttestations = requestedAttestations,
+                    requestedAttestations = requested
                 )
 
             is WrprcAuthentication.Invalid ->
                 RegistrationCertificateResult.Failed(authentication.reason)
         }
     }
-}
-
-internal fun RequestedAttestationInfo.toRequestedAttestation(): RequestedAttestation {
-    val meta = if (docType != null || !vctValues.isNullOrEmpty()) {
-        CredentialMeta(vctValues = vctValues, doctypeValue = docType)
-    } else {
-        null
-    }
-    return RequestedAttestation(format = format, meta = meta, claimPaths = claimPaths)
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DeviceRequestedAttestations.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DeviceRequestedAttestations.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration.relyingparty
+
+import eu.europa.ec.eudi.iso18013.transfer.response.MSO_MDOC_FORMAT
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
+import eu.europa.ec.eudi.wallet.registration.ClaimPathElement
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+
+/**
+ * Projects a document requested over ISO/IEC 18013-5 onto the attestation the registered scope is
+ * checked against. An mdoc claim path is the namespace and the data element identifier, both of them
+ * names (OpenID4VP clause 7.2).
+ */
+internal fun RequestedDocument.toRequestedAttestation(): RequestedAttestation =
+    RequestedAttestation(
+        format = MSO_MDOC_FORMAT,
+        meta = CredentialMeta(doctypeValue = docType),
+        claimPaths = nameSpaces.flatMap { (namespace, elements) ->
+            elements.map { element ->
+                listOf(ClaimPathElement.Claim(namespace), ClaimPathElement.Claim(element))
+            }
+        }
+    )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/OverAsking.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/OverAsking.kt
@@ -15,23 +15,25 @@
  */
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
+import eu.europa.ec.eudi.wallet.registration.ClaimPathElement
 import eu.europa.ec.eudi.wallet.registration.CredentialMeta
 import eu.europa.ec.eudi.wallet.registration.OverAskedClaim
 import eu.europa.ec.eudi.wallet.registration.RegisteredCredential
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import eu.europa.ec.eudi.wallet.registration.covers
 
 /**
  * An attestation together with the claims a relying party requests from it in a presentation
- * request. Used to check the request against the registered scope.
+ * request, checked against the registered scope by a [WrpRegistrationEvaluator].
  *
  * @property format the requested attestation format, for example `dc+sd-jwt` or `mso_mdoc`
  * @property meta the properties that identify the requested attestation type
- * @property claimPaths the path pointers of the requested claims
+ * @property claimPaths the paths of the requested claims, one list of [ClaimPathElement] per claim
  */
-internal data class RequestedAttestation(
+data class RequestedAttestation(
     val format: String,
     val meta: CredentialMeta? = null,
-    val claimPaths: List<List<String>> = emptyList(),
+    val claimPaths: List<List<ClaimPathElement>> = emptyList(),
 )
 
 /**
@@ -40,7 +42,9 @@ internal data class RequestedAttestation(
  *
  * A requested claim is reported when no registered credential of the same attestation permits it; a
  * registered credential with no declared claims permits every claim of that attestation. When the
- * registration declares no requestable credentials, every requested claim is reported.
+ * registration declares no requestable credentials, every requested claim is reported. A registered
+ * credential or a request that does not identify its attestation type is matched by neither, since the
+ * type is mandatory in both.
  */
 internal fun RegistrationCertificate.findOverAskedClaims(
     requested: List<RequestedAttestation>,
@@ -54,8 +58,8 @@ internal fun RegistrationCertificate.findOverAskedClaims(
 
 private fun RegisteredCredential.matches(requested: RequestedAttestation): Boolean {
     if (format != requested.format) return false
-    val registeredMeta = meta ?: return true
-    val requestedMeta = requested.meta ?: return true
+    val registeredMeta = meta ?: return false
+    val requestedMeta = requested.meta ?: return false
     val docTypeMatch = registeredMeta.doctypeValue != null &&
         registeredMeta.doctypeValue == requestedMeta.doctypeValue
     val vctMatch = !registeredMeta.vctValues.isNullOrEmpty() &&
@@ -64,12 +68,5 @@ private fun RegisteredCredential.matches(requested: RequestedAttestation): Boole
     return docTypeMatch || vctMatch
 }
 
-private fun RegisteredCredential.allows(path: List<String>): Boolean =
+private fun RegisteredCredential.allows(path: List<ClaimPathElement>): Boolean =
     claims.isEmpty() || claims.any { it.path.covers(path) }
-
-/**
- * Whether this registered claims path covers a requested one: equal length and, at each position, an
- * equal element or a null wildcard (the DCQL "all array elements" pointer).
- */
-private fun List<String?>.covers(requested: List<String>): Boolean =
-    size == requested.size && indices.all { this[it] == null || this[it] == requested[it] }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/RegistrationCertificatePolicyFactory.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/RegistrationCertificatePolicyFactory.kt
@@ -50,7 +50,7 @@ internal fun wrpRegistrationCertificatePolicy(
 ): RegistrationCertificatePolicy =
     RegistrationCertificatePolicy { accessCertificate, registrationCertificate, dcql ->
         val serialized = decodeSerializedRegistrationCertificate(registrationCertificate)
-        val requestedAttestations = dcql.toRequestedAttestationInfos()
+        val requestedAttestations = dcql.toRequestedAttestations()
         val result = if (serialized == null) {
             RegistrationCertificateResult.Failed(RegistrationFailureReason.MALFORMED)
         } else when (val authentication = authenticator.authenticate(serialized)) {

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/ResolvedWrpRegistration.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/ResolvedWrpRegistration.kt
@@ -17,7 +17,6 @@
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import java.security.cert.X509Certificate
 
 /**
@@ -46,8 +45,8 @@ internal class ResolvedWrpRegistration {
     fun publish(
         certificate: ByteArray,
         accessCertificate: X509Certificate?,
-        requestedAttestations: List<RequestedAttestationInfo>,
-        result: RegistrationCertificateResult,
+        requestedAttestations: List<RequestedAttestation>,
+        result: RegistrationCertificateResult
     ) {
         evaluation = Evaluation(certificate, accessCertificate, requestedAttestations, result)
     }
@@ -61,7 +60,7 @@ internal class ResolvedWrpRegistration {
     fun take(
         certificate: ByteArray?,
         accessCertificate: X509Certificate?,
-        requestedAttestations: List<RequestedAttestationInfo>,
+        requestedAttestations: List<RequestedAttestation>
     ): RegistrationCertificateResult? {
         val published = evaluation ?: return null
         evaluation = null
@@ -76,7 +75,7 @@ internal class ResolvedWrpRegistration {
     private class Evaluation(
         val certificate: ByteArray,
         val accessCertificate: X509Certificate?,
-        val requestedAttestations: List<RequestedAttestationInfo>,
-        val result: RegistrationCertificateResult,
+        val requestedAttestations: List<RequestedAttestation>,
+        val result: RegistrationCertificateResult
     )
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/WrpRegistrationEvaluator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/relyingparty/WrpRegistrationEvaluator.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import java.security.cert.X509Certificate
@@ -45,6 +44,6 @@ fun interface WrpRegistrationEvaluator {
     suspend fun evaluate(
         registration: RegistrationCertificate,
         accessCertificate: X509Certificate?,
-        requestedAttestations: List<RequestedAttestationInfo>,
+        requestedAttestations: List<RequestedAttestation>
     ): RegistrationCertificateResult
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
@@ -20,7 +20,6 @@ import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
-import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
 import eu.europa.ec.eudi.openid4vp.Format
 import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject
 import eu.europa.ec.eudi.openid4vp.dcql.CredentialQuery
@@ -42,7 +41,8 @@ import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.registration.relyingparty.ResolvedWrpRegistration
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.relyingparty.extractRegistrationCertificate
-import eu.europa.ec.eudi.wallet.registration.relyingparty.toRequestedAttestationInfos
+import eu.europa.ec.eudi.wallet.registration.relyingparty.DefaultWrpRegistrationValidator
+import eu.europa.ec.eudi.wallet.registration.relyingparty.toRequestedAttestations
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpReaderTrust
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpReaderTrustImpl
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpRequest
@@ -102,7 +102,7 @@ class DcqlRequestProcessor(
      * Validator for the relying party registration certificate. Set internally when the registration
      * policy is enforced; when null, the registration certificate is neither validated nor surfaced.
      */
-    internal var wrpRegistrationValidator: WrpRegistrationValidator? = null
+    internal var wrpRegistrationValidator: DefaultWrpRegistrationValidator? = null
 
     /**
      * Receives the registration certificate evaluation the OpenID4VP library policy produced while
@@ -196,14 +196,14 @@ class DcqlRequestProcessor(
     ): RegistrationCertificateResult? {
         val validator = wrpRegistrationValidator ?: return null
         val certificate = resolvedRequestObject.verifierInfo.extractRegistrationCertificate()
-        val requestedAttestations = dcql.toRequestedAttestationInfos()
+        val requestedAttestations = dcql.toRequestedAttestations()
         resolvedRegistration
             ?.take(certificate, accessChain.firstOrNull(), requestedAttestations)
             ?.let { return it }
-        return validator.validate(
+        return validator.validateAttestations(
             registrationCertificate = certificate,
             readerAccessChain = accessChain,
-            requestedAttestations = requestedAttestations,
+            requested = requestedAttestations,
         ) as? RegistrationCertificateResult
     }
 

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/ClaimPathTestHelpers.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/ClaimPathTestHelpers.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration
+
+/**
+ * Builds a claim path from the JSON shapes a path is written in: a string is a claim name, an integer
+ * is an array index, and null is the array wildcard.
+ */
+internal fun claimPath(vararg elements: Any?): List<ClaimPathElement> = elements.map { element ->
+    when (element) {
+        null -> ClaimPathElement.AllArrayElements
+        is Int -> ClaimPathElement.ArrayElement(element)
+        else -> ClaimPathElement.Claim(element.toString())
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateClaimPathTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/RegistrationCertificateClaimPathTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration
+
+import eu.europa.ec.eudi.wallet.registration.relyingparty.RequestedAttestation
+import eu.europa.ec.eudi.wallet.registration.relyingparty.findOverAskedClaims
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val PID_VCT = "urn:eudi:pid:1"
+private const val SD_JWT_VC_FORMAT = "dc+sd-jwt"
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/**
+ * Reading the claim paths a registration certificate declares for the credentials it may request
+ * (ETSI TS 119 475 clause 5.2.4 `credentials`). An element of a path is a claim name, an array index,
+ * or the wildcard for all elements of an array (OpenID4VP clause 7.1).
+ */
+class RegistrationCertificateClaimPathTest {
+
+    @Test
+    fun `path elements are read as names, indices and the wildcard`() {
+        val claims = registeredClaims(
+            """["family_name"]""",
+            """["nationalities", null]""",
+            """["nationalities", 0]""",
+            """["addresses", 0, "street"]""",
+        )
+
+        assertEquals(
+            listOf(
+                claimPath("family_name"),
+                claimPath("nationalities", null),
+                claimPath("nationalities", 0),
+                claimPath("addresses", 0, "street"),
+            ),
+            claims.map { it.path },
+        )
+    }
+
+    @Test
+    fun `a number and a quoted number are read differently`() {
+        val claims = registeredClaims("""["nationalities", 0]""", """["nationalities", "0"]""")
+
+        assertEquals(ClaimPathElement.ArrayElement(0), claims.first().path.last())
+        assertEquals(ClaimPathElement.Claim("0"), claims.last().path.last())
+    }
+
+    /**
+     * Only a non-negative integer is an array index, so a negative number is read as a claim name. It
+     * then matches no requested claim, which reports the request rather than granting it.
+     */
+    @Test
+    fun `a negative number is not an array index`() {
+        val claim = registeredClaims("""["nationalities", -1]""").single()
+
+        assertEquals(ClaimPathElement.Claim("-1"), claim.path.last())
+    }
+
+    @Test
+    fun `a declared wildcard covers the requested elements of that array`() {
+        val certificate = certificateRequesting("""["nationalities", null]""")
+
+        val overAsked = certificate.findOverAskedClaims(
+            listOf(
+                pidRequestFor(
+                    claimPath("nationalities", null),
+                    claimPath("nationalities", 0),
+                ),
+            ),
+        )
+
+        assertTrue("reported as over-asked: $overAsked", overAsked.isEmpty())
+    }
+
+    /**
+     * A claim entry with no path selects nothing, so it must not widen the registered scope. An empty
+     * path is not a valid claims path pointer (OpenID4VP clause 7.1).
+     */
+    @Test
+    fun `a claim declared with an empty path grants nothing`() {
+        val certificate = certificateRequesting("""[]""")
+
+        val overAsked = certificate.findOverAskedClaims(
+            listOf(pidRequestFor(claimPath("family_name"))),
+        )
+
+        assertEquals(claimPath("family_name"), overAsked.single().path)
+    }
+
+    @Test
+    fun `a declared index does not cover another index of the same array`() {
+        val certificate = certificateRequesting("""["nationalities", 0]""")
+
+        val overAsked = certificate.findOverAskedClaims(
+            listOf(pidRequestFor(claimPath("nationalities", 1))),
+        )
+
+        assertEquals(claimPath("nationalities", 1), overAsked.single().path)
+    }
+}
+
+/** Decodes a certificate payload that may request the given claim paths from a PID. */
+private fun certificateRequesting(vararg paths: String): RegistrationCertificate =
+    json.decodeFromString<RegistrationCertificateDto>(
+        """
+        {
+          "credentials": [
+            {
+              "format": "$SD_JWT_VC_FORMAT",
+              "meta": { "vct_values": ["$PID_VCT"] },
+              "claim": [${paths.joinToString(",") { """{"path": $it}""" }}]
+            }
+          ]
+        }
+        """.trimIndent(),
+    ).toRegistrationCertificate()
+
+private fun registeredClaims(vararg paths: String): List<RegisteredClaim> =
+    certificateRequesting(*paths).requestedCredentials.single().claims
+
+private fun pidRequestFor(vararg paths: List<ClaimPathElement>): RequestedAttestation =
+    RequestedAttestation(
+        format = SD_JWT_VC_FORMAT,
+        meta = CredentialMeta(vctValues = listOf(PID_VCT)),
+        claimPaths = paths.toList(),
+    )

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DcqlOverAskingTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DcqlOverAskingTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration.relyingparty
+
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPath
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimsQuery
+import eu.europa.ec.eudi.openid4vp.dcql.CredentialQuery
+import eu.europa.ec.eudi.openid4vp.dcql.Credentials
+import eu.europa.ec.eudi.openid4vp.dcql.DCQL
+import eu.europa.ec.eudi.openid4vp.dcql.DCQLMetaSdJwtVcExtensions
+import eu.europa.ec.eudi.openid4vp.dcql.QueryId
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.claimPath
+import eu.europa.ec.eudi.wallet.registration.RegisteredClaim
+import eu.europa.ec.eudi.wallet.registration.RegisteredCredential
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val PID_VCT = "urn:eudi:pid:1"
+private const val SD_JWT_VC_FORMAT = "dc+sd-jwt"
+
+/**
+ * Over-asking checked through the DCQL projection, so a requested path keeps every element of the
+ * pointer. A claim path is a list of elements that may be a claim name, an array index, or the
+ * wildcard for all array elements (OpenID4VP clause 6, ETSI TS 119 475 clause 5.2.4 `credentials`).
+ */
+class DcqlOverAskingTest {
+
+    @Test
+    fun `a wildcard request against a wildcard registration is within scope`() {
+        val requested = pidRequest(
+            ClaimPath(
+                listOf(ClaimPathElement.Claim("nationalities"), ClaimPathElement.AllArrayElements),
+            ),
+        )
+
+        val result = registeredForNationalitiesWildcard().findOverAskedClaims(requested)
+
+        assertTrue("a wildcard request is covered by a wildcard registration", result.isEmpty())
+    }
+
+    @Test
+    fun `an indexed request against a wildcard registration is within scope`() {
+        val requested = pidRequest(
+            ClaimPath(
+                listOf(ClaimPathElement.Claim("nationalities"), ClaimPathElement.ArrayElement(0)),
+            ),
+        )
+
+        val result = registeredForNationalitiesWildcard().findOverAskedClaims(requested)
+
+        assertTrue("an indexed request is covered by a wildcard registration", result.isEmpty())
+    }
+
+    @Test
+    fun `a nested path keeps its index and stays within scope`() {
+        val requested = pidRequest(
+            ClaimPath(
+                listOf(
+                    ClaimPathElement.Claim("addresses"),
+                    ClaimPathElement.ArrayElement(0),
+                    ClaimPathElement.Claim("street"),
+                ),
+            ),
+        )
+        val registration = registeredFor(
+            RegisteredClaim(path = claimPath("addresses", null, "street")),
+        )
+
+        val result = registration.findOverAskedClaims(requested)
+
+        assertTrue("the index in the middle of the path must be kept", result.isEmpty())
+    }
+
+    @Test
+    fun `a request outside the registered scope is still reported`() {
+        val requested = pidRequest(ClaimPath(listOf(ClaimPathElement.Claim("family_name"))))
+
+        val result = registeredForNationalitiesWildcard().findOverAskedClaims(requested)
+
+        assertEquals(1, result.size)
+        assertEquals(SD_JWT_VC_FORMAT, result.single().format)
+    }
+
+    /**
+     * A registered path that stops at a parent selects the whole subtree below it, so it covers a
+     * request that drills into a member of that subtree (OpenID4VP clause 7.3: `["address"]` selects
+     * the address claim with its sub-claims as the value).
+     */
+    @Test
+    fun `a request for a member of a registered parent is within scope`() {
+        val requested = pidRequest(
+            ClaimPath(listOf(ClaimPathElement.Claim("address"), ClaimPathElement.Claim("street_address"))),
+        )
+        val registration = registeredFor(RegisteredClaim(path = claimPath("address")))
+
+        val result = registration.findOverAskedClaims(requested)
+
+        assertTrue("a registered parent covers a requested member", result.isEmpty())
+    }
+
+    @Test
+    fun `a request for a sibling of a registered member is reported`() {
+        val requested = pidRequest(
+            ClaimPath(listOf(ClaimPathElement.Claim("address"), ClaimPathElement.Claim("street_address"))),
+        )
+        val registration = registeredFor(RegisteredClaim(path = claimPath("address", "postal_code")))
+
+        val result = registration.findOverAskedClaims(requested)
+
+        assertEquals(1, result.size)
+        assertEquals(claimPath("address", "street_address"), result.single().path)
+    }
+
+    @Test
+    fun `a wildcard request against an indexed registration is reported`() {
+        val requested = pidRequest(
+            ClaimPath(listOf(ClaimPathElement.Claim("nationalities"), ClaimPathElement.AllArrayElements)),
+        )
+        val registration = registeredFor(RegisteredClaim(path = claimPath("nationalities", 0)))
+
+        val result = registration.findOverAskedClaims(requested)
+
+        assertEquals(1, result.size)
+        assertEquals(claimPath("nationalities", null), result.single().path)
+    }
+}
+
+private fun registeredForNationalitiesWildcard(): RegistrationCertificate =
+    registeredFor(RegisteredClaim(path = claimPath("nationalities", null)))
+
+private fun registeredFor(vararg claims: RegisteredClaim): RegistrationCertificate =
+    RegistrationCertificate(
+        requestedCredentials = listOf(
+            RegisteredCredential(
+                format = SD_JWT_VC_FORMAT,
+                meta = CredentialMeta(vctValues = listOf(PID_VCT)),
+                claims = claims.toList(),
+            ),
+        ),
+    )
+
+/** Builds the requested attestations the same way a resolved request does. */
+private fun pidRequest(path: ClaimPath): List<RequestedAttestation> =
+    DCQL(
+        credentials = Credentials(
+            listOf(
+                CredentialQuery.sdJwtVc(
+                    id = QueryId("query_0"),
+                    sdJwtVcMeta = DCQLMetaSdJwtVcExtensions(vctValues = listOf(PID_VCT)),
+                    claims = listOf(ClaimsQuery.sdJwtVc(path = path)),
+                ),
+            ),
+        ),
+        credentialSets = null,
+    ).toRequestedAttestations()

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationEvaluatorTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationEvaluatorTest.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.wallet.registration.relyingparty
 
 import eu.europa.ec.eudi.wallet.registration.CertificateTrust
 import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.claimPath
 import eu.europa.ec.eudi.wallet.registration.Intermediary
 import eu.europa.ec.eudi.wallet.registration.OverAskedClaim
 import eu.europa.ec.eudi.wallet.registration.RegisteredClaim
@@ -26,7 +27,6 @@ import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
 import eu.europa.ec.eudi.wallet.registration.RegistrationIdentifier
 import eu.europa.ec.eudi.wallet.registration.RevocationOutcome
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import eu.europa.ec.eudi.statium.StatusIndex
 import eu.europa.ec.eudi.statium.StatusReference
 import io.mockk.mockk
@@ -226,7 +226,7 @@ class DefaultWrpRegistrationEvaluatorTest {
                         format = "mso_mdoc",
                         meta = CredentialMeta(doctypeValue = "org.iso.18013.5.1.mDL"),
                         claims = listOf(
-                            RegisteredClaim(path = listOf("org.iso.18013.5.1", "family_name")),
+                            RegisteredClaim(path = claimPath("org.iso.18013.5.1", "family_name")),
                         ),
                     ),
                 ),
@@ -236,12 +236,12 @@ class DefaultWrpRegistrationEvaluatorTest {
                 registration = registration,
                 accessCertificate = certificateWithOrgId("ORG-123"),
                 requestedAttestations = listOf(
-                    RequestedAttestationInfo(
+                    RequestedAttestation(
                         format = "mso_mdoc",
-                        docType = "org.iso.18013.5.1.mDL",
+                        meta = CredentialMeta(doctypeValue = "org.iso.18013.5.1.mDL"),
                         claimPaths = listOf(
-                            listOf("org.iso.18013.5.1", "family_name"),
-                            listOf("org.iso.18013.5.1", "portrait"),
+                            claimPath("org.iso.18013.5.1", "family_name"),
+                            claimPath("org.iso.18013.5.1", "portrait"),
                         ),
                     ),
                 ),
@@ -253,7 +253,7 @@ class DefaultWrpRegistrationEvaluatorTest {
                     OverAskedClaim(
                         format = "mso_mdoc",
                         meta = CredentialMeta(doctypeValue = "org.iso.18013.5.1.mDL"),
-                        path = listOf("org.iso.18013.5.1", "portrait"),
+                        path = claimPath("org.iso.18013.5.1", "portrait"),
                     ),
                 ),
                 verified.overAskedClaims,

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationValidatorTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DefaultWrpRegistrationValidatorTest.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
@@ -38,7 +37,7 @@ class DefaultWrpRegistrationValidatorTest {
         val result = validator.validate(
             registrationCertificate = null,
             readerAccessChain = emptyList(),
-            requestedAttestations = emptyList(),
+            requestedDocuments = emptyList()
         )
 
         assertEquals(
@@ -56,11 +55,11 @@ class DefaultWrpRegistrationValidatorTest {
         coEvery { authenticator.authenticate(any()) } returns WrprcAuthentication.Authentic(registration)
         coEvery { evaluator.evaluate(registration, any(), any()) } returns evaluation
 
-        val requested = listOf(RequestedAttestationInfo(format = "mso_mdoc"))
-        val result = validator.validate(
+        val requested = listOf(RequestedAttestation(format = "mso_mdoc"))
+        val result = validator.validateAttestations(
             registrationCertificate = byteArrayOf(1, 2, 3),
             readerAccessChain = emptyList(),
-            requestedAttestations = requested,
+            requested = requested
         )
 
         assertSame(evaluation, result)
@@ -75,7 +74,7 @@ class DefaultWrpRegistrationValidatorTest {
         val result = validator.validate(
             registrationCertificate = byteArrayOf(9),
             readerAccessChain = emptyList(),
-            requestedAttestations = emptyList(),
+            requestedDocuments = emptyList()
         )
 
         assertEquals(

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DeviceRequestedAttestationsTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/DeviceRequestedAttestationsTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.registration.relyingparty
+
+import eu.europa.ec.eudi.iso18013.transfer.response.MSO_MDOC_FORMAT
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
+import eu.europa.ec.eudi.wallet.registration.ClaimPathElement
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.RegisteredClaim
+import eu.europa.ec.eudi.wallet.registration.RegisteredCredential
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import eu.europa.ec.eudi.wallet.registration.claimPath
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val MDL_DOCTYPE = "org.iso.18013.5.1.mDL"
+private const val MDL_NAMESPACE = "org.iso.18013.5.1"
+private const val MDL_EU_NAMESPACE = "eu.europa.ec.eudi.mdl.1"
+
+/**
+ * Projecting a document requested over ISO/IEC 18013-5 onto the attestation the registered scope is
+ * checked against, as the proximity and DC-API paths do.
+ */
+class DeviceRequestedAttestationsTest {
+
+    /**
+     * An mdoc claim path is the namespace and the data element identifier, both of type string
+     * (OpenID4VP clause 7.2), so neither is an array index or the wildcard.
+     */
+    @Test
+    fun `a path is the namespace and the data element, both as names`() {
+        val requested = mdlRequest(MDL_NAMESPACE to setOf("family_name")).toRequestedAttestation()
+
+        assertEquals(
+            listOf(
+                listOf(
+                    ClaimPathElement.Claim(MDL_NAMESPACE),
+                    ClaimPathElement.Claim("family_name"),
+                ),
+            ),
+            requested.claimPaths
+        )
+    }
+
+    @Test
+    fun `the document type identifies the requested attestation`() {
+        val requested = mdlRequest().toRequestedAttestation()
+
+        assertEquals(MSO_MDOC_FORMAT, requested.format)
+        assertEquals(CredentialMeta(doctypeValue = MDL_DOCTYPE), requested.meta)
+    }
+
+    @Test
+    fun `every element of every requested namespace is projected`() {
+        val requested = mdlRequest(
+            MDL_NAMESPACE to setOf("family_name", "age_over_18"),
+            MDL_EU_NAMESPACE to setOf("portrait"),
+        ).toRequestedAttestation()
+
+        assertEquals(
+            setOf(
+                claimPath(MDL_NAMESPACE, "family_name"),
+                claimPath(MDL_NAMESPACE, "age_over_18"),
+                claimPath(MDL_EU_NAMESPACE, "portrait")
+            ),
+            requested.claimPaths.toSet(),
+        )
+    }
+
+    @Test
+    fun `a document requesting nothing has no claim paths`() {
+        assertEquals(emptyList<List<ClaimPathElement>>(), mdlRequest().toRequestedAttestation().claimPaths)
+    }
+
+    @Test
+    fun `a projected request within the registered scope is not reported`() {
+        val overAsked = registeredForMdl("family_name").findOverAskedClaims(
+            listOf(mdlRequest(MDL_NAMESPACE to setOf("family_name")).toRequestedAttestation()),
+        )
+
+        assertTrue("reported as over-asked: $overAsked", overAsked.isEmpty())
+    }
+
+    @Test
+    fun `a projected request outside the registered scope is reported`() {
+        val overAsked = registeredForMdl("family_name").findOverAskedClaims(
+            listOf(mdlRequest(MDL_NAMESPACE to setOf("portrait")).toRequestedAttestation()),
+        )
+
+        assertEquals(claimPath(MDL_NAMESPACE, "portrait"), overAsked.single().path)
+    }
+}
+
+private fun mdlRequest(vararg nameSpaces: Pair<String, Set<String>>): RequestedDocument =
+    RequestedDocument(docType = MDL_DOCTYPE, nameSpaces = nameSpaces.toMap())
+
+private fun registeredForMdl(vararg elements: String): RegistrationCertificate =
+    RegistrationCertificate(
+        requestedCredentials = listOf(
+            RegisteredCredential(
+                format = MSO_MDOC_FORMAT,
+                meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
+                claims = elements.map { RegisteredClaim(path = claimPath(MDL_NAMESPACE, it)) },
+            )
+        )
+    )

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/OverAskingTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/OverAskingTest.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
 import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.claimPath
 import eu.europa.ec.eudi.wallet.registration.OverAskedClaim
 import eu.europa.ec.eudi.wallet.registration.RegisteredClaim
 import eu.europa.ec.eudi.wallet.registration.RegisteredCredential
@@ -71,6 +72,42 @@ class OverAskingTest {
         assertEquals(listOf(overAsked("family_name"), overAsked("given_name")), result)
     }
 
+    /**
+     * A credential query must state the attestation type for both supported formats, `doctype_value`
+     * for mdoc and `vct_values` for SD-JWT VC (OpenID4VP clauses B.2.3 and B.3.5). A query that omits
+     * it cannot be scoped to a registered type, so its claims are reported.
+     */
+    @Test
+    fun `a request naming no attestation type is outside a registration that names one`() {
+        val registration = RegistrationCertificate(
+            requestedCredentials = listOf(registeredMdl("family_name")),
+        )
+
+        val result = registration.findOverAskedClaims(untypedRequest("family_name"))
+
+        assertEquals(1, result.size)
+        assertEquals(claimPath(MDL_NAMESPACE, "family_name"), result.single().path)
+    }
+
+    /**
+     * The attestation type is mandatory in a registered credential: `meta` has multiplicity [1..1] in
+     * ETSI TS 119 475 clause B.2.9, the standard the registration certificate is required to comply
+     * with. An entry without it identifies no attestation, so it covers nothing rather than every
+     * attestation of its format.
+     */
+    @Test
+    fun `a registration naming no attestation type covers nothing`() {
+        val registration = RegistrationCertificate(
+            requestedCredentials = listOf(
+                RegisteredCredential(format = "mso_mdoc", claims = emptyList()),
+            ),
+        )
+
+        val result = registration.findOverAskedClaims(mdlRequest("family_name"))
+
+        assertEquals(listOf(overAsked("family_name")), result)
+    }
+
     @Test
     fun `no registered credentials and no requested claims reports nothing`() {
         val registration = RegistrationCertificate(requestedCredentials = emptyList())
@@ -80,21 +117,28 @@ class OverAskingTest {
         assertTrue(result.isEmpty())
     }
 
+    /**
+     * The array wildcard applies to arrays only: a path element of `null` selects all elements of the
+     * currently selected array, and OpenID4VP clause 7.1.1 makes it an error against anything else. An
+     * mdoc path is exactly two strings (clause 7.2), so a namespace is never covered by a wildcard —
+     * "every claim of this attestation" is expressed by registering no claims at all, which the test
+     * above covers.
+     */
     @Test
-    fun `a registered null wildcard path covers any requested element at that position`() {
+    fun `a registered wildcard does not cover an mdoc namespace`() {
         val registration = RegistrationCertificate(
             requestedCredentials = listOf(
                 RegisteredCredential(
                     format = "mso_mdoc",
                     meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
-                    claims = listOf(RegisteredClaim(path = listOf(MDL_NAMESPACE, null))),
+                    claims = listOf(RegisteredClaim(path = claimPath(MDL_NAMESPACE, null))),
                 ),
             ),
         )
 
-        val result = registration.findOverAskedClaims(mdlRequest("family_name", "portrait"))
+        val result = registration.findOverAskedClaims(mdlRequest("family_name"))
 
-        assertTrue(result.isEmpty())
+        assertEquals(listOf(overAsked("family_name")), result)
     }
 
     @Test
@@ -104,7 +148,7 @@ class OverAskingTest {
                 RegisteredCredential(
                     format = "mso_mdoc",
                     meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
-                    claims = listOf(RegisteredClaim(path = listOf("other.namespace", null))),
+                    claims = listOf(RegisteredClaim(path = claimPath("other.namespace", null))),
                 ),
             ),
         )
@@ -115,12 +159,22 @@ class OverAskingTest {
     }
 }
 
+/** A request whose credential query carries an empty `meta`, so it names no attestation type. */
+private fun untypedRequest(vararg elements: String): List<RequestedAttestation> =
+    listOf(
+        RequestedAttestation(
+            format = "mso_mdoc",
+            meta = null,
+            claimPaths = elements.map { claimPath(MDL_NAMESPACE, it) },
+        ),
+    )
+
 private fun mdlRequest(vararg elements: String): List<RequestedAttestation> =
     listOf(
         RequestedAttestation(
             format = "mso_mdoc",
             meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
-            claimPaths = elements.map { listOf(MDL_NAMESPACE, it) },
+            claimPaths = elements.map { claimPath(MDL_NAMESPACE, it) },
         ),
     )
 
@@ -128,12 +182,12 @@ private fun registeredMdl(vararg elements: String): RegisteredCredential =
     RegisteredCredential(
         format = "mso_mdoc",
         meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
-        claims = elements.map { RegisteredClaim(path = listOf(MDL_NAMESPACE, it)) },
+        claims = elements.map { RegisteredClaim(path = claimPath(MDL_NAMESPACE, it)) },
     )
 
 private fun overAsked(element: String): OverAskedClaim =
     OverAskedClaim(
         format = "mso_mdoc",
         meta = CredentialMeta(doctypeValue = MDL_DOCTYPE),
-        path = listOf(MDL_NAMESPACE, element),
+        path = claimPath(MDL_NAMESPACE, element),
     )

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/ResolvedWrpRegistrationTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/relyingparty/ResolvedWrpRegistrationTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.wallet.registration.relyingparty
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedAttestationInfo
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
 import org.junit.Assert.assertEquals
@@ -27,7 +27,7 @@ import java.security.cert.X509Certificate
 import java.util.Date
 
 private val CERTIFICATE = byteArrayOf(1, 2, 3)
-private val ATTESTATIONS = listOf(RequestedAttestationInfo(format = "mso_mdoc", docType = "org.iso.18013.5.1.mDL"))
+private val ATTESTATIONS = listOf(RequestedAttestation(format = "mso_mdoc", meta = CredentialMeta(doctypeValue = "org.iso.18013.5.1.mDL")))
 private val RESULT = RegistrationCertificateResult.Verified(RegistrationCertificate(name = "Relying Party"))
 
 class ResolvedWrpRegistrationTest {
@@ -77,7 +77,7 @@ class ResolvedWrpRegistrationTest {
     fun `an evaluation is not taken by a request asking for different attestations`() {
         resolvedRegistration.publish(CERTIFICATE, accessCertificate, ATTESTATIONS, RESULT)
 
-        val other = listOf(RequestedAttestationInfo(format = "mso_mdoc", docType = "eu.europa.ec.eudi.pid.1"))
+        val other = listOf(RequestedAttestation(format = "mso_mdoc", meta = CredentialMeta(doctypeValue = "eu.europa.ec.eudi.pid.1")))
         assertNull(resolvedRegistration.take(CERTIFICATE, accessCertificate, other))
     }
 


### PR DESCRIPTION
Requesting ["nationalities", 0] or ["nationalities", null] from an SD-JWT PID was reported as over-asking even when the registration certificate declared ["nationalities", null]. Claim paths were modelled as plain strings: the DCQL projection dropped array indices and the wildcard, and the certificate side stringified them, so the requested and registered paths no longer matched.

Model a claim path as a list of ClaimPathElement (claim name, array index, or all array elements) with containment as defined in OpenID4VP clause 7, and carry it through the over-asking check on every channel.