### PR TITLE
Forward RedirectURI dispatch outcome via TransferEvent.Redirect

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpManager.kt
@@ -354,8 +354,8 @@ class OpenId4VpManager(
                     encryptionParameters = response.encryptionParameters,
                 )) {
                     is DispatchOutcome.RedirectURI -> {
-                        logger?.d(TAG, "Verifier respond with RedirectURI: ${outcome.value}")
-                        transferEventListeners.onTransferEvent(TransferEvent.ResponseSent)
+                        logger?.d(TAG, "Redirecting to: ${outcome.value}")
+                        transferEventListeners.onTransferEvent(TransferEvent.Redirect(outcome.value))
                     }
 
                     is DispatchOutcome.VerifierResponse.Accepted -> {


### PR DESCRIPTION
## Summary

`OpenId4VpManager.sendResponse()` discards the redirect URI for `DispatchOutcome.RedirectURI` — the outcome produced when `response_mode` is `fragment`/`query` (i.e. no `direct_post` HTTP backend). It only emits `TransferEvent.ResponseSent`, never `TransferEvent.Redirect(outcome.value)`, so:

- The wallet never fires `ACTION_VIEW` back to the verifier's `redirect_uri`.
- Since the encoded `vp_token` response is embedded directly in that URI for this response mode, the response payload itself is lost, not just the redirect.

This is inconsistent with the neighboring `DispatchOutcome.VerifierResponse.Accepted` branch (and with `reject()`), both of which already forward a non-null redirect URI via `TransferEvent.Redirect`.

## Fix

```kotlin
is DispatchOutcome.RedirectURI -> {
    logger?.d(TAG, "Redirecting to: ${outcome.value}")
    transferEventListeners.onTransferEvent(TransferEvent.Redirect(outcome.value))
}
```

## Test plan

- [ ] Verified locally: same-device OpenID4VP presentation with `response_mode=fragment` and a custom-scheme `redirect_uri` now correctly redirects back into the verifier app with the `vp_token` response after the wallet's success screen.