### PR TITLE
 Block issuance when the issuer registration certificate lacks the required entitlement 

### DIFF
--- a/REGISTRATION_CERTIFICATE.md
+++ b/REGISTRATION_CERTIFICATE.md
@@ -68,8 +68,12 @@ Each check derives from:
 | Status reference present | `STATUS_MISSING` | ETSI TS 119 475 §6.2.6.2, REV-6.2.6.2-03 (status list mandatory) |
 | Revocation | `REVOKED` / `REVOCATION_STATUS_UNKNOWN` | ETSI TS 119 475 §6.2.6.2 |
 
-The scope check that follows is path-specific: over-asking on the presentation path, over-providing
-on the issuance path.
+The checks that follow are path-specific. On the issuance path the issuer's **entitlement** is checked
+next, and then over-providing; on the presentation path, over-asking.
+
+| Check | Failure reason | Source |
+|---|---|---|
+| Entitlement (issuance only) | `ENTITLEMENT_MISSING` | ARF ISSU_24a (the PID Provider is registered as a PID Provider), ISSU_34a (the Attestation Provider is registered as a QEAA, PuB-EAA or EAA Provider); the entitlement URIs are those of ETSI TS 119 475, listed in TS5 |
 
 ### The outcome
 
@@ -98,6 +102,7 @@ Both paths produce a `RegistrationCertificateResult`:
 | `STATUS_MISSING` | The certificate carries no status-list reference (mandatory) | Evaluation |
 | `REVOKED` | The status list reports the certificate as revoked | Evaluation |
 | `REVOCATION_STATUS_UNKNOWN` | The revocation status could not be determined | Evaluation |
+| `ENTITLEMENT_MISSING` | The issuer is not registered for the provider role that issuing the offered attestations requires (issuance path only) | Evaluation |
 
 ---
 
@@ -320,9 +325,13 @@ nothing to validate the certificate against, so validation is skipped and logged
 
 The default evaluator (`DefaultIssuerRegistrationEvaluator`) runs the same validity checks as the
 presentation path — binding, expiry, status reference and revocation, with binding taken against the
-certificate that signed the issuer metadata — and then compares the offered credential configurations
-against the registered `provides_attestations` scope, reporting anything outside it as
-`overProvidedAttestations`.
+certificate that signed the issuer metadata. It then checks the issuer's `entitlements` against what it
+offers to issue, failing with `ENTITLEMENT_MISSING` when the provider role is not confirmed, and
+finally compares the offered credential configurations against the registered `provides_attestations`
+scope, reporting anything outside it as `overProvidedAttestations`.
+
+Replacing the evaluator replaces the entitlement check too. A custom evaluator that does not implement
+it does not satisfy ISSU_24a / ISSU_34a.
 
 You can replace the evaluation stage via `configureIssuerRegistrationEvaluator`:
 
@@ -404,3 +413,31 @@ when (val registration = outcome.getOrNull()) {
 The same two-axis reading as on the presentation path applies, with `overProvidedAttestations` in
 place of `overAskedClaims`: a `Verified` issuer registration can still be over-providing, and
 `requiresExplicitApproval` folds both axes into one gate.
+
+### The entitlement check
+
+Before the scope check, the issuer's `entitlements` are checked against what it offers to issue. Each
+offered attestation requires the provider role that issuing it calls for:
+
+| Offered attestation | Required entitlement |
+|---|---|
+| A PID | `PID_Provider` |
+| Anything else | any one of `QEAA_Provider`, `PUB_EAA_Provider`, `Non_Q_EAA_Provider` |
+
+The non-PID case is a disjunction because ARF ISSU_34a requires only that the provider be registered
+as a QEAA, PuB-EAA **or** EAA Provider. The entitlement is what the registrar asserted, whereas the
+wallet's own classification of an attestation is local configuration — so requiring the two to agree
+would refuse providers legitimately registered under a different one of the three.
+
+Which offered attestations are PIDs is decided by the `pids` classification already configured for
+trust-area routing (`configureEtsiTrust { classifications(...) }`), so this check and the trust
+evaluation cannot disagree. An attestation identifying no type, and every attestation when no `pids`
+classification is configured, counts as non-PID.
+
+A shortfall is a **hard failure**, `Failed(ENTITLEMENT_MISSING, registration)` — not a finding on a
+verified result. Per ISSU_24a / ISSU_34a the wallet must not request issuance, so this is deliberately
+the one scope-shaped check that does not produce a warning the application may choose to accept. The
+parsed `registration` is still carried, so the provider can be named on the blocking screen.
+
+An absent or empty `entitlements` claim satisfies nothing: a certificate that does not confirm the
+role cannot be treated as confirming it.

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 
 # Single source of version truth for all three modules
-VERSION_NAME=0.30.1
+VERSION_NAME=0.30.2-SNAPSHOT
 
 # Publishing (vanniktech) — shared values; per-artifact values live in <module>/gradle.properties
 SONATYPE_HOST=CENTRAL_PORTAL

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
@@ -32,6 +32,7 @@ import eu.europa.ec.eudi.wallet.presentation.PresentationManager
 import eu.europa.ec.eudi.wallet.provider.WalletAttestationsProvider
 import eu.europa.ec.eudi.wallet.provider.WalletKeyManager
 import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolver
+import eu.europa.ec.eudi.wallet.trust.pidClassification
 import eu.europa.ec.eudi.wallet.transactionLogging.TransactionLogger
 import io.ktor.client.HttpClient
 import org.multipaz.storage.Storage
@@ -119,6 +120,8 @@ class EudiWalletImpl internal constructor(
             ?.let { certificateTrust ->
                 val evaluator = this@EudiWalletImpl.config.issuerRegistrationEvaluator
                     ?: DefaultIssuerRegistrationEvaluator(
+                        isPid = this@EudiWalletImpl.config.etsiTrustConfig
+                            ?.classifications.pidClassification,
                         statusTrust = issuerRegistrationStatusTrust,
                         logger = logger,
                         httpClientFactory = httpClientFactory,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationFailureReason.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/RegistrationFailureReason.kt
@@ -45,5 +45,12 @@ enum class RegistrationFailureReason {
     REVOCATION_STATUS_UNKNOWN,
 
     /** The certificate is not bound to the relying party that signed the request. */
-    NOT_BOUND_TO_REQUESTER
+    NOT_BOUND_TO_REQUESTER,
+
+    /**
+     * The certificate does not confirm that the provider is registered for the operation at hand: on
+     * the issuance path, its `entitlements` do not cover issuing the offered attestations (ARF
+     * ISSU_24a for a PID, ISSU_34a for any other attestation).
+     */
+    ENTITLEMENT_MISSING
 }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/DefaultIssuerRegistrationEvaluator.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/DefaultIssuerRegistrationEvaluator.kt
@@ -16,12 +16,14 @@
 
 package eu.europa.ec.eudi.wallet.registration.issuer
 
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
 import eu.europa.ec.eudi.statium.StatusReference
 import eu.europa.ec.eudi.wallet.internal.d
 import eu.europa.ec.eudi.wallet.logging.Logger
 import eu.europa.ec.eudi.wallet.registration.CertificateTrust
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
 import eu.europa.ec.eudi.wallet.registration.OverProvidedAttestation
+import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
 import eu.europa.ec.eudi.wallet.registration.RevocationOutcome
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import eu.europa.ec.eudi.wallet.registration.checkStatusListRevocation
@@ -31,17 +33,23 @@ import java.security.cert.X509Certificate
 
 /**
  * Default [IssuerRegistrationEvaluator]. Runs the certificate-validity checks (binding, expiry,
- * mandatory status reference and revocation) and then checks the offered attestations against the
- * certificate's registered `provides_attestations`.
+ * mandatory status reference and revocation), then checks that the issuer is entitled to issue the
+ * offered attestations, and finally checks them against the certificate's registered
+ * `provides_attestations`.
  *
- * A validity failure yields a [RegistrationCertificateResult.Failed]; offered attestations outside the
- * registered scope are reported as [OverProvidedAttestation]s on an otherwise verified result.
+ * A validity failure and a missing entitlement both yield a [RegistrationCertificateResult.Failed];
+ * offered attestations outside the registered scope are reported as [OverProvidedAttestation]s on an
+ * otherwise verified result. The entitlement check runs before the scope check, in the order the ARF
+ * states the two requirements (ISSU_24a before ISSU_24b, ISSU_34a before ISSU_34b).
  *
+ * @param isPid the classification deciding which offered attestations are PIDs, which selects the
+ *   entitlement each one requires; defaults to classifying nothing as a PID
  * @param statusTrust trust for the status list token signer chain; when null only the token's own
  *   signature is checked, without establishing that its signer is a trusted status list provider
  * @param checkRevocation the revocation check; defaults to a status-list check
  */
 internal class DefaultIssuerRegistrationEvaluator(
+    private val isPid: AttestationIdentifierPredicate = AttestationIdentifierPredicate.None,
     statusTrust: CertificateTrust? = null,
     private val logger: Logger? = null,
     httpClientFactory: (() -> HttpClient)? = null,
@@ -57,6 +65,20 @@ internal class DefaultIssuerRegistrationEvaluator(
         registration.validateCertificate(accessCertificate, checkRevocation)?.let { failure ->
             logger?.d(TAG, "issuer registration evaluation failed: ${failure.reason}")
             return failure
+        }
+
+        val unmetEntitlements = registration.findUnmetEntitlements(offeredAttestations, isPid)
+        if (unmetEntitlements.isNotEmpty()) {
+            logger?.d(
+                TAG,
+                "issuer '${registration.name}' is NOT ENTITLED to issue what it offers; " +
+                    "unmet: ${unmetEntitlements.joinToString()}; " +
+                    "registered: ${registration.entitlements.joinToString().ifEmpty { "none" }}",
+            )
+            return RegistrationCertificateResult.Failed(
+                RegistrationFailureReason.ENTITLEMENT_MISSING,
+                registration,
+            )
         }
 
         val overProvided = registration.findOverProvidedAttestations(offeredAttestations)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerEntitlements.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerEntitlements.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.registration.issuer
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+
+/**
+ * The entitlement URIs a provider may be registered for, as carried in the registration certificate's
+ * `entitlements` claim (ETSI TS 119 475; the URIs are those specified in TS5 for the roles of the CIR
+ * for Relying Party Registration).
+ */
+internal object IssuerEntitlements {
+    private const val BASE = "https://uri.etsi.org/19475/Entitlement"
+
+    const val PID = "$BASE/PID_Provider"
+    const val QEAA = "$BASE/QEAA_Provider"
+    const val PUB_EAA = "$BASE/PUB_EAA_Provider"
+    const val NON_Q_EAA = "$BASE/Non_Q_EAA_Provider"
+}
+
+/**
+ * The provider role an offered attestation requires its issuer to be registered for.
+ *
+ * Issuing a PID requires registration as a PID Provider (ARF ISSU_24a); issuing any other attestation
+ * requires registration as a QEAA, PuB-EAA or EAA Provider (ARF ISSU_34a). The latter is a disjunction
+ * on purpose: the entitlement is what the registrar asserted, whereas the wallet's own classification
+ * of an attestation is local configuration, so requiring the two to agree would refuse providers that
+ * are legitimately registered under a different one of the three.
+ */
+internal enum class EntitlementRequirement { PID_PROVIDER, EAA_PROVIDER }
+
+private val EAA_ENTITLEMENTS = setOf(
+    IssuerEntitlements.QEAA,
+    IssuerEntitlements.PUB_EAA,
+    IssuerEntitlements.NON_Q_EAA,
+)
+
+/**
+ * Returns the entitlement requirements of the [offered] attestations that this registration does not
+ * satisfy. An empty result means the issuer is registered for everything it offers to issue.
+ *
+ * [isPid] decides which offered attestations are PIDs; it is the classification the wallet is already
+ * configured with for trust-area routing. An attestation that identifies no type, and any attestation
+ * when no PID classification is configured, counts as a non-PID attestation.
+ */
+internal fun RegistrationCertificate.findUnmetEntitlements(
+    offered: List<OfferedAttestation>,
+    isPid: AttestationIdentifierPredicate,
+): Set<EntitlementRequirement> =
+    offered.map { it.requirement(isPid) }
+        .filterNot { it.isMetBy(entitlements) }
+        .toSet()
+
+private fun OfferedAttestation.requirement(
+    isPid: AttestationIdentifierPredicate,
+): EntitlementRequirement =
+    if (identifiers().any { isPid.test(it) }) {
+        EntitlementRequirement.PID_PROVIDER
+    } else {
+        EntitlementRequirement.EAA_PROVIDER
+    }
+
+/**
+ * The attestation type identifiers this offered attestation may be known by. A registered mdoc
+ * doctype and each SD-JWT VC type are both projected, so the classification matches on whichever the
+ * offer carries.
+ */
+private fun OfferedAttestation.identifiers(): List<AttestationIdentifier> = buildList {
+    meta?.doctypeValue?.let { add(AttestationIdentifier.MDoc(it)) }
+    meta?.vctValues?.forEach { add(AttestationIdentifier.SDJwtVc(it)) }
+}
+
+private fun EntitlementRequirement.isMetBy(entitlements: List<String>): Boolean = when (this) {
+    EntitlementRequirement.PID_PROVIDER -> IssuerEntitlements.PID in entitlements
+    EntitlementRequirement.EAA_PROVIDER -> entitlements.any { it in EAA_ENTITLEMENTS }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/PidClassification.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/PidClassification.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+
+/**
+ * The classification deciding which attestations are PIDs, as configured for trust-area routing
+ * (`configureEtsiTrust { classifications(...) }`). It is the single source of truth for the question,
+ * so checks that treat PIDs differently from other attestations agree with the trust evaluation.
+ *
+ * Absent configuration classifies nothing as a PID.
+ */
+internal val AttestationClassifications?.pidClassification: AttestationIdentifierPredicate
+    get() = this?.pids ?: AttestationIdentifierPredicate.None

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/issuer/DefaultIssuerRegistrationEvaluatorTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/issuer/DefaultIssuerRegistrationEvaluatorTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.registration.issuer
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+import eu.europa.ec.eudi.statium.StatusIndex
+import eu.europa.ec.eudi.statium.StatusReference
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.ProvidedAttestation
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
+import eu.europa.ec.eudi.wallet.registration.RegistrationFailureReason
+import eu.europa.ec.eudi.wallet.registration.RegistrationIdentifier
+import eu.europa.ec.eudi.wallet.registration.RevocationOutcome
+import kotlinx.coroutines.test.runTest
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x500.X500NameBuilder
+import org.bouncycastle.asn1.x500.style.BCStyle
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.security.spec.ECGenParameterSpec
+import java.time.Instant
+import java.util.Date
+
+class DefaultIssuerRegistrationEvaluatorTest {
+
+    private val evaluator = DefaultIssuerRegistrationEvaluator(
+        isPid = isPidPredicate,
+        checkRevocation = { RevocationOutcome.VALID },
+    )
+
+    @Test
+    fun `an issuer entitled and registered for what it offers is verified`() = runTest {
+        val registration = registration(
+            entitlements = listOf(IssuerEntitlements.PID),
+            provides = listOf(pidProvidedAttestation),
+        )
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId(ORG_ID),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val verified = result as RegistrationCertificateResult.Verified
+        assertEquals(registration, verified.registration)
+        assertEquals(emptyList<Any>(), verified.overProvidedAttestations)
+    }
+
+    @Test
+    fun `an issuer missing the entitlement for what it offers fails validation`() = runTest {
+        val registration = registration(
+            entitlements = listOf(IssuerEntitlements.QEAA),
+            provides = listOf(pidProvidedAttestation),
+        )
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId(ORG_ID),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val failed = result as RegistrationCertificateResult.Failed
+        assertEquals(RegistrationFailureReason.ENTITLEMENT_MISSING, failed.reason)
+    }
+
+    @Test
+    fun `a failed entitlement check still carries the parsed registration`() = runTest {
+        val registration = registration(
+            entitlements = emptyList(),
+            provides = listOf(pidProvidedAttestation),
+        )
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId(ORG_ID),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val failed = result as RegistrationCertificateResult.Failed
+        assertEquals(registration, failed.registration)
+    }
+
+    @Test
+    fun `the entitlement check precedes the over-providing check`() = runTest {
+        // Neither entitled nor registered for the offer: ISSU_24a is reported ahead of ISSU_24b.
+        val registration = registration(entitlements = emptyList(), provides = emptyList())
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId(ORG_ID),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val failed = result as RegistrationCertificateResult.Failed
+        assertEquals(RegistrationFailureReason.ENTITLEMENT_MISSING, failed.reason)
+    }
+
+    @Test
+    fun `a certificate validity failure is reported ahead of the entitlement check`() = runTest {
+        val registration = registration(entitlements = emptyList(), provides = emptyList())
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId("SOME-OTHER-ORG"),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val failed = result as RegistrationCertificateResult.Failed
+        assertEquals(RegistrationFailureReason.NOT_BOUND_TO_REQUESTER, failed.reason)
+    }
+
+    @Test
+    fun `an entitled issuer offering outside its registered scope is verified and over-providing`() = runTest {
+        val registration = registration(
+            entitlements = listOf(IssuerEntitlements.PID),
+            provides = emptyList(),
+        )
+
+        val result = evaluator.evaluate(
+            registration = registration,
+            accessCertificate = certificateWithOrgId(ORG_ID),
+            offeredAttestations = listOf(pidMdoc),
+        )
+
+        val verified = result as RegistrationCertificateResult.Verified
+        assertEquals(1, verified.overProvidedAttestations.size)
+    }
+}
+
+private const val ORG_ID = "ORG-123"
+
+private val isPidPredicate = AttestationIdentifierPredicate.any(
+    setOf(AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")),
+)
+
+private val pidMdoc = OfferedAttestation(
+    format = "mso_mdoc",
+    meta = CredentialMeta(doctypeValue = "eu.europa.ec.eudi.pid.1"),
+)
+
+private val pidProvidedAttestation = ProvidedAttestation(
+    format = "mso_mdoc",
+    meta = CredentialMeta(doctypeValue = "eu.europa.ec.eudi.pid.1"),
+)
+
+private fun registration(
+    entitlements: List<String>,
+    provides: List<ProvidedAttestation>,
+): RegistrationCertificate =
+    RegistrationCertificate(
+        identifiers = listOf(RegistrationIdentifier(value = ORG_ID)),
+        name = "Nordic PID Provider",
+        entitlements = entitlements,
+        providedAttestations = provides,
+        status = StatusReference(uri = "https://issuer.example/status/1", index = StatusIndex(5)),
+    )
+
+private fun certificateWithOrgId(orgId: String): X509Certificate =
+    selfSignedCertificate(
+        X500NameBuilder(BCStyle.INSTANCE)
+            .addRDN(BCStyle.CN, "Test Credential Issuer")
+            .addRDN(BCStyle.ORGANIZATION_IDENTIFIER, orgId)
+            .build(),
+    )
+
+private fun selfSignedCertificate(subject: X500Name): X509Certificate {
+    val keyPair = ecKeyPair()
+    val now = Instant.now()
+    val builder = JcaX509v3CertificateBuilder(
+        subject,
+        BigInteger(64, SecureRandom()),
+        Date.from(now.minusSeconds(3600)),
+        Date.from(now.plusSeconds(86400)),
+        subject,
+        keyPair.public,
+    )
+    val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+    return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+}
+
+private fun ecKeyPair(): KeyPair =
+    KeyPairGenerator.getInstance("EC")
+        .apply { initialize(ECGenParameterSpec("secp256r1")) }
+        .generateKeyPair()

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerEntitlementsTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/registration/issuer/IssuerEntitlementsTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.registration.issuer
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+import eu.europa.ec.eudi.wallet.registration.CredentialMeta
+import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IssuerEntitlementsTest {
+
+    @Test
+    fun `a pid offer is met by the pid provider entitlement`() {
+        val unmet = registration(IssuerEntitlements.PID)
+            .findUnmetEntitlements(listOf(pidMdoc), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `a pid offer without the pid provider entitlement is unmet`() {
+        val unmet = registration(IssuerEntitlements.QEAA)
+            .findUnmetEntitlements(listOf(pidMdoc), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.PID_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `a pid offer identified by vct without the pid provider entitlement is unmet`() {
+        val unmet = registration(IssuerEntitlements.PUB_EAA)
+            .findUnmetEntitlements(listOf(pidSdJwtVc), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.PID_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `a non pid offer is met by the qeaa provider entitlement`() {
+        val unmet = registration(IssuerEntitlements.QEAA)
+            .findUnmetEntitlements(listOf(mdl), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `a non pid offer is met by the pub eaa provider entitlement`() {
+        val unmet = registration(IssuerEntitlements.PUB_EAA)
+            .findUnmetEntitlements(listOf(mdl), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `a non pid offer is met by the non qualified eaa provider entitlement`() {
+        val unmet = registration(IssuerEntitlements.NON_Q_EAA)
+            .findUnmetEntitlements(listOf(mdl), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `a non pid offer is not met by the pid provider entitlement alone`() {
+        val unmet = registration(IssuerEntitlements.PID)
+            .findUnmetEntitlements(listOf(mdl), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.EAA_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `the service provider entitlement alone meets nothing`() {
+        val unmet = registration("https://uri.etsi.org/19475/Entitlement/Service_Provider")
+            .findUnmetEntitlements(listOf(pidMdoc, mdl), isPid)
+
+        assertEquals(
+            setOf(EntitlementRequirement.PID_PROVIDER, EntitlementRequirement.EAA_PROVIDER),
+            unmet,
+        )
+    }
+
+    @Test
+    fun `a mixed offer requires both a pid and an eaa entitlement`() {
+        val unmet = registration(IssuerEntitlements.PID)
+            .findUnmetEntitlements(listOf(pidMdoc, mdl), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.EAA_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `a mixed offer is met by a pid and an eaa entitlement together`() {
+        val unmet = registration(IssuerEntitlements.PID, IssuerEntitlements.NON_Q_EAA)
+            .findUnmetEntitlements(listOf(pidMdoc, mdl), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `an absent entitlements claim leaves the requirement unmet`() {
+        val unmet = registration()
+            .findUnmetEntitlements(listOf(pidMdoc), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.PID_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `an offer of nothing requires no entitlement`() {
+        val unmet = registration().findUnmetEntitlements(emptyList(), isPid)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    @Test
+    fun `an attestation that identifies no type is treated as a non pid attestation`() {
+        val untyped = OfferedAttestation(format = "mso_mdoc", meta = null)
+
+        val unmet = registration(IssuerEntitlements.PID)
+            .findUnmetEntitlements(listOf(untyped), isPid)
+
+        assertEquals(setOf(EntitlementRequirement.EAA_PROVIDER), unmet)
+    }
+
+    @Test
+    fun `without configured pid classification a pid offer is treated as a non pid attestation`() {
+        val unmet = registration(IssuerEntitlements.NON_Q_EAA)
+            .findUnmetEntitlements(listOf(pidMdoc), AttestationIdentifierPredicate.None)
+
+        assertEquals(emptySet<EntitlementRequirement>(), unmet)
+    }
+
+    // -- helpers --
+
+    private val isPid = AttestationIdentifierPredicate.any(
+        setOf(
+            AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1"),
+            AttestationIdentifier.SDJwtVc("urn:eudi:pid:1"),
+        ),
+    )
+
+    private val pidMdoc = OfferedAttestation(
+        format = "mso_mdoc",
+        meta = CredentialMeta(doctypeValue = "eu.europa.ec.eudi.pid.1"),
+    )
+
+    private val pidSdJwtVc = OfferedAttestation(
+        format = "dc+sd-jwt",
+        meta = CredentialMeta(vctValues = listOf("urn:eudi:pid:1")),
+    )
+
+    private val mdl = OfferedAttestation(
+        format = "mso_mdoc",
+        meta = CredentialMeta(doctypeValue = "org.iso.18013.5.1.mDL"),
+    )
+
+    private fun registration(vararg entitlements: String) =
+        RegistrationCertificate(name = "Provider", entitlements = entitlements.toList())
+}

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/PidClassificationTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/trust/PidClassificationTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.wallet.trust
+
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationClassifications
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifier
+import eu.europa.ec.eudi.etsi1196x2.consultation.AttestationIdentifierPredicate
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PidClassificationTest {
+
+    private val pid = AttestationIdentifier.MDoc("eu.europa.ec.eudi.pid.1")
+    private val mdl = AttestationIdentifier.MDoc("org.iso.18013.5.1.mDL")
+
+    @Test
+    fun `the configured pid classification is used`() {
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.any(setOf(pid)),
+        )
+
+        assertTrue(classifications.pidClassification.test(pid))
+        assertFalse(classifications.pidClassification.test(mdl))
+    }
+
+    @Test
+    fun `an unconfigured classification classifies nothing as a pid`() {
+        val classifications: AttestationClassifications? = null
+
+        assertFalse(classifications.pidClassification.test(pid))
+    }
+
+    @Test
+    fun `a classification configured without pids classifies nothing as a pid`() {
+        val classifications = AttestationClassifications(
+            qEAAs = AttestationIdentifierPredicate.any(setOf(mdl)),
+        )
+
+        assertFalse(classifications.pidClassification.test(pid))
+        assertFalse(classifications.pidClassification.test(mdl))
+    }
+}


### PR DESCRIPTION
The `entitlements` claim of the credential issuer's registration certificate was parsed and                                                                                      
  exposed but never evaluated, so a provider that is not registered for PID or (Q)EAA issuance                                                                                     
  passed validation and issuance completed. ARF ISSU_24a and ISSU_34a require the wallet to                                                                                        
  display a warning and not request the issuance in that case.                       

 Specified by: [eudi-doc-testing-application#310](https://github.com/eu-digital-identity-wallet/eudi-doc-testing-application/issues/310)                                                                                              
                                                                                                                                                                                   
### What it does

- Checks the offered attestations against the certificate's `entitlements`, after the
  certificate-validity checks and before the `provides_attestations` scope check — the order in
  which the ARF states the two requirements
- A PID requires `PID_Provider`; any other attestation requires **any one of** `QEAA_Provider`,
  `PUB_EAA_Provider` or `Non_Q_EAA_Provider`. The disjunction is deliberate: ISSU_34a asks only
  that the provider be registered as one of the three, and the entitlement is what the registrar
  asserted whereas the wallet's own classification of an attestation is local configuration —
  requiring the two to agree would refuse providers legitimately registered under a different one
  of the three
- Which offered attestations are PIDs comes from the `pids` classification already configured for
  trust-area routing (`configureEtsiTrust { classifications(...) }`), so this check cannot disagree
  with the trust evaluation. No new configuration surface
- A shortfall yields `Failed(ENTITLEMENT_MISSING, registration)` rather than a finding on a
  verified result: the wallet must not request the issuance, so this is not a warning an
  application may choose to accept. The parsed registration is carried along so the provider can
  still be named on the blocking screen
- An absent or empty `entitlements` claim satisfies nothing

### For consumers                                                                                                                                                                
                                                                                                                                                                                   
  `RegistrationFailureReason` gains `ENTITLEMENT_MISSING`. This is **source-breaking** for any                                                                                     
  consumer that maps the enum in an exhaustive `when` — including the reference app, whose                                                                                         
  `toRegistrationFailureReasonDomain()` will need a new branch and a matching domain constant. The                                                                                 
  break is intentional: it forces every consumer to decide how to present the new outcome instead of                                                                               
  silently not blocking.                                                                                                                                                           
                                                                                                                                                                                   
  No further app change is needed for the block itself — the reference app already refuses anything                                                                                
  short of `Verified` through `isBlockedForIssuance`. 

Replacing the evaluator via `configureIssuerRegistrationEvaluator` replaces this check too; a
custom evaluator that does not implement it does not satisfy ISSU_24a / ISSU_34a.

### Docs

`REGISTRATION_CERTIFICATE.md` documents the check, its ARF basis and the new failure reason, and
notes that replacing the evaluator replaces the check.