### PR TITLE
Issuer registration certificate: add resolveIssuerRegistration pre-check

### DIFF
--- a/REGISTRATION_CERTIFICATE.md
+++ b/REGISTRATION_CERTIFICATE.md
@@ -23,7 +23,7 @@ compared against, and how the outcome is read.
 | Registered scope | `credentials` — what it may request | `provides_attestations` — what it may issue |
 | Out-of-scope finding | Over-**asking** (claim level) | Over-**providing** (attestation level) |
 | Policy | `WrpRegistrationPolicy` | `IssuerRegistrationPolicy` |
-| Outcome read from | `ProcessedRequest.Success.wrpRegistration` | `Offer.issuerRegistration`, `IssueEvent.IssuerRegistrationChecked` |
+| Outcome read from | `ProcessedRequest.Success.wrpRegistration` | `Offer.issuerRegistration`, `OpenId4VciManager.resolveIssuerRegistration(…)` |
 
 > **Note:** Registration-certificate handling is **enabled by default** on both paths.
 
@@ -289,9 +289,7 @@ issuer metadata; otherwise it is silently skipped and logged.
 **An absent certificate is not a failure to the wallet.** Metadata that carries no registration
 certificate yields `null` rather than `Failed(CERTIFICATE_ABSENT)`, so the application can tell "the
 issuer offered none" apart from "one was offered and did not validate". Metadata that carries more than
-one is reported as `Failed(MALFORMED)`. Neither is treated as a failure here — but note that the
-OpenID4VCI library does reject the issuance itself in these cases, as described under
-[Validation does not block](#validation-does-not-block).
+one is reported as `Failed(MALFORMED)`.
 
 ### Enabling and disabling
 
@@ -372,20 +370,32 @@ openId4VciManager.resolveDocumentOffer(offerUri) { result ->
 }
 ```
 
-**During issuance** — `IssueEvent.IssuerRegistrationChecked`, delivered before `IssueEvent.Started`
-whichever method started the issuance. Use it when the issuance does not begin from a resolved offer;
-it arrives only when there is an outcome:
+**Before issuance, on demand** — `OpenId4VciManager.resolveIssuerRegistration(…)`, for flows that do
+not begin from a resolved offer: issuing by configuration identifier, or before a re-issuance. It
+resolves the issuer metadata and returns the verdict up front, so the application can decide whether to
+proceed before any credential is requested:
 
 ```kotlin
-openId4VciManager.issueDocumentByConfigurationIdentifiers(issuerUrl, ids) { event ->
-    when (event) {
-        is IssueEvent.IssuerRegistrationChecked ->
-            if (event.result.requiresExplicitApproval) {
-                // warn the user before the issuance proceeds
-            }
-        // … the remaining issuance events
-        else -> Unit
+// wallet-initiated issuance, by issuer URL and offered configuration identifiers:
+val outcome = openId4VciManager.resolveIssuerRegistration(issuerUrl, credentialConfigurationIds)
+// or, before re-issuing an existing document:
+val outcome = openId4VciManager.resolveIssuerRegistration(documentId)
+
+when (val registration = outcome.getOrNull()) {
+    is RegistrationCertificateResult.Failed -> {
+        // the issuer could not be verified — registration.reason says why
+        // (UNTRUSTED_PROVIDER, EXPIRED, REVOKED, MALFORMED, …); inform the user and refuse if you choose to
+        val reason = registration.reason
     }
+    is RegistrationCertificateResult.Verified ->
+        if (registration.overProvidedAttestations.isEmpty()) {
+            // verified AND within the registered scope — nothing to warn about
+        } else {
+            // verified, but the issuer offers attestations beyond its registered scope (over-providing)
+            // registration.overProvidedAttestations — the attestation types outside the registered scope
+        }
+    // null: no verdict to act on — proceed as for an unregulated issuer
+    null -> Unit
 }
 ```
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -47,6 +47,7 @@ import eu.europa.ec.eudi.wallet.issue.openid4vci.reissue.ReissuanceIssuer
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.provider.WalletAttestationsProvider
 import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.issuer.IssuerRegistrationResolver
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import io.ktor.client.HttpClient
@@ -328,20 +329,71 @@ internal class DefaultOpenId4VciManager(
      * disabled, signed issuer metadata is not configured, or no trust is available for the
      * certificate's signer chain.
      */
-    private suspend fun Offer.withIssuerRegistration(): Offer {
-        if (issuerMetadataPolicy !is IssuerMetadataPolicy.RequireSigned) return this
-        // Qualified: within this Offer receiver, issuerRegistration is the offer's own outcome.
-        val resolver = this@DefaultOpenId4VciManager.issuerRegistration ?: return this
-        val result = runCatching {
-            resolver.resolve(
+    private suspend fun Offer.withIssuerRegistration(): Offer =
+        copy(
+            issuerRegistration = evaluateIssuerRegistration(
                 metadata = issuerMetadata,
-                offeredConfigurationIds = credentialOffer.credentialConfigurationIdentifiers,
-            )
-        }.getOrElse {
-            logger?.e(TAG, "issuer registration resolution failed", it)
-            null
+                configurationIds = credentialOffer.credentialConfigurationIdentifiers,
+            ).getOrNull()
+        )
+
+    /**
+     * Authenticates and evaluates the credential issuer's registration certificate for the given
+     * metadata and offered configurations. A success carries the validation verdict; a failure means
+     * no validation applied — signed issuer metadata is not required, no resolver is available, or the
+     * issuer published no registration certificate — or carries the underlying error when the
+     * resolution itself failed.
+     */
+    private suspend fun evaluateIssuerRegistration(
+        metadata: CredentialIssuerMetadata,
+        configurationIds: List<CredentialConfigurationIdentifier>,
+    ): Result<RegistrationCertificateResult> {
+        if (issuerMetadataPolicy !is IssuerMetadataPolicy.RequireSigned) {
+            return Result.failure(IllegalStateException("issuer registration validation not applicable: signed issuer metadata is not required"))
         }
-        return copy(issuerRegistration = result)
+        val resolver = issuerRegistration
+            ?: return Result.failure(IllegalStateException("issuer registration validation not applicable: no registration resolver configured"))
+        return runCatching {
+            resolver.resolve(metadata = metadata, offeredConfigurationIds = configurationIds)
+        }.fold(
+            onSuccess = { result ->
+                if (result == null) {
+                    Result.failure(IllegalStateException("issuer registration validation not applicable: issuer published no registration certificate"))
+                } else {
+                    Result.success(result)
+                }
+            },
+            onFailure = { error ->
+                logger?.e(TAG, "issuer registration resolution failed", error)
+                Result.failure(error)
+            },
+        )
+    }
+
+    override suspend fun resolveIssuerRegistration(
+        issuerUrl: String,
+        credentialConfigurationIds: List<String>
+    ): Result<RegistrationCertificateResult> =
+        getIssuerMetadata(issuerUrl).fold(
+            onSuccess = { metadata ->
+                evaluateIssuerRegistration(
+                    metadata = metadata,
+                    configurationIds = credentialConfigurationIds.map { CredentialConfigurationIdentifier(it) },
+                )
+            },
+            onFailure = { error ->
+                logger?.e(TAG, "issuer metadata resolution failed", error)
+                Result.failure(error)
+            },
+        )
+
+    override suspend fun resolveIssuerRegistration(documentId: DocumentId): Result<RegistrationCertificateResult> {
+        val issuanceMetadata = loadIssuanceMetadata(documentId)
+            ?: return Result.failure(IllegalStateException("No issuance metadata stored for document $documentId"))
+        return resolveIssuerRegistration(
+            issuerUrl = issuanceMetadata.credentialIssuerId,
+            credentialConfigurationIds = listOf(issuanceMetadata.credentialConfigurationIdentifier),
+        )
     }
 
     override fun resumeWithAuthorization(uri: Uri) = issuerAuthorization.resumeFromUri(uri)
@@ -414,8 +466,6 @@ internal class DefaultOpenId4VciManager(
                 )
                 val requestMap = documentCreator.createDocuments(offer)
 
-                (offer.issuerRegistration ?: offer.withIssuerRegistration().issuerRegistration)
-                    ?.let { listener(IssueEvent.IssuerRegistrationChecked(it)) }
                 listener(IssueEvent.Started(requestMap.size))
 
                 //  Submit the issuance request using stored AuthorizedRequest
@@ -530,8 +580,6 @@ internal class DefaultOpenId4VciManager(
         txCode: String?,
         listener: OpenId4VciManager.OnResult<IssueEvent>,
     ) {
-        (offer.issuerRegistration ?: offer.withIssuerRegistration().issuerRegistration)
-            ?.let { listener(IssueEvent.IssuerRegistrationChecked(it)) }
         var authorizedRequest = issuerAuthorization.authorize(issuer, txCode)
         listener(IssueEvent.Started(offer.offeredDocuments.size))
         val issuedDocumentIds = mutableListOf<DocumentId>()

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssueEvent.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/IssueEvent.kt
@@ -21,7 +21,6 @@ import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.UnsignedDocument
-import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import org.multipaz.crypto.Algorithm
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.KeyUnlockData
@@ -38,16 +37,6 @@ sealed interface IssueEvent : OpenId4VciResult {
      * @property total the total number of documents to issue
      */
     data class Started(val total: Int) : IssueEvent
-
-    /**
-     * The credential issuer's registration certificate — carried in the signed issuer metadata
-     * (`issuer_info`, ETSI TS 119 472-3) — was validated. Emitted before the issuance proceeds when
-     * issuer registration validation is enabled and the metadata carried a registration certificate.
-     * The outcome is informative and does not block issuance; the wallet may present it to the user
-     * (for example a warning when [RegistrationCertificateResult] requires explicit approval).
-     * @property result the registration validation outcome
-     */
-    data class IssuerRegistrationChecked(val result: RegistrationCertificateResult) : IssueEvent
 
     /**
      * The issuance has finished.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
@@ -31,6 +31,7 @@ import eu.europa.ec.eudi.wallet.document.DeferredDocument
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager.Config.ParUsage.Companion.IF_SUPPORTED
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager.Config.ParUsage.Companion.NEVER
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager.Config.ParUsage.Companion.REQUIRED
@@ -58,6 +59,37 @@ interface OpenId4VciManager {
      * @param issuerUrl the issuer URL to resolve metadata from
      */
     suspend fun getIssuerMetadata(issuerUrl: String): Result<CredentialIssuerMetadata>
+
+    /**
+     * Resolves the credential issuer's registration certificate (ETSI TS 119 472-3 `issuer_info`)
+     * for the given issuer and credential configurations, without starting an issuance. Use it to
+     * obtain the outcome up front — to present it to the user or to decide whether to proceed — for
+     * flows that do not carry a resolved [Offer], such as direct configuration-identifier issuance.
+     *
+     * @param issuerUrl the issuer URL to resolve metadata from
+     * @param credentialConfigurationIds the offered credential configuration identifiers
+     * @return success with the validation verdict when a validation ran; a failure when no validation
+     *   applied (the wallet does not require signed issuer metadata, or the issuer published no
+     *   registration certificate); or a failure carrying the underlying error when the check could not
+     *   be performed
+     */
+    suspend fun resolveIssuerRegistration(
+        issuerUrl: String,
+        credentialConfigurationIds: List<String>
+    ): Result<RegistrationCertificateResult>
+
+    /**
+     * Resolves the credential issuer's registration certificate for the issuer and credential
+     * configuration of a previously issued [documentId], without starting a re-issuance. Use it to
+     * obtain the outcome before re-issuing, so a decision to refuse lands before the existing
+     * document is replaced.
+     *
+     * @param documentId the identifier of the document that would be re-issued
+     * @return success with the validation verdict when a validation ran; a failure when no validation
+     *   applied; or a failure carrying the underlying error when the check could not be performed,
+     *   including when no issuance metadata is stored for [documentId]
+     */
+    suspend fun resolveIssuerRegistration(documentId: DocumentId): Result<RegistrationCertificateResult>
 
 
     /**


### PR DESCRIPTION
Adds a pull-based pre-check so the app can obtain the credential issuer's registration
certificate verdict before issuing — for flows that don't start from a resolved offer
(wallet-initiated "add from list", and re-issuance):

- `OpenId4VciManager.resolveIssuerRegistration(issuerUrl, credentialConfigurationIds)`
- `OpenId4VciManager.resolveIssuerRegistration(documentId)`

Removes `IssueEvent.IssuerRegistrationChecked`

Docs updated in `REGISTRATION_CERTIFICATE.md`.