### PR TITLE
Bug Fix identifier-based credential request when issuer returns credential identifiers

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
 import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
+import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerId
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadata
@@ -454,6 +455,11 @@ internal class DefaultOpenId4VciManager(
 
                 val offer = Offer(issuer.credentialOffer, issuerRegistration)
 
+                //  Expand offered documents into IssuanceItems based on credential identifiers
+                //  from the token response (one item per credential identifier, or one
+                //  ConfigurationBased item when no identifiers are present).
+                val issuanceItems = expandToIssuanceItems(offer, updatedAuthorizedRequest.credentialIdentifiers)
+
                 //  Create a new UnsignedDocument (fresh keys) via DocumentCreator
                 //    This fires IssueEvent.DocumentRequiresCreateSettings.MandatoryReusePolicy
                 //    or IssueEvent.DocumentRequiresCreateSettings.OptionalReusePolicy so the app
@@ -464,7 +470,7 @@ internal class DefaultOpenId4VciManager(
                     supportedPolicies = config.supportedCredentialReusePolicies,
                     logger = logger
                 )
-                val requestMap = documentCreator.createDocuments(offer)
+                val requestMap = documentCreator.createDocuments(issuanceItems)
 
                 listener(IssueEvent.Started(requestMap.size))
 
@@ -581,7 +587,8 @@ internal class DefaultOpenId4VciManager(
         listener: OpenId4VciManager.OnResult<IssueEvent>,
     ) {
         var authorizedRequest = issuerAuthorization.authorize(issuer, txCode)
-        listener(IssueEvent.Started(offer.offeredDocuments.size))
+        val issuanceItems = expandToIssuanceItems(offer, authorizedRequest.credentialIdentifiers)
+        listener(IssueEvent.Started(issuanceItems.size))
         val issuedDocumentIds = mutableListOf<DocumentId>()
         val deferredDocumentIds = mutableListOf<DocumentId>()
         val documentCreator = DocumentCreator(
@@ -590,7 +597,7 @@ internal class DefaultOpenId4VciManager(
             supportedPolicies = config.supportedCredentialReusePolicies,
             logger = logger
         )
-        val requestMap = documentCreator.createDocuments(offer)
+        val requestMap = documentCreator.createDocuments(issuanceItems)
 
         val submit = SubmitRequest(walletProvider, issuer, authorizedRequest)
         val response = submit.request(requestMap).also {
@@ -650,4 +657,28 @@ internal class DefaultOpenId4VciManager(
         }
     }
 
+}
+
+/**
+ * Expands the offer's documents into [IssuanceItem]s based on the credential identifiers
+ * returned in the token response.
+ *
+ * When the Authorization Server returns `credential_identifiers` for a configuration,
+ * each identifier represents a distinct credential dataset that requires its own request.
+ * This function creates one [IssuanceItem.IdentifierBased] per identifier. When no
+ * identifiers are present for a configuration, a single [IssuanceItem.ConfigurationBased]
+ * is produced (preserving backward compatibility).
+ */
+internal fun expandToIssuanceItems(
+    offer: Offer,
+    credentialIdentifiers: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>?,
+): List<IssuanceItem> = offer.offeredDocuments.flatMap { offeredDocument ->
+    val identifiers = credentialIdentifiers?.get(offeredDocument.configurationIdentifier)
+    if (!identifiers.isNullOrEmpty()) {
+        identifiers.map { credentialIdentifier ->
+            IssuanceItem.IdentifierBased(offeredDocument, credentialIdentifier)
+        }
+    } else {
+        listOf(IssuanceItem.ConfigurationBased(offeredDocument))
+    }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -22,6 +22,7 @@ import androidx.core.net.toUri
 import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError
+import eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerId
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadataResolver
@@ -455,10 +456,10 @@ internal class DefaultOpenId4VciManager(
 
                 val offer = Offer(issuer.credentialOffer, issuerRegistration)
 
-                //  Expand offered documents into IssuanceItems based on credential identifiers
-                //  from the token response (one item per credential identifier, or one
-                //  ConfigurationBased item when no identifiers are present).
-                val issuanceItems = expandToIssuanceItems(offer, updatedAuthorizedRequest.credentialIdentifiers)
+                //  Resolve issuance request payloads based on credential identifiers
+                //  from the token response (one IdentifierBased payload per credential
+                //  identifier, or one ConfigurationBased payload when none are present).
+                val issuancePayloads = resolveIssuanceRequestPayloads(offer, updatedAuthorizedRequest.credentialIdentifiers)
 
                 //  Create a new UnsignedDocument (fresh keys) via DocumentCreator
                 //    This fires IssueEvent.DocumentRequiresCreateSettings.MandatoryReusePolicy
@@ -470,7 +471,7 @@ internal class DefaultOpenId4VciManager(
                     supportedPolicies = config.supportedCredentialReusePolicies,
                     logger = logger
                 )
-                val requestMap = documentCreator.createDocuments(issuanceItems)
+                val requestMap = documentCreator.createDocuments(issuancePayloads)
 
                 listener(IssueEvent.Started(requestMap.size))
 
@@ -587,8 +588,8 @@ internal class DefaultOpenId4VciManager(
         listener: OpenId4VciManager.OnResult<IssueEvent>,
     ) {
         var authorizedRequest = issuerAuthorization.authorize(issuer, txCode)
-        val issuanceItems = expandToIssuanceItems(offer, authorizedRequest.credentialIdentifiers)
-        listener(IssueEvent.Started(issuanceItems.size))
+        val issuancePayloads = resolveIssuanceRequestPayloads(offer, authorizedRequest.credentialIdentifiers)
+        listener(IssueEvent.Started(issuancePayloads.size))
         val issuedDocumentIds = mutableListOf<DocumentId>()
         val deferredDocumentIds = mutableListOf<DocumentId>()
         val documentCreator = DocumentCreator(
@@ -597,7 +598,7 @@ internal class DefaultOpenId4VciManager(
             supportedPolicies = config.supportedCredentialReusePolicies,
             logger = logger
         )
-        val requestMap = documentCreator.createDocuments(issuanceItems)
+        val requestMap = documentCreator.createDocuments(issuancePayloads)
 
         val submit = SubmitRequest(walletProvider, issuer, authorizedRequest)
         val response = submit.request(requestMap).also {
@@ -660,25 +661,27 @@ internal class DefaultOpenId4VciManager(
 }
 
 /**
- * Expands the offer's documents into [IssuanceItem]s based on the credential identifiers
- * returned in the token response.
+ * Resolves the [IssuanceRequestPayload] for each offered document based on the credential
+ * identifiers returned in the token response.
  *
  * When the Authorization Server returns `credential_identifiers` for a configuration,
  * each identifier represents a distinct credential dataset that requires its own request.
- * This function creates one [IssuanceItem.IdentifierBased] per identifier. When no
- * identifiers are present for a configuration, a single [IssuanceItem.ConfigurationBased]
- * is produced (preserving backward compatibility).
+ * This function creates one [IssuanceRequestPayload.IdentifierBased] entry per identifier.
+ * When no identifiers are present for a configuration, a single
+ * [IssuanceRequestPayload.ConfigurationBased] entry is produced (preserving backward
+ * compatibility).
  */
-internal fun expandToIssuanceItems(
+internal fun resolveIssuanceRequestPayloads(
     offer: Offer,
     credentialIdentifiers: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>?,
-): List<IssuanceItem> = offer.offeredDocuments.flatMap { offeredDocument ->
-    val identifiers = credentialIdentifiers?.get(offeredDocument.configurationIdentifier)
+): List<Pair<Offer.OfferedDocument, IssuanceRequestPayload>> = offer.offeredDocuments.flatMap { offeredDocument ->
+    val configId = offeredDocument.configurationIdentifier
+    val identifiers = credentialIdentifiers?.get(configId)
     if (!identifiers.isNullOrEmpty()) {
         identifiers.map { credentialIdentifier ->
-            IssuanceItem.IdentifierBased(offeredDocument, credentialIdentifier)
+            offeredDocument to IssuanceRequestPayload.IdentifierBased(configId, credentialIdentifier)
         }
     } else {
-        listOf(IssuanceItem.ConfigurationBased(offeredDocument))
+        listOf(offeredDocument to IssuanceRequestPayload.ConfigurationBased(configId))
     }
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DocumentCreator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DocumentCreator.kt
@@ -36,6 +36,9 @@ internal class DocumentCreator(
     suspend fun createDocuments(offer: Offer): Map<UnsignedDocument, Offer.OfferedDocument> =
         offer.offeredDocuments.associateBy { createDocument(it) }
 
+    suspend fun createDocuments(items: List<IssuanceItem>): Map<UnsignedDocument, IssuanceItem> =
+        items.associateBy { createDocument(it.offeredDocument) }
+
     suspend fun createDocument(offeredDocument: Offer.OfferedDocument): UnsignedDocument {
         val resolvedPolicy = resolveReusePolicy(
             offeredDocument.credentialReusePolicy,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DocumentCreator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DocumentCreator.kt
@@ -17,6 +17,7 @@
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.CredentialReusePolicies
+import eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload
 import eu.europa.ec.eudi.wallet.document.CreateDocumentSettings
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.UnsignedDocument
@@ -36,8 +37,10 @@ internal class DocumentCreator(
     suspend fun createDocuments(offer: Offer): Map<UnsignedDocument, Offer.OfferedDocument> =
         offer.offeredDocuments.associateBy { createDocument(it) }
 
-    suspend fun createDocuments(items: List<IssuanceItem>): Map<UnsignedDocument, IssuanceItem> =
-        items.associateBy { createDocument(it.offeredDocument) }
+    suspend fun createDocuments(
+        items: List<Pair<Offer.OfferedDocument, IssuanceRequestPayload>>,
+    ): Map<UnsignedDocument, Pair<Offer.OfferedDocument, IssuanceRequestPayload>> =
+        items.associateBy { createDocument(it.first) }
 
     suspend fun createDocument(offeredDocument: Offer.OfferedDocument): UnsignedDocument {
         val resolvedPolicy = resolveReusePolicy(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
@@ -51,7 +51,7 @@ internal class ProcessResponse(
     val logger: Logger? = null,
     val authorizedRequest: AuthorizedRequest,
     val issuer: Issuer,
-    val documentToConfigurationMap: Map<UnsignedDocument, Offer.OfferedDocument>,
+    val documentToConfigurationMap: Map<UnsignedDocument, IssuanceItem>,
     val dpopKeyAlias: String?,
     val issuanceMetadataStorage: Storage,
     val clientAuthentication: ClientAuthentication,
@@ -164,7 +164,7 @@ internal class ProcessResponse(
                     dpopKeyAlias
                 ).copy(
                     replacesDocumentId = replacesDocumentId,
-                    credentialConfigurationIdentifier = documentToConfigurationMap[unsignedDocument]?.configurationIdentifier?.value,
+                    credentialConfigurationIdentifier = documentToConfigurationMap[unsignedDocument]?.offeredDocument?.configurationIdentifier?.value,
                     credentialEndpoint = issuer.credentialOffer.credentialIssuerMetadata.credentialEndpoint.toString(),
                 )
 
@@ -203,7 +203,7 @@ internal class ProcessResponse(
 
         runCatching {
             val credentialConfigurationId = requireNotNull(
-                documentToConfigurationMap[unsignedDocument]?.configurationIdentifier?.value
+                documentToConfigurationMap[unsignedDocument]?.offeredDocument?.configurationIdentifier?.value
             ) { "Credential configuration identifier not found for document" }
 
             // Get metadata from credential offer

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ProcessResponse.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.eudi.wallet.issue.openid4vci
 import eu.europa.ec.eudi.openid4vci.AccessToken
 import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
 import eu.europa.ec.eudi.openid4vci.ClientAuthentication
+import eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload
 import eu.europa.ec.eudi.openid4vci.Issuer
 import eu.europa.ec.eudi.openid4vci.SubmissionOutcome
 import eu.europa.ec.eudi.wallet.document.DocumentId
@@ -51,7 +52,7 @@ internal class ProcessResponse(
     val logger: Logger? = null,
     val authorizedRequest: AuthorizedRequest,
     val issuer: Issuer,
-    val documentToConfigurationMap: Map<UnsignedDocument, IssuanceItem>,
+    val documentToConfigurationMap: Map<UnsignedDocument, Pair<Offer.OfferedDocument, IssuanceRequestPayload>>,
     val dpopKeyAlias: String?,
     val issuanceMetadataStorage: Storage,
     val clientAuthentication: ClientAuthentication,
@@ -164,7 +165,7 @@ internal class ProcessResponse(
                     dpopKeyAlias
                 ).copy(
                     replacesDocumentId = replacesDocumentId,
-                    credentialConfigurationIdentifier = documentToConfigurationMap[unsignedDocument]?.offeredDocument?.configurationIdentifier?.value,
+                    credentialConfigurationIdentifier = documentToConfigurationMap[unsignedDocument]?.first?.configurationIdentifier?.value,
                     credentialEndpoint = issuer.credentialOffer.credentialIssuerMetadata.credentialEndpoint.toString(),
                 )
 
@@ -203,7 +204,7 @@ internal class ProcessResponse(
 
         runCatching {
             val credentialConfigurationId = requireNotNull(
-                documentToConfigurationMap[unsignedDocument]?.offeredDocument?.configurationIdentifier?.value
+                documentToConfigurationMap[unsignedDocument]?.first?.configurationIdentifier?.value
             ) { "Credential configuration identifier not found for document" }
 
             // Get metadata from credential offer

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
@@ -37,10 +37,10 @@ internal class SubmitRequest(
     var authorizedRequest: AuthorizedRequest = authorizedRequest
         private set
 
-    suspend fun request(offeredDocuments: Map<UnsignedDocument, Offer.OfferedDocument>): Response {
-        return Response(offeredDocuments.mapValues { (unsignedDocument, offeredDocument) ->
+    suspend fun request(issuanceItems: Map<UnsignedDocument, IssuanceItem>): Response {
+        return Response(issuanceItems.mapValues { (unsignedDocument, issuanceItem) ->
             try {
-                val (keyAliases, outcome) = submitRequest(unsignedDocument, offeredDocument)
+                val (keyAliases, outcome) = submitRequest(unsignedDocument, issuanceItem)
                 ResponseResult(
                     keyAliases = keyAliases,
                     outcome = Result.success(outcome)
@@ -53,13 +53,19 @@ internal class SubmitRequest(
 
     private suspend fun submitRequest(
         unsignedDocument: UnsignedDocument,
-        offeredDocument: Offer.OfferedDocument,
+        issuanceItem: IssuanceItem,
         keyUnlockData: Map<KeyAlias, KeyUnlockData?>? = null,
     ): ResponseResult<SubmissionOutcome> {
-        val payload =
-            IssuanceRequestPayload.ConfigurationBased(offeredDocument.configurationIdentifier)
+        val configId = issuanceItem.offeredDocument.configurationIdentifier
+        val payload = when (issuanceItem) {
+            is IssuanceItem.ConfigurationBased ->
+                IssuanceRequestPayload.ConfigurationBased(configId)
+            is IssuanceItem.IdentifierBased ->
+                IssuanceRequestPayload.IdentifierBased(configId, issuanceItem.credentialIdentifier)
+        }
+
         val signers = unsignedDocument.getPoPSigners()
-        val proofTypesSupported = offeredDocument.configuration.proofTypesSupported
+        val proofTypesSupported = issuanceItem.offeredDocument.configuration.proofTypesSupported
 
         val (updatedAuthorizedRequest, outcome) = when {
             // Issuer requires no proof
@@ -77,7 +83,7 @@ internal class SubmitRequest(
                 authorizedRequest.requestWithJwtProofWithKeyAttestation(
                     payload, signers, keyUnlockData,
                     unlockResume = { updatedKeyUnlockData ->
-                        submitRequest(unsignedDocument, offeredDocument, updatedKeyUnlockData)
+                        submitRequest(unsignedDocument, issuanceItem, updatedKeyUnlockData)
                     }
                 )
             }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/SubmitRequest.kt
@@ -37,10 +37,12 @@ internal class SubmitRequest(
     var authorizedRequest: AuthorizedRequest = authorizedRequest
         private set
 
-    suspend fun request(issuanceItems: Map<UnsignedDocument, IssuanceItem>): Response {
-        return Response(issuanceItems.mapValues { (unsignedDocument, issuanceItem) ->
+    suspend fun request(
+        requestMap: Map<UnsignedDocument, Pair<Offer.OfferedDocument, IssuanceRequestPayload>>,
+    ): Response {
+        return Response(requestMap.mapValues { (unsignedDocument, entry) ->
             try {
-                val (keyAliases, outcome) = submitRequest(unsignedDocument, issuanceItem)
+                val (keyAliases, outcome) = submitRequest(unsignedDocument, entry.first, entry.second)
                 ResponseResult(
                     keyAliases = keyAliases,
                     outcome = Result.success(outcome)
@@ -53,19 +55,12 @@ internal class SubmitRequest(
 
     private suspend fun submitRequest(
         unsignedDocument: UnsignedDocument,
-        issuanceItem: IssuanceItem,
+        offeredDocument: Offer.OfferedDocument,
+        payload: IssuanceRequestPayload,
         keyUnlockData: Map<KeyAlias, KeyUnlockData?>? = null,
     ): ResponseResult<SubmissionOutcome> {
-        val configId = issuanceItem.offeredDocument.configurationIdentifier
-        val payload = when (issuanceItem) {
-            is IssuanceItem.ConfigurationBased ->
-                IssuanceRequestPayload.ConfigurationBased(configId)
-            is IssuanceItem.IdentifierBased ->
-                IssuanceRequestPayload.IdentifierBased(configId, issuanceItem.credentialIdentifier)
-        }
-
         val signers = unsignedDocument.getPoPSigners()
-        val proofTypesSupported = issuanceItem.offeredDocument.configuration.proofTypesSupported
+        val proofTypesSupported = offeredDocument.configuration.proofTypesSupported
 
         val (updatedAuthorizedRequest, outcome) = when {
             // Issuer requires no proof
@@ -83,7 +78,7 @@ internal class SubmitRequest(
                 authorizedRequest.requestWithJwtProofWithKeyAttestation(
                     payload, signers, keyUnlockData,
                     unlockResume = { updatedKeyUnlockData ->
-                        submitRequest(unsignedDocument, issuanceItem, updatedKeyUnlockData)
+                        submitRequest(unsignedDocument, offeredDocument, payload, updatedKeyUnlockData)
                     }
                 )
             }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/Types.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/Types.kt
@@ -16,4 +16,29 @@
 
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
+import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
+
 typealias KeyAlias = String
+
+/**
+ * Represents an item to be issued, pairing an [Offer.OfferedDocument] with the
+ * payload type required for the credential request.
+ *
+ * Mirrors the distinction in [eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload]:
+ * - [ConfigurationBased]: no credential identifiers were returned by the Authorization Server
+ *   the request uses only the credential configuration identifier.
+ * - [IdentifierBased]: the Authorization Server returned credential identifiers in the token
+ *   response; each identifier represents a distinct credential dataset and requires its own request.
+ */
+internal sealed interface IssuanceItem {
+    val offeredDocument: Offer.OfferedDocument
+
+    data class ConfigurationBased(
+        override val offeredDocument: Offer.OfferedDocument,
+    ) : IssuanceItem
+
+    data class IdentifierBased(
+        override val offeredDocument: Offer.OfferedDocument,
+        val credentialIdentifier: CredentialIdentifier,
+    ) : IssuanceItem
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/Types.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/Types.kt
@@ -16,29 +16,4 @@
 
 package eu.europa.ec.eudi.wallet.issue.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
-
 typealias KeyAlias = String
-
-/**
- * Represents an item to be issued, pairing an [Offer.OfferedDocument] with the
- * payload type required for the credential request.
- *
- * Mirrors the distinction in [eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload]:
- * - [ConfigurationBased]: no credential identifiers were returned by the Authorization Server
- *   the request uses only the credential configuration identifier.
- * - [IdentifierBased]: the Authorization Server returned credential identifiers in the token
- *   response; each identifier represents a distinct credential dataset and requires its own request.
- */
-internal sealed interface IssuanceItem {
-    val offeredDocument: Offer.OfferedDocument
-
-    data class ConfigurationBased(
-        override val offeredDocument: Offer.OfferedDocument,
-    ) : IssuanceItem
-
-    data class IdentifierBased(
-        override val offeredDocument: Offer.OfferedDocument,
-        val credentialIdentifier: CredentialIdentifier,
-    ) : IssuanceItem
-}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ExpandToIssuanceItemsTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ExpandToIssuanceItemsTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.issue.openid4vci
+
+import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
+import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ExpandToIssuanceItemsTest {
+
+    private val configIdA = CredentialConfigurationIdentifier("config-a")
+    private val configIdB = CredentialConfigurationIdentifier("config-b")
+
+    private fun createOfferedDocument(
+        configId: CredentialConfigurationIdentifier,
+    ): Offer.OfferedDocument = mockk {
+        every { configurationIdentifier } returns configId
+    }
+
+    private fun createOffer(
+        vararg offeredDocuments: Offer.OfferedDocument,
+    ): Offer = mockk {
+        every { this@mockk.offeredDocuments } returns offeredDocuments.toList()
+    }
+
+    @Test
+    fun `null credentialIdentifiers produces ConfigurationBased for each offered document`() {
+        val docA = createOfferedDocument(configIdA)
+        val docB = createOfferedDocument(configIdB)
+        val offer = createOffer(docA, docB)
+
+        val result = expandToIssuanceItems(offer, credentialIdentifiers = null)
+
+        assertEquals(2, result.size)
+        assertIs<IssuanceItem.ConfigurationBased>(result[0])
+        assertEquals(docA, result[0].offeredDocument)
+        assertIs<IssuanceItem.ConfigurationBased>(result[1])
+        assertEquals(docB, result[1].offeredDocument)
+    }
+
+    @Test
+    fun `empty map produces ConfigurationBased for each offered document`() {
+        val docA = createOfferedDocument(configIdA)
+        val offer = createOffer(docA)
+
+        val result = expandToIssuanceItems(offer, credentialIdentifiers = emptyMap())
+
+        assertEquals(1, result.size)
+        assertIs<IssuanceItem.ConfigurationBased>(result[0])
+        assertEquals(docA, result[0].offeredDocument)
+    }
+
+    @Test
+    fun `empty list for a config produces ConfigurationBased`() {
+        val docA = createOfferedDocument(configIdA)
+        val offer = createOffer(docA)
+
+        val result = expandToIssuanceItems(
+            offer,
+            credentialIdentifiers = mapOf(configIdA to emptyList()),
+        )
+
+        assertEquals(1, result.size)
+        assertIs<IssuanceItem.ConfigurationBased>(result[0])
+    }
+
+    @Test
+    fun `single identifier produces one IdentifierBased`() {
+        val docA = createOfferedDocument(configIdA)
+        val offer = createOffer(docA)
+        val credId = CredentialIdentifier("degree-1")
+
+        val result = expandToIssuanceItems(
+            offer,
+            credentialIdentifiers = mapOf(configIdA to listOf(credId)),
+        )
+
+        assertEquals(1, result.size)
+        val item = assertIs<IssuanceItem.IdentifierBased>(result[0])
+        assertEquals(docA, item.offeredDocument)
+        assertEquals(credId, item.credentialIdentifier)
+    }
+
+    @Test
+    fun `multiple identifiers for one config produces one IdentifierBased per identifier`() {
+        val docA = createOfferedDocument(configIdA)
+        val offer = createOffer(docA)
+        val credId1 = CredentialIdentifier("degree-civil")
+        val credId2 = CredentialIdentifier("degree-electrical")
+        val credId3 = CredentialIdentifier("degree-mechanical")
+
+        val result = expandToIssuanceItems(
+            offer,
+            credentialIdentifiers = mapOf(configIdA to listOf(credId1, credId2, credId3)),
+        )
+
+        assertEquals(3, result.size)
+        result.forEachIndexed { index, item ->
+            val identifierBased = assertIs<IssuanceItem.IdentifierBased>(item)
+            assertEquals(docA, identifierBased.offeredDocument)
+        }
+        assertEquals(credId1, (result[0] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        assertEquals(credId2, (result[1] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        assertEquals(credId3, (result[2] as IssuanceItem.IdentifierBased).credentialIdentifier)
+    }
+
+    @Test
+    fun `mixed configs - some with identifiers, some without`() {
+        val docA = createOfferedDocument(configIdA)
+        val docB = createOfferedDocument(configIdB)
+        val offer = createOffer(docA, docB)
+        val credId1 = CredentialIdentifier("id-1")
+        val credId2 = CredentialIdentifier("id-2")
+
+        val result = expandToIssuanceItems(
+            offer,
+            credentialIdentifiers = mapOf(
+                configIdA to listOf(credId1, credId2),
+                // configIdB not present in map → falls back to ConfigurationBased
+            ),
+        )
+
+        assertEquals(3, result.size)
+        // config-a expanded to 2 IdentifierBased items
+        assertIs<IssuanceItem.IdentifierBased>(result[0])
+        assertEquals(credId1, (result[0] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        assertIs<IssuanceItem.IdentifierBased>(result[1])
+        assertEquals(credId2, (result[1] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        // config-b falls back to ConfigurationBased
+        assertIs<IssuanceItem.ConfigurationBased>(result[2])
+        assertEquals(docB, result[2].offeredDocument)
+    }
+
+    @Test
+    fun `identifiers for unknown config are ignored - only offered documents matter`() {
+        val docA = createOfferedDocument(configIdA)
+        val offer = createOffer(docA)
+        val unknownConfigId = CredentialConfigurationIdentifier("unknown-config")
+
+        val result = expandToIssuanceItems(
+            offer,
+            credentialIdentifiers = mapOf(
+                unknownConfigId to listOf(CredentialIdentifier("id-1")),
+            ),
+        )
+
+        assertEquals(1, result.size)
+        assertIs<IssuanceItem.ConfigurationBased>(result[0])
+        assertEquals(docA, result[0].offeredDocument)
+    }
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ResolveIssuanceRequestPayloadsTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/issue/openid4vci/ResolveIssuanceRequestPayloadsTest.kt
@@ -18,13 +18,14 @@ package eu.europa.ec.eudi.wallet.issue.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.CredentialConfigurationIdentifier
 import eu.europa.ec.eudi.openid4vci.CredentialIdentifier
+import eu.europa.ec.eudi.openid4vci.IssuanceRequestPayload
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-class ExpandToIssuanceItemsTest {
+class ResolveIssuanceRequestPayloadsTest {
 
     private val configIdA = CredentialConfigurationIdentifier("config-a")
     private val configIdB = CredentialConfigurationIdentifier("config-b")
@@ -47,13 +48,13 @@ class ExpandToIssuanceItemsTest {
         val docB = createOfferedDocument(configIdB)
         val offer = createOffer(docA, docB)
 
-        val result = expandToIssuanceItems(offer, credentialIdentifiers = null)
+        val result = resolveIssuanceRequestPayloads(offer, credentialIdentifiers = null)
 
         assertEquals(2, result.size)
-        assertIs<IssuanceItem.ConfigurationBased>(result[0])
-        assertEquals(docA, result[0].offeredDocument)
-        assertIs<IssuanceItem.ConfigurationBased>(result[1])
-        assertEquals(docB, result[1].offeredDocument)
+        assertEquals(docA, result[0].first)
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[0].second)
+        assertEquals(docB, result[1].first)
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[1].second)
     }
 
     @Test
@@ -61,11 +62,11 @@ class ExpandToIssuanceItemsTest {
         val docA = createOfferedDocument(configIdA)
         val offer = createOffer(docA)
 
-        val result = expandToIssuanceItems(offer, credentialIdentifiers = emptyMap())
+        val result = resolveIssuanceRequestPayloads(offer, credentialIdentifiers = emptyMap())
 
         assertEquals(1, result.size)
-        assertIs<IssuanceItem.ConfigurationBased>(result[0])
-        assertEquals(docA, result[0].offeredDocument)
+        assertEquals(docA, result[0].first)
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[0].second)
     }
 
     @Test
@@ -73,13 +74,13 @@ class ExpandToIssuanceItemsTest {
         val docA = createOfferedDocument(configIdA)
         val offer = createOffer(docA)
 
-        val result = expandToIssuanceItems(
+        val result = resolveIssuanceRequestPayloads(
             offer,
             credentialIdentifiers = mapOf(configIdA to emptyList()),
         )
 
         assertEquals(1, result.size)
-        assertIs<IssuanceItem.ConfigurationBased>(result[0])
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[0].second)
     }
 
     @Test
@@ -88,15 +89,16 @@ class ExpandToIssuanceItemsTest {
         val offer = createOffer(docA)
         val credId = CredentialIdentifier("degree-1")
 
-        val result = expandToIssuanceItems(
+        val result = resolveIssuanceRequestPayloads(
             offer,
             credentialIdentifiers = mapOf(configIdA to listOf(credId)),
         )
 
         assertEquals(1, result.size)
-        val item = assertIs<IssuanceItem.IdentifierBased>(result[0])
-        assertEquals(docA, item.offeredDocument)
-        assertEquals(credId, item.credentialIdentifier)
+        assertEquals(docA, result[0].first)
+        val payload = assertIs<IssuanceRequestPayload.IdentifierBased>(result[0].second)
+        assertEquals(credId, payload.credentialIdentifier)
+        assertEquals(configIdA, payload.credentialConfigurationIdentifier)
     }
 
     @Test
@@ -107,19 +109,19 @@ class ExpandToIssuanceItemsTest {
         val credId2 = CredentialIdentifier("degree-electrical")
         val credId3 = CredentialIdentifier("degree-mechanical")
 
-        val result = expandToIssuanceItems(
+        val result = resolveIssuanceRequestPayloads(
             offer,
             credentialIdentifiers = mapOf(configIdA to listOf(credId1, credId2, credId3)),
         )
 
         assertEquals(3, result.size)
-        result.forEachIndexed { index, item ->
-            val identifierBased = assertIs<IssuanceItem.IdentifierBased>(item)
-            assertEquals(docA, identifierBased.offeredDocument)
+        result.forEach { (offeredDoc, payload) ->
+            assertEquals(docA, offeredDoc)
+            assertIs<IssuanceRequestPayload.IdentifierBased>(payload)
         }
-        assertEquals(credId1, (result[0] as IssuanceItem.IdentifierBased).credentialIdentifier)
-        assertEquals(credId2, (result[1] as IssuanceItem.IdentifierBased).credentialIdentifier)
-        assertEquals(credId3, (result[2] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        assertEquals(credId1, (result[0].second as IssuanceRequestPayload.IdentifierBased).credentialIdentifier)
+        assertEquals(credId2, (result[1].second as IssuanceRequestPayload.IdentifierBased).credentialIdentifier)
+        assertEquals(credId3, (result[2].second as IssuanceRequestPayload.IdentifierBased).credentialIdentifier)
     }
 
     @Test
@@ -130,23 +132,25 @@ class ExpandToIssuanceItemsTest {
         val credId1 = CredentialIdentifier("id-1")
         val credId2 = CredentialIdentifier("id-2")
 
-        val result = expandToIssuanceItems(
+        val result = resolveIssuanceRequestPayloads(
             offer,
             credentialIdentifiers = mapOf(
                 configIdA to listOf(credId1, credId2),
-                // configIdB not present in map → falls back to ConfigurationBased
+                // configIdB not present in map -> falls back to ConfigurationBased
             ),
         )
 
         assertEquals(3, result.size)
-        // config-a expanded to 2 IdentifierBased items
-        assertIs<IssuanceItem.IdentifierBased>(result[0])
-        assertEquals(credId1, (result[0] as IssuanceItem.IdentifierBased).credentialIdentifier)
-        assertIs<IssuanceItem.IdentifierBased>(result[1])
-        assertEquals(credId2, (result[1] as IssuanceItem.IdentifierBased).credentialIdentifier)
+        // config-a expanded to 2 IdentifierBased entries
+        assertEquals(docA, result[0].first)
+        assertIs<IssuanceRequestPayload.IdentifierBased>(result[0].second)
+        assertEquals(credId1, (result[0].second as IssuanceRequestPayload.IdentifierBased).credentialIdentifier)
+        assertEquals(docA, result[1].first)
+        assertIs<IssuanceRequestPayload.IdentifierBased>(result[1].second)
+        assertEquals(credId2, (result[1].second as IssuanceRequestPayload.IdentifierBased).credentialIdentifier)
         // config-b falls back to ConfigurationBased
-        assertIs<IssuanceItem.ConfigurationBased>(result[2])
-        assertEquals(docB, result[2].offeredDocument)
+        assertEquals(docB, result[2].first)
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[2].second)
     }
 
     @Test
@@ -155,7 +159,7 @@ class ExpandToIssuanceItemsTest {
         val offer = createOffer(docA)
         val unknownConfigId = CredentialConfigurationIdentifier("unknown-config")
 
-        val result = expandToIssuanceItems(
+        val result = resolveIssuanceRequestPayloads(
             offer,
             credentialIdentifiers = mapOf(
                 unknownConfigId to listOf(CredentialIdentifier("id-1")),
@@ -163,7 +167,7 @@ class ExpandToIssuanceItemsTest {
         )
 
         assertEquals(1, result.size)
-        assertIs<IssuanceItem.ConfigurationBased>(result[0])
-        assertEquals(docA, result[0].offeredDocument)
+        assertEquals(docA, result[0].first)
+        assertIs<IssuanceRequestPayload.ConfigurationBased>(result[0].second)
     }
 }


### PR DESCRIPTION
- Fix identifier-based credential request selection per OpenID4VCI spec: when the Authorization Server returns `credential_identifiers` in the token response, the wallet now uses `IdentifierBased` request payloads instead of unconditionally using `ConfigurationBased`
- Support multiple credential identifiers per configuration by expanding offered documents into separate unsigned documents one per credential dataset, each with its own keys and submission request
- Add `resolveIssuanceRequestPayloads()` function that resolves the correct `IssuanceRequestPayload` variant for each offered document based on the authorized request's credential identifiers, applied in both `doIssue()` and `reissueDocument()` flows