### PR TITLE
Unify reader authentication into single configureReaderAuthentication DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,6 @@ val customWallet = EudiWallet(context, config) {
     withStorage(myStorage)
     // a list of SecureArea implementations to be used
     withSecureAreas(listOf(deviceSecureArea, cloudSecureArea))
-    // custom ReaderTrustStore (prefer configureReaderAuthentication in config instead)
-    withReaderTrustStore(myReaderTrustStore)
     // custom logger to be used
     withLogger(myLogger)
     // custom HTTP client for network operations

--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ val config = EudiWalletConfig()
         // to store the keys
         useStrongBoxForKeys = true
     )
-    .configureReaderTrustStore(
-        // set the reader trusted certificates for the reader trust store
-        listOf(readerCertificate)
-    )
-    // configure the reader authentication enforcement policy
-    // default is EnforceIfPresent
-    .configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+    .configureReaderAuthentication {
+        // set the reader trusted certificates
+        trustedCertificates(readerCertificate)
+        // configure the reader authentication enforcement policy
+        // default is EnforceIfPresent
+        enforceIfPresent()
+    }
     // configure the OpenId4Vci service
     .configureOpenId4Vci {
         withIssuerUrl("https://issuer.com")
@@ -297,7 +297,7 @@ val customWallet = EudiWallet(context, config) {
     withStorage(myStorage)
     // a list of SecureArea implementations to be used
     withSecureAreas(listOf(deviceSecureArea, cloudSecureArea))
-    // ReaderTrustStore to be used for reader authentication
+    // custom ReaderTrustStore (prefer configureReaderAuthentication in config instead)
     withReaderTrustStore(myReaderTrustStore)
     // custom logger to be used
     withLogger(myLogger)
@@ -318,52 +318,63 @@ wallet-core library with custom SecureArea implementations.
 #### Reader Authentication Policy
 
 The reader authentication policy controls how reader authentication results affect document
-disclosure during proximity (BLE/NFC) and DCAPI presentations. This works in conjunction with the
-`ReaderTrustStore` configured via `configureReaderTrustStore`.
-
-When a verifier's DeviceRequest includes reader authentication, the wallet verifies the reader's
-certificate chain against the configured `ReaderTrustStore`. The `ReaderAuthPolicy` determines what
-happens based on the verification result:
-
-| Policy | Behavior |
-|---|---|
-| `ReaderAuthPolicy.DoNotEnforce` | Reader authentication is evaluated but never blocks document disclosure. Documents are always included in the response. |
-| `ReaderAuthPolicy.EnforceIfPresent` | **(Default)** Documents are excluded from the response when reader authentication is present but fails verification. Documents without reader authentication are included normally. |
-| `ReaderAuthPolicy.AlwaysRequire` | Documents are excluded unless reader authentication is present and verified successfully. |
-
-Per ISO 18013-5, when all documents are excluded due to reader authentication failure, the wallet
-returns a DeviceResponse with status 10 (General Error) instead of an empty success response.
-
-The reader auth policy can be set in two ways, for flexibility:
-
-**Inside the ETSI reader trust DSL** (when using `configureEtsiTrust`):
+disclosure during proximity (BLE/NFC), remote (OpenID4VP), and DCAPI presentations. Trust sources
+and enforcement intent are configured together via `configureReaderAuthentication`:
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureEtsiTrust { /* ... */ }
-    configureReaderTrustStore {
-        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    configureReaderAuthentication {
+        trustedCertificates(cert1, cert2)
+        enforceIfPresent() // default — can be omitted
     }
 }
 ```
 
-**As a standalone call** (when using certificate-based or custom `ReaderTrustStore`):
+When a verifier's request includes reader authentication, the wallet verifies the reader's
+certificate chain against the configured trust sources. The enforcement policy determines what
+happens based on the verification result:
+
+| Policy | Behavior |
+|---|---|
+| `doNotEnforce()` | Reader authentication is evaluated but never blocks document disclosure. Documents are always included in the response. |
+| `enforceIfPresent()` | **(Default)** Documents are excluded from the response when reader authentication is present but fails verification. Documents without reader authentication are included normally. |
+| `alwaysRequire()` | Documents are excluded unless reader authentication is present and verified successfully. |
+
+Per ISO 18013-5, when all documents are excluded due to reader authentication failure, the wallet
+returns a DeviceResponse with status 10 (General Error) instead of an empty success response.
+
+**With ETSI trust** (trust source inherited from `configureEtsiTrust`):
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureReaderTrustStore(listOf(trustedReaderCertificate))
-    configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+    configureEtsiTrust { /* ... */ }
+    configureReaderAuthentication {
+        alwaysRequire()
+        // trust source resolved from configureEtsiTrust at build time
+    }
 }
 ```
 
-The standalone `configureReaderAuthPolicy()` method remains available for users who use the
-certificate-based `configureReaderTrustStore(certificates)` overloads or a custom `ReaderTrustStore`,
-since those paths don't have a DSL block.
+**With static certificates**:
+
+```kotlin
+val config = EudiWalletConfig {
+    configureReaderAuthentication {
+        trustedCertificates(trustedCert1, trustedCert2)
+        revocationPolicy(RevocationPolicy.SoftFail)
+        enforceIfPresent()
+    }
+}
+```
+
+> **Note:** `enforceIfPresent()` and `alwaysRequire()` require trust sources. If no trust
+> source is configured (and no central ETSI trust source is available), an
+> `IllegalArgumentException` is thrown at build time. Call `doNotEnforce()` to explicitly opt out.
 
 > **Note:** If a verifier includes reader authentication in its request but its certificate is not in
-> the configured `ReaderTrustStore`, the document will be excluded from the response when using
-> `EnforceIfPresent` or `AlwaysRequire` policies. To allow presentations to verifiers whose
-> certificates are not in the trust store, use `ReaderAuthPolicy.DoNotEnforce`.
+> the configured trust store, the document will be excluded from the response when using
+> `enforceIfPresent()` or `alwaysRequire()`. To allow presentations to verifiers whose
+> certificates are not in the trust store, use `doNotEnforce()`.
 
 #### WalletKeyManager Configuration
 This interface is responsible for managing Attestation Keys used during Attestation Based Client Authentication with OpenId4Vci.
@@ -638,7 +649,7 @@ The recommended approach is to use `configureEtsiTrust` to centralize the LoTE t
 infrastructure in the core. This builds the entire trust pipeline internally — HTTP client,
 file cache, JWT signature verification, trust anchor provisioning, and caching — from a
 small set of high-level configuration knobs. Each trust area (`configureIssuerTrust`,
-`configureDocumentStatusResolver`, `configureReaderTrustStore`) inherits the shared trust
+`configureDocumentStatusResolver`, `configureReaderAuthentication`) inherits the shared trust
 source automatically and only needs area-specific settings (policies, clock skew, etc.).
 
 Each trust verification feature is independently configurable and opt-in. When not configured,
@@ -714,8 +725,8 @@ val config = EudiWalletConfig {
     configureDocumentStatusResolver {
         clockSkew(5)
     }
-    configureReaderTrustStore {
-        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    configureReaderAuthentication {
+        alwaysRequire()
     }
 }
 ```
@@ -778,7 +789,10 @@ val config = EudiWalletConfig {
             classifications(myClassifications)
         }
     }
-    configureReaderTrustStore(isChainTrusted)
+    configureReaderAuthentication {
+        trustSource(isChainTrusted)
+        enforceIfPresent()
+    }
 }
 
 // On shutdown:
@@ -1018,45 +1032,47 @@ signature verification without ETSI trust chain validation.
 
 #### Reader Authentication with Trusted Lists
 
-`EtsiReaderTrustStore` is a drop-in replacement for `ReaderTrustStoreImpl` that delegates
-reader certificate chain validation to the ETSI library's `IsChainTrustedForEUDIW`. It
-uses the `WalletRelyingPartyAccessCertificate` (WRPAC) verification context by default.
+Reader certificate chain validation can be delegated to the ETSI library's
+`IsChainTrustedForEUDIW` using the `WalletRelyingPartyAccessCertificate` (WRPAC)
+verification context. All trust sources and enforcement are configured through the unified
+`configureReaderAuthentication` DSL.
 
-**Using centralized ETSI trust** (recommended): The DSL block inherits the trust source from
-`configureEtsiTrust` and allows setting the reader authentication policy in the same place:
+**Using centralized ETSI trust** (recommended): The trust source is inherited from
+`configureEtsiTrust` — only the enforcement policy needs to be set:
 
 ```kotlin
 val config = EudiWalletConfig {
     configureEtsiTrust { /* ... */ }
 
-    configureReaderTrustStore {
-        readerAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    configureReaderAuthentication {
+        alwaysRequire()
+        // trust source resolved from configureEtsiTrust at build time
     }
 }
 ```
 
-**Using a manually built trust source**: Pass `IsChainTrustedForEUDIW` directly. The reader
-auth policy is set separately via `configureReaderAuthPolicy()`:
+**Using a manually built trust source**: Pass `IsChainTrustedForEUDIW` directly via
+`trustSource()`:
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureReaderTrustStore(isChainTrusted)
-    configureReaderAuthPolicy(ReaderAuthPolicy.AlwaysRequire)
+    configureReaderAuthentication {
+        trustSource(isChainTrusted)
+        alwaysRequire()
+    }
 }
 ```
 
-**Using static certificates**: The overloads that accept `X509Certificate` lists remain
-available. The reader auth policy is set separately, and the certificate revocation checking
-policy can be configured via the `revocationPolicy` parameter (defaults to
-`RevocationPolicy.HardFail`):
+**Using static certificates**: Pass certificates directly and configure the revocation
+checking policy (defaults to `RevocationPolicy.HardFail`):
 
 ```kotlin
 val config = EudiWalletConfig {
-    configureReaderTrustStore(
-        listOf(trustedCert1, trustedCert2),
-        revocationPolicy = RevocationPolicy.SoftFail
-    )
-    configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+    configureReaderAuthentication {
+        trustedCertificates(trustedCert1, trustedCert2)
+        revocationPolicy(RevocationPolicy.SoftFail)
+        enforceIfPresent()
+    }
 }
 ```
 
@@ -1068,12 +1084,13 @@ The available revocation policies are:
 | `RevocationPolicy.SoftFail` | Validation fails if a certificate is revoked, but tolerates CRL/OCSP unavailability. |
 | `RevocationPolicy.NoCheck` | No revocation checking is performed. |
 
-> **Note:** `RevocationPolicy` only applies to the static certificate-based `configureReaderTrustStore`
-> overloads. When using ETSI/LoTE-based trust (via `configureEtsiTrust`), revocation checking is
-> controlled by `relaxPkixRevocation()` inside the `configureEtsiTrust` block instead.
+> **Note:** `RevocationPolicy` only applies to the static certificate-based
+> `trustedCertificates()` overloads. When using ETSI/LoTE-based trust (via
+> `configureEtsiTrust`), revocation checking is controlled by `relaxPkixRevocation()` inside
+> the `configureEtsiTrust` block instead.
 
 For advanced use cases requiring a specific verification context, create an
-`EtsiReaderTrustStore` explicitly:
+`EtsiReaderTrustStore` explicitly and pass it as a custom trust source:
 
 ```kotlin
 val readerTrustStore = EtsiReaderTrustStore(
@@ -1082,14 +1099,11 @@ val readerTrustStore = EtsiReaderTrustStore(
 )
 
 val config = EudiWalletConfig {
-    configureReaderTrustStore(readerTrustStore)
+    configureReaderAuthentication {
+        trustSource(readerTrustStore)
+        alwaysRequire()
+    }
 }
-```
-
-You can also update the reader trust store at runtime:
-
-```kotlin
-wallet.setReaderTrustStore(EtsiReaderTrustStore(isChainTrusted))
 ```
 
 > **Note:** For best performance during presentations, pre-warm the ETSI cache on app startup.
@@ -1151,9 +1165,9 @@ val config = EudiWalletConfig {
         clockSkew(5)
     }
 
-    // Reader authentication — trust source inherited, policy set inline
-    configureReaderTrustStore {
-        readerAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)
+    // Reader authentication — trust source inherited, enforcement set inline
+    configureReaderAuthentication {
+        enforceIfPresent()
     }
 }
 ```

--- a/STATIC_CERTIFICATE_TRUST_CONFIGURATION.md
+++ b/STATIC_CERTIFICATE_TRUST_CONFIGURATION.md
@@ -6,7 +6,7 @@ requirement. Trust anchors can be provided from **static certificate files**, a
 **keystore**, or any other source, with no `HttpClient` and no LoTE URL involved.
 
 This document shows how to configure all trust areas using the ETSI consultation
-library's composable API with locally-provided certificates
+library's composable API with locally-provided certificates.
 
 ## How it works
 
@@ -29,11 +29,10 @@ Each trust area uses specific `VerificationContext` values. Your trust source mu
 the contexts needed by the areas you want to enable:
 
 | Trust area | Config entry point | Verification contexts |
-  |---|---|---|
+|---|---|---|
 | Credential issuance | `configureIssuerTrust { trustSource(...) }` | `PID`, `PubEAA`, `QEAA`, `EAA(useCase)` |
-| Status list tokens | `configureDocumentStatusResolver { configureTrust { trustSource(...) } }` | `PIDStatus`, `PubEAAStatus`, `QEAAStatus`,
-  `EAAStatus(useCase)` |
-| Reader/verifier auth | `configureReaderTrustStore(trust)` | `WalletRelyingPartyAccessCertificate` |
+| Status list tokens | `configureDocumentStatusResolver { configureTrust { trustSource(...) } }` | `PIDStatus`, `PubEAAStatus`, `QEAAStatus`, `EAAStatus(useCase)` |
+| Reader/verifier auth | `configureReaderAuthentication { trustSource(...) }` | `WalletRelyingPartyAccessCertificate` |
 | Signed issuer metadata | Via `configureIssuerTrust { requireSignedMetadata() }` | `WalletRelyingPartyAccessCertificate` |
 
 ## Example: static certificates
@@ -124,7 +123,11 @@ config = EudiWalletConfig {
         }
     }
 
-    configureReaderTrustStore(composedTrust)
+    configureReaderAuthentication {
+        trustSource(composedTrust)
+        enforceIfPresent()
+        revocationPolicy(RevocationPolicy.HardFail)
+    }
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.1"
+agp = "9.3.2"
 androidx-credentials = "1.6.0"
 androidx-credentials-registry = "1.0.0-alpha04"
 appcompat = "1.7.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 #Thu Sep 12 17:12:58 EEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.iso18013.transfer
 import android.content.Context
 import eu.europa.ec.eudi.iso18013.transfer.engagement.DeviceRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
@@ -93,8 +92,7 @@ interface TransferManager : TransferEvent.Listenable {
          *
          * @param context
          * @param documentManager
-         * @param readerTrustStore
-         * @param readerAuthPolicy
+         * @param readerAuthPolicy the reader authentication policy (carries the trust store)
          * @param retrievalMethods
          * @param zkSystemRepository
          * @param zkResponsePolicy the ZK response policy to use when ZK proof generation fails.
@@ -105,15 +103,13 @@ interface TransferManager : TransferEvent.Listenable {
         fun getDefault(
             context: Context,
             documentManager: DocumentManager,
-            readerTrustStore: ReaderTrustStore? = null,
-            readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+            readerAuthPolicy: ReaderAuthPolicy,
             retrievalMethods: List<DeviceRetrievalMethod>? = null,
             zkSystemRepository: ZkSystemRepository? = null,
             zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
             wrpRegistrationValidator: WrpRegistrationValidator? = null
         ): TransferManager = TransferManagerImpl(context) {
             documentManager(documentManager)
-            readerTrustStore?.let { readerTrustStore(it) }
             readerAuthPolicy(readerAuthPolicy)
             retrievalMethods?.let { retrievalMethods(it) }
             zkSystemRepository?.let { zkSystemRepository(it) }

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
@@ -25,8 +25,6 @@ import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.iso18013.transfer.internal.QrEngagement
 import eu.europa.ec.eudi.iso18013.transfer.internal.TAG
 import eu.europa.ec.eudi.iso18013.transfer.internal.stopPresentation
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
@@ -55,14 +53,8 @@ class TransferManagerImpl @JvmOverloads constructor(
     context: Context,
     override val requestProcessor: RequestProcessor,
     retrievalMethods: List<DeviceRetrievalMethod>? = null,
-) : TransferManager, ReaderTrustStoreAware {
+) : TransferManager {
     private val context = context.applicationContext
-
-    override var readerTrustStore: ReaderTrustStore?
-        get() = (requestProcessor as? ReaderTrustStoreAware)?.readerTrustStore
-        set(value) {
-            (requestProcessor as? ReaderTrustStoreAware)?.readerTrustStore = value
-        }
 
     /**
      * Device retrieval helper instance
@@ -322,7 +314,7 @@ class TransferManagerImpl @JvmOverloads constructor(
      * Builder class for instantiating a [TransferManager] implementation
      *
      * @property documentManager document manager instance
-     * @property readerTrustStore reader trust store instance
+     * @property readerAuthPolicy reader authentication policy (carries the trust store)
      * @property retrievalMethods list of device retrieval methods
      * @property zkSystemRepository ZK system repository instance
      * @property zkResponsePolicy ZK response policy
@@ -332,8 +324,7 @@ class TransferManagerImpl @JvmOverloads constructor(
     class Builder(context: Context) {
         private val context = context.applicationContext
         var documentManager: DocumentManager? = null
-        var readerTrustStore: ReaderTrustStore? = null
-        var readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent
+        lateinit var readerAuthPolicy: ReaderAuthPolicy
         var retrievalMethods: List<DeviceRetrievalMethod>? = null
         var zkSystemRepository: ZkSystemRepository? = null
         var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict
@@ -348,16 +339,8 @@ class TransferManagerImpl @JvmOverloads constructor(
         }
 
         /**
-         * Reader trust store instance that will be used to verify the reader's certificate
-         * @param readerTrustStore
-         */
-        fun readerTrustStore(readerTrustStore: ReaderTrustStore) = apply {
-            this.readerTrustStore = readerTrustStore
-        }
-
-        /**
          * Policy for enforcing reader authentication results during response generation.
-         * Default is [ReaderAuthPolicy.EnforceIfPresent].
+         * The trust store is embedded in the policy.
          * @param readerAuthPolicy the reader authentication policy
          */
         fun readerAuthPolicy(readerAuthPolicy: ReaderAuthPolicy) = apply {
@@ -407,7 +390,6 @@ class TransferManagerImpl @JvmOverloads constructor(
                 context = context,
                 requestProcessor = DeviceRequestProcessor(
                     documentManager = documentManager!!,
-                    readerTrustStore = readerTrustStore,
                     readerAuthPolicy = readerAuthPolicy,
                     zkSystemRepository = zkSystemRepository,
                     zkResponsePolicy = zkResponsePolicy,

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/ReaderTrustStoreAware.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/ReaderTrustStoreAware.kt
@@ -23,6 +23,11 @@ package eu.europa.ec.eudi.iso18013.transfer.readerauth
  * @see [ReaderTrustStore]
  * @property readerTrustStore the reader trust store
  */
+@Deprecated(
+    "ReaderTrustStore is now embedded in ReaderAuthPolicy. " +
+        "Use ReaderAuthPolicy.readerTrustStore instead.",
+    level = DeprecationLevel.WARNING
+)
 interface ReaderTrustStoreAware {
     var readerTrustStore: ReaderTrustStore?
 }

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/ReaderAuthPolicy.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/ReaderAuthPolicy.kt
@@ -16,33 +16,48 @@
 
 package eu.europa.ec.eudi.iso18013.transfer.response
 
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+
 /**
  * Policy for how reader authentication results are enforced during response generation.
  *
- * Controls whether [ProcessedDeviceRequest.generateResponse] includes documents in the
- * device response based on the [ReaderAuth] result of the corresponding [RequestedDocument].
+ * Each enforcing variant carries its own [ReaderTrustStore] so that enforcement intent and
+ * enforcement means are always bundled together. This prevents misconfiguration where
+ * a policy is set without a trust store, or vice versa.
  */
 sealed interface ReaderAuthPolicy {
 
     /**
+     * The trust store used to validate verifier certificate chains.
+     * Null only for [DoNotEnforce], which performs no trust evaluation.
+     */
+    val readerTrustStore: ReaderTrustStore?
+        get() = null
+
+    /**
      * Do not enforce reader authentication results.
-     * Documents are always included in the response regardless of [ReaderAuth] status.
+     * Documents are always included in the response regardless of trust status.
+     * No trust evaluation is performed.
      */
     data object DoNotEnforce : ReaderAuthPolicy
 
     /**
      * Enforce reader authentication when present.
-     * Documents are skipped when [ReaderAuth] is present but [ReaderAuth.isVerified] is `false`.
-     * Documents with no reader authentication (null [ReaderAuth]) are still included.
-     *
-     * This is the default policy.
+     * Documents are skipped when a verifier certificate chain is present but
+     * fails trust validation against the [readerTrustStore].
+     * Requests with no certificate chain (e.g. unsigned OpenID4VP requests)
+     * are still allowed through.
      */
-    data object EnforceIfPresent : ReaderAuthPolicy
+    data class EnforceIfPresent(
+        override val readerTrustStore: ReaderTrustStore
+    ) : ReaderAuthPolicy
 
     /**
      * Always require verified reader authentication.
-     * Documents are skipped when [ReaderAuth] is null or [ReaderAuth.isVerified] is `false`.
-     * Only documents with verified reader authentication are included in the response.
+     * Documents are skipped unless the verifier's certificate chain is present
+     * and successfully validated against the [readerTrustStore].
      */
-    data object AlwaysRequire : ReaderAuthPolicy
+    data class AlwaysRequire(
+        override val readerTrustStore: ReaderTrustStore
+    ) : ReaderAuthPolicy
 }

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
@@ -18,8 +18,6 @@ package eu.europa.ec.eudi.iso18013.transfer.response.device
 
 import eu.europa.ec.eudi.iso18013.transfer.internal.cn
 import eu.europa.ec.eudi.iso18013.transfer.internal.getValidIssuedMsoMdocDocuments
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.EU_WRPRC_REQUEST_INFO_KEY
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
@@ -67,8 +65,8 @@ import org.multipaz.mdoc.request.DeviceRequest as MultipazDeviceRequest
  * confirmed by the user, in line with ISO 18013-5 partial-response semantics.
  *
  * @property documentManager the document manager to retrieve the requested documents
- * @property readerTrustStore the reader trust store to perform reader authentication
- * @property readerAuthPolicy the policy for enforcing reader authentication during response generation
+ * @property readerAuthPolicy the policy for enforcing reader authentication during response generation.
+ *   The trust store used for certificate chain validation is embedded in the policy.
  * @property zkSystemRepository the ZKP system repository
  * @property zkResponsePolicy the ZK response policy to use when ZK proof generation fails
  * @property wrpRegistrationValidator validates the relying party registration certificate carried in
@@ -76,12 +74,11 @@ import org.multipaz.mdoc.request.DeviceRequest as MultipazDeviceRequest
  */
 class DeviceRequestProcessor(
     private val documentManager: DocumentManager,
-    override var readerTrustStore: ReaderTrustStore? = null,
-    private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+    private val readerAuthPolicy: ReaderAuthPolicy,
     private var zkSystemRepository: ZkSystemRepository? = null,
     internal val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
     private val wrpRegistrationValidator: WrpRegistrationValidator? = null,
-) : RequestProcessor, ReaderTrustStoreAware {
+) : RequestProcessor {
 
     /**
      * Process the [DeviceRequest] and return [ProcessedDeviceRequest] (success) or
@@ -103,10 +100,10 @@ class DeviceRequestProcessor(
                 false
             }
 
-            // Validate the reader cert chain against the trust store, if any.
+            // Validate the reader cert chain against the trust store embedded in the policy.
             val readerCertChain = parsedRequest.getRequester()?.javaX509Certificates ?: emptyList()
             val isTrusted = readerCertChain.isNotEmpty() &&
-                    readerTrustStore?.validateCertificationTrustPath(readerCertChain) == true
+                    readerAuthPolicy.readerTrustStore?.validateCertificationTrustPath(readerCertChain) == true
                     && signatureValid
 
             val requester = Requester(

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
@@ -75,7 +75,7 @@ class ProcessedDeviceRequest(
     presentmentData: CredentialPresentmentData,
     requester: Requester,
     trustMetadata: TrustMetadata?,
-    private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+    private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
     private val zkSystemRepository: ZkSystemRepository? = null,
     private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
     wrpRegistration: WrpRegistrationInfo? = null
@@ -129,8 +129,8 @@ class ProcessedDeviceRequest(
             val readerAuthPresent = requester.certChain != null
             val skipAllByPolicy = when (readerAuthPolicy) {
                 ReaderAuthPolicy.DoNotEnforce -> false
-                ReaderAuthPolicy.EnforceIfPresent -> readerAuthPresent && !isReaderTrustVerified
-                ReaderAuthPolicy.AlwaysRequire -> !isReaderTrustVerified
+                is ReaderAuthPolicy.EnforceIfPresent -> readerAuthPresent && !isReaderTrustVerified
+                is ReaderAuthPolicy.AlwaysRequire -> !isReaderTrustVerified
             }
 
             if (skipAllByPolicy) {

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
@@ -75,7 +75,7 @@ class ProcessedDeviceRequest(
     presentmentData: CredentialPresentmentData,
     requester: Requester,
     trustMetadata: TrustMetadata?,
-    private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
+    private val readerAuthPolicy: ReaderAuthPolicy,
     private val zkSystemRepository: ZkSystemRepository? = null,
     private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
     wrpRegistration: WrpRegistrationInfo? = null

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.eudi.iso18013.transfer
 import android.util.Log
 import eu.europa.ec.eudi.iso18013.transfer.engagement.DeviceRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import io.mockk.mockk
@@ -49,6 +50,7 @@ class TransferManagerImplBuilderTest {
     fun buildTransferManagerWithDefaults() {
         val transferManager = TransferManagerImpl.Builder(Context)
             .documentManager(createDocumentManager(null))
+            .readerAuthPolicy(ReaderAuthPolicy.DoNotEnforce)
             .build()
 
         assertNotNull(transferManager)
@@ -58,7 +60,9 @@ class TransferManagerImplBuilderTest {
     @Test
     fun buildTransferManagerWithoutDocumentManagerThrowsException() {
         val throwable = assertFailsWith<IllegalArgumentException> {
-            TransferManagerImpl.Builder(Context).build()
+            TransferManagerImpl.Builder(Context)
+                .readerAuthPolicy(ReaderAuthPolicy.DoNotEnforce)
+                .build()
         }
 
         assertEquals("Document manager must be provided", throwable.message)
@@ -69,6 +73,7 @@ class TransferManagerImplBuilderTest {
         val retrievalMethods: List<DeviceRetrievalMethod> = listOf(mockk(), mockk())
         val transferManager = TransferManagerImpl.Builder(Context)
             .documentManager(createDocumentManager(null))
+            .readerAuthPolicy(ReaderAuthPolicy.DoNotEnforce)
             .retrievalMethods(retrievalMethods)
             .build()
 
@@ -81,6 +86,7 @@ class TransferManagerImplBuilderTest {
     fun buildTransferManagerWithDefaultZkResponsePolicy() {
         val transferManager = TransferManagerImpl.Builder(Context)
             .documentManager(createDocumentManager(null))
+            .readerAuthPolicy(ReaderAuthPolicy.DoNotEnforce)
             .build()
 
         assertNotNull(transferManager)
@@ -92,15 +98,15 @@ class TransferManagerImplBuilderTest {
     }
 
     @Test
-    fun buildTransferManagerWithReaderTrustStore() {
+    fun buildTransferManagerWithReaderAuthPolicy() {
         val readerTrustStore = mockk<ReaderTrustStore>()
+        val policy = ReaderAuthPolicy.EnforceIfPresent(readerTrustStore)
         val transferManager = TransferManagerImpl.Builder(Context)
             .documentManager(createDocumentManager(null))
-            .readerTrustStore(readerTrustStore)
+            .readerAuthPolicy(policy)
             .build()
 
         assertNotNull(transferManager)
         assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
-        assertEquals(readerTrustStore, transferManager.requestProcessor.readerTrustStore)
     }
 }

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplTest.kt
@@ -21,8 +21,6 @@ import com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper
 import eu.europa.ec.eudi.iso18013.transfer.engagement.DeviceRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.iso18013.transfer.internal.QrEngagement
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.Response
@@ -358,26 +356,4 @@ class TransferManagerImplTest {
         verify { listener.onTransferEvent(any<TransferEvent.Error>()) }
     }
 
-    @Test
-    fun `setting and getting readerTrustStore delegates to requestProcessor if the latter is ReaderTrustStoreAware`() {
-
-        val processor: RequestProcessor = object : RequestProcessor, ReaderTrustStoreAware {
-            override suspend fun process(request: Request): RequestProcessor.ProcessedRequest {
-                return mockk()
-            }
-
-            override var readerTrustStore: ReaderTrustStore? = null
-        }
-
-        val manager = TransferManagerImpl(
-            context = Context,
-            requestProcessor = processor
-        )
-
-        val readerTrustStore: ReaderTrustStore = mockk()
-
-        manager.readerTrustStore = readerTrustStore
-
-        assertSame(readerTrustStore, manager.readerTrustStore)
-    }
 }

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerTest.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.eudi.iso18013.transfer
 import android.util.Log
 import eu.europa.ec.eudi.iso18013.transfer.engagement.DeviceRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequestProcessor
 import io.mockk.mockk
 import org.mockito.MockedStatic
@@ -45,8 +46,11 @@ class TransferManagerTest {
 
     @Test
     fun `makeMsoMdocTransferManager method should return a MsoMdocTransferManager instance`() {
-        val transferManager =
-            TransferManager.getDefault(Context, createDocumentManager(null))
+        val transferManager = TransferManager.getDefault(
+            context = Context,
+            documentManager = createDocumentManager(null),
+            readerAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
+        )
 
         assertIs<eu.europa.ec.eudi.iso18013.transfer.TransferManagerImpl>(transferManager)
         assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
@@ -58,6 +62,7 @@ class TransferManagerTest {
         val transferManager = TransferManager.getDefault(
             context = Context,
             documentManager = createDocumentManager(null),
+            readerAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
             retrievalMethods = deviceRetrievalMethods
         )
 
@@ -67,16 +72,16 @@ class TransferManagerTest {
     }
 
     @Test
-    fun `makeMsoMdocTransferManager with readerTrustStore method should return a MsoMdocTransferManager instance`() {
+    fun `makeMsoMdocTransferManager with readerAuthPolicy should return a MsoMdocTransferManager instance`() {
         val readerTrustStore: ReaderTrustStore = mockk()
+        val policy = ReaderAuthPolicy.EnforceIfPresent(readerTrustStore)
         val transferManager = TransferManager.getDefault(
             context = Context,
             documentManager = createDocumentManager(null),
-            readerTrustStore = readerTrustStore
+            readerAuthPolicy = policy,
         )
 
         assertIs<eu.europa.ec.eudi.iso18013.transfer.TransferManagerImpl>(transferManager)
         assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
-        assertEquals(readerTrustStore, transferManager.requestProcessor.readerTrustStore)
     }
 }

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessorTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessorTest.kt
@@ -21,6 +21,7 @@ import eu.europa.ec.eudi.iso18013.transfer.DeviceRequest
 import eu.europa.ec.eudi.iso18013.transfer.KeyLockPassphrase
 import eu.europa.ec.eudi.iso18013.transfer.createDocumentManager
 import eu.europa.ec.eudi.iso18013.transfer.mockAndroidLog
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.ResponseResult
@@ -64,7 +65,7 @@ class DeviceRequestProcessorTest {
     fun `process returns ProcessedDeviceRequest with matched mDL credential and the expected requested claims`() =
         runBlocking {
             val documentManager = createDocumentManager(keyLockPassphrase = null)
-            val processor = DeviceRequestProcessor(documentManager)
+            val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
 
             val processed = processor.process(DeviceRequest)
 
@@ -94,7 +95,7 @@ class DeviceRequestProcessorTest {
     @Test
     fun `process returns Failure when the request is not a DeviceRequest`(): Unit = runBlocking {
         val documentManager = createDocumentManager(keyLockPassphrase = null)
-        val processor = DeviceRequestProcessor(documentManager)
+        val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
         val unknownRequest = mockk<Request>()
 
         val processed = processor.process(unknownRequest)
@@ -106,7 +107,7 @@ class DeviceRequestProcessorTest {
     fun `process plus generateResponse produces a valid signed DeviceResponse end-to-end`() =
         runBlocking {
             val documentManager = createDocumentManager(keyLockPassphrase = null)
-            val processor = DeviceRequestProcessor(documentManager)
+            val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
             val processed = assertIs<ProcessedDeviceRequest>(processor.process(DeviceRequest))
             val match = processed.firstMatch()
 
@@ -140,7 +141,7 @@ class DeviceRequestProcessorTest {
             // constructor + filtering behaviour: building a selection with a narrower
             // `match.claims` map and verifying it reaches the issuer-signed output.
             val documentManager = createDocumentManager(keyLockPassphrase = null)
-            val processor = DeviceRequestProcessor(documentManager)
+            val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
             val processed = assertIs<ProcessedDeviceRequest>(processor.process(DeviceRequest))
             val fullMatch = processed.firstMatch()
 
@@ -170,7 +171,7 @@ class DeviceRequestProcessorTest {
     fun `generateResponse with a PIN-locked credential succeeds when matching KeyUnlockData is provided`() =
         runBlocking {
             val documentManager = createDocumentManager(keyLockPassphrase = KeyLockPassphrase)
-            val processor = DeviceRequestProcessor(documentManager)
+            val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
             val processed = assertIs<ProcessedDeviceRequest>(processor.process(DeviceRequest))
             val match = processed.firstMatch()
 
@@ -209,7 +210,7 @@ class DeviceRequestProcessorTest {
             val documentManager = mockk<DocumentManager> {
                 coEvery { getDocuments(any()) } throws CancellationException("scope cancelled")
             }
-            val processor = DeviceRequestProcessor(documentManager)
+            val processor = DeviceRequestProcessor(documentManager, ReaderAuthPolicy.DoNotEnforce)
 
             val thrown = assertFailsWith<CancellationException> {
                 processor.process(DeviceRequest)

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequestTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequestTest.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.eudi.iso18013.transfer.response.device
 
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.ResponseResult
 import eu.europa.ec.eudi.wallet.document.DocumentManager
@@ -73,7 +74,7 @@ class ProcessedDeviceRequestTest {
         // This is the regression test for the missing-return skipAllByPolicy bug.
         val processed = buildProcessedRequest(
             trustMetadata = null,
-            readerAuthPolicy = ReaderAuthPolicy.AlwaysRequire,
+            readerAuthPolicy = ReaderAuthPolicy.AlwaysRequire(mockk<ReaderTrustStore>()),
         )
 
         val response = processed.generateEmptyResponse()
@@ -86,7 +87,7 @@ class ProcessedDeviceRequestTest {
     fun `AlwaysRequire produces STATUS_OK response when trustMetadata is set`() = runBlocking {
         val processed = buildProcessedRequest(
             trustMetadata = TrustMetadata(displayName = "Trusted Verifier"),
-            readerAuthPolicy = ReaderAuthPolicy.AlwaysRequire,
+            readerAuthPolicy = ReaderAuthPolicy.AlwaysRequire(mockk<ReaderTrustStore>()),
         )
 
         val response = processed.generateEmptyResponse()
@@ -104,7 +105,7 @@ class ProcessedDeviceRequestTest {
         val processed = buildProcessedRequest(
             trustMetadata = null,
             requester = Requester(certChain = mockk<X509CertChain>()),
-            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent(mockk<ReaderTrustStore>()),
         )
 
         val response = processed.generateEmptyResponse()
@@ -119,7 +120,7 @@ class ProcessedDeviceRequestTest {
         val processed = buildProcessedRequest(
             trustMetadata = null,
             requester = Requester(certChain = null),
-            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent(mockk<ReaderTrustStore>()),
         )
 
         val response = processed.generateEmptyResponse()
@@ -133,7 +134,7 @@ class ProcessedDeviceRequestTest {
         val processed = buildProcessedRequest(
             trustMetadata = TrustMetadata(displayName = "Trusted"),
             requester = Requester(certChain = mockk<X509CertChain>()),
-            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+            readerAuthPolicy = ReaderAuthPolicy.EnforceIfPresent(mockk<ReaderTrustStore>()),
         )
 
         val response = processed.generateEmptyResponse()
@@ -370,7 +371,7 @@ class ProcessedDeviceRequestTest {
     private fun buildProcessedRequest(
         trustMetadata: TrustMetadata?,
         requester: Requester = Requester(certChain = null),
-        readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+        readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
         presentmentData: CredentialPresentmentData = CredentialPresentmentData(emptyList()),
     ): ProcessedDeviceRequest = ProcessedDeviceRequest(
         documentManager = mockk<DocumentManager>(relaxed = true),

--- a/wallet-core/build.gradle.kts
+++ b/wallet-core/build.gradle.kts
@@ -5,14 +5,6 @@ plugins {
     id("kotlin-parcelize")
 }
 
-android {
-    // base opt-ins already in the convention plugin; this module only needs its
-    // unique test resource location
-    sourceSets.getByName("test").apply {
-        res.setSrcDirs(files("resources"))
-    }
-}
-
 dependencies {
     api(project(":document-manager"))
     api(project(":transfer-manager"))

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -21,7 +21,7 @@ import androidx.annotation.RawRes
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.engagement.BleRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.statium.Status
 import eu.europa.ec.eudi.wallet.dcapi.DCAPIManager
 import eu.europa.ec.eudi.wallet.dcapi.registration.DCAPIRegistration
@@ -57,7 +57,7 @@ import eu.europa.ec.eudi.wallet.registration.relyingparty.WrpRegistrationPolicy
 import eu.europa.ec.eudi.wallet.trust.EtsiReaderTrustStore
 import eu.europa.ec.eudi.wallet.trust.EtsiTrustProvider
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
-import eu.europa.ec.eudi.wallet.trust.asReaderTrustStore
+import eu.europa.ec.eudi.wallet.trust.ReaderAuthenticationConfigBuilder
 import eu.europa.ec.eudi.wallet.statium.DocumentStatusResolverConfigBuilder
 import eu.europa.ec.eudi.wallet.transactionLogging.presentation.TransactionsDecorator
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.OpenId4VpManager
@@ -102,32 +102,45 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
     val walletKeyManager: WalletKeyManager
 
     /**
-     * Sets the reader trust store with the given [ReaderTrustStore]. This method is useful when
-     * the reader trust store is not set in the configuration object, or when the reader trust store
-     * needs to be updated at runtime.
+     * Sets the reader trust store with the given [ReaderTrustStore].
+     *
      * @param readerTrustStore the reader trust store
      * @return this [EudiWallet] instance
      */
+    @Deprecated(
+        "Reader trust is now configured at build time via " +
+            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
+        replaceWith = ReplaceWith("this"),
+        level = DeprecationLevel.WARNING,
+    )
     fun setReaderTrustStore(readerTrustStore: ReaderTrustStore): EudiWallet
 
     /**
-     * Sets the reader trust store with the given list of [X509Certificate]. This method is useful
-     * when the reader trust store is not set in the configuration object, or when the reader trust
-     * store needs to be updated at runtime.
+     * Sets the reader trust store with the given list of [X509Certificate].
      *
-     * @param readerCertificates the list of reader certificates
+     * @param trustedReaderCertificates the list of reader certificates
      * @return this [EudiWallet] instance
      */
+    @Deprecated(
+        "Reader trust is now configured at build time via " +
+            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
+        replaceWith = ReplaceWith("this"),
+        level = DeprecationLevel.WARNING,
+    )
     fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>): EudiWallet
 
     /**
-     * Sets the reader trust store with the given list of raw resource IDs. This method is useful
-     * when the reader trust store is not set in the configuration object, or when the reader trust
-     * store needs to be updated at runtime.
+     * Sets the reader trust store with the given list of raw resource IDs.
      *
      * @param rawRes the list of raw resource IDs
      * @return this [EudiWallet] instance
      */
+    @Deprecated(
+        "Reader trust is now configured at build time via " +
+            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
+        replaceWith = ReplaceWith("this"),
+        level = DeprecationLevel.WARNING,
+    )
     fun setTrustedReaderCertificates(@RawRes vararg rawRes: Int): EudiWallet
 
     /**
@@ -214,7 +227,6 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
         var storage: Storage? = null
         var secureAreas: List<SecureArea>? = null
         var documentManager: DocumentManager? = null
-        var readerTrustStore: ReaderTrustStore? = null
         var presentationManager: PresentationManager? = null
         var logger: Logger? = null
         var ktorHttpClientFactory: (() -> HttpClient)? = null
@@ -259,14 +271,19 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
         /**
          * Configure with the given [ReaderTrustStore] to use for performing reader authentication.
-         * If not set, the default reader trust store will be used which is initialized with the certificates
-         * provided in the [EudiWalletConfig.configureReaderTrustStore] methods.
          *
          * @param readerTrustStore the reader trust store
          * @return this [Builder] instance
          */
+        @Deprecated(
+            "Reader trust is now configured via " +
+                "EudiWalletConfig.configureReaderAuthentication { trustSource(...) }. " +
+                "This method is a no-op.",
+            replaceWith = ReplaceWith("this"),
+            level = DeprecationLevel.WARNING,
+        )
         fun withReaderTrustStore(readerTrustStore: ReaderTrustStore) =
-            apply { this.readerTrustStore = readerTrustStore }
+            apply { /* no-op: trust store is configured via configureReaderAuthentication */ }
 
         /**
          * Configure with the given [PresentationManager] to use for both proximity and remote presentation.
@@ -443,20 +460,13 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                         } else manager
                     }
 
-            val readerTrustStoreToUse = (readerTrustStore
-                ?: config.readerTrustStore
-                ?: when {
-                    config.useEtsiReaderTrust && etsiSource != null ->
-                        etsiSource.asReaderTrustStore()
+            // --- Build ReaderAuthPolicy (single policy for both transports) ---
+            val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthenticationConfigBuilder()
+                .apply(config.readerAuthBlock ?: {})
+                .build(etsiSource = etsiSource, logger = loggerToUse)
 
-                    else -> config.readerTrustedCertificates?.let { certificates ->
-                        ReaderTrustStoreImpl(
-                            certificates,
-                            profileValidation = { _, _ -> true },
-                            revocationPolicy = config.revocationPolicy,
-                        )
-                    }
-                })?.also {
+            // Derive trust store for components not yet migrated to ReaderAuthPolicy
+            val readerTrustStoreToUse = readerAuthPolicy.readerTrustStore?.also {
                 if (it is EtsiReaderTrustStore) it.logger = loggerToUse
             }
 
@@ -478,24 +488,8 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                 registrationCertificatePolicy = null
                 resolvedRegistration = null
             } else {
-                val certificateTrust: CertificateTrust? = (readerTrustStore ?: config.readerTrustStore)
-                    ?.asCertificateTrust()
-                    ?: if (config.useEtsiReaderTrust && etsiSource != null) {
-                        etsiSource.asCertificateTrust(
-                            VerificationContext.WalletRelyingPartyRegistrationCertificate,
-                            logger = loggerToUse,
-                        )
-                    } else {
-                        config.readerTrustedCertificates
-                            ?.takeIf { it.isNotEmpty() }
-                            ?.let {
-                                ReaderTrustStoreImpl(
-                                    it,
-                                    profileValidation = { _, _ -> true },
-                                    revocationPolicy = config.revocationPolicy,
-                                ).asCertificateTrust()
-                            }
-                    }
+                val certificateTrust: CertificateTrust? =
+                    readerTrustStoreToUse?.asCertificateTrust()
                 val evaluator = config.wrpRegistrationEvaluator ?: DefaultWrpRegistrationEvaluator(
                     statusTrust = if (config.useEtsiReaderTrust && etsiSource != null) {
                         etsiSource.asCertificateTrust(
@@ -518,13 +512,14 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
             val transferManager = getTransferManager(
                 documentManager = documentManagerToUse,
-                readerTrustStore = readerTrustStoreToUse,
+                readerAuthPolicy = readerAuthPolicy,
                 wrpRegistrationValidator = wrpRegistrationValidator
             )
 
             val presentationManagerToUse = presentationManager ?: getDefaultPresentationManager(
                 documentManager = documentManagerToUse,
                 transferManager = transferManager,
+                readerAuthPolicy = readerAuthPolicy,
                 readerTrustStore = readerTrustStoreToUse,
                 registrationValidator = wrpRegistrationValidator,
                 registrationCertificatePolicy = registrationCertificatePolicy,
@@ -556,13 +551,15 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
          * Get the default [PresentationManagerImpl] instance based on the [DocumentManager] and [TransferManager] implementations
          * @param documentManager the document manager
          * @param transferManager the transfer manager
-         * @param readerTrustStore the reader trust store
+         * @param readerAuthPolicy the reader authentication policy (embeds the trust store)
+         * @param readerTrustStore the reader trust store (derived from policy, for components not yet migrated)
          * @return the default [PresentationManagerImpl] instance
          */
         @JvmSynthetic
         internal fun getDefaultPresentationManager(
             documentManager: DocumentManager,
             transferManager: TransferManager,
+            readerAuthPolicy: ReaderAuthPolicy,
             readerTrustStore: ReaderTrustStore?,
             loggerObj: Logger,
             registrationValidator: DefaultWrpRegistrationValidator? = null,
@@ -575,6 +572,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                     requestProcessor = DcqlRequestProcessor(
                         documentManager = documentManager,
                         readerTrustStore = readerTrustStore,
+                        readerAuthPolicy = readerAuthPolicy,
                         logger = loggerObj
                     ).apply {
                         wrpRegistrationValidator = registrationValidator
@@ -598,7 +596,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                     ?.let { openId4VpConfig ->
                         OpenId4VpDCAPIRequestProcessor(
                             openId4VpConfig = openId4VpConfig,
-                            dcqlRequestProcessor = DcqlRequestProcessor(documentManager, readerTrustStore)
+                            dcqlRequestProcessor = DcqlRequestProcessor(documentManager, readerTrustStore, readerAuthPolicy)
                                 .apply {
                                     wrpRegistrationValidator = registrationValidator
                                     this.resolvedRegistration = resolvedRegistration
@@ -612,8 +610,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
                 DCAPIManager(
                     isoMdocRequestProcessor = IsoMdocDCAPIRequestProcessor(
                         documentManager = documentManager,
-                        readerTrustStore = readerTrustStore,
-                        readerAuthPolicy = config.readerAuthPolicy,
+                        readerAuthPolicy = readerAuthPolicy,
                         privilegedAllowlist = privilegedAllowlist,
                         zkSystemRepository = config.zkSystemRepository,
                         zkResponsePolicy = config.zkResponsePolicy,
@@ -690,21 +687,20 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
         }
 
         /**
-         * Get the default [TransferManager] instance based on the [DocumentManager] and [ReaderTrustStore]
+         * Get the default [TransferManager] instance based on the [DocumentManager] and [ReaderAuthPolicy]
          * @param documentManager the document manager
-         * @param readerTrustStore the reader trust store
+         * @param readerAuthPolicy the reader authentication policy (embeds the trust store)
          * @return the default [TransferManager] instance
          */
         @JvmSynthetic
         internal fun getTransferManager(
             documentManager: DocumentManager,
-            readerTrustStore: ReaderTrustStore? = null,
+            readerAuthPolicy: ReaderAuthPolicy,
             wrpRegistrationValidator: WrpRegistrationValidator? = null
         ) = TransferManager.getDefault(
             context = context,
             documentManager = documentManager,
-            readerTrustStore = readerTrustStore,
-            readerAuthPolicy = config.readerAuthPolicy,
+            readerAuthPolicy = readerAuthPolicy,
             retrievalMethods = listOf(
                 BleRetrievalMethod(
                     peripheralServerMode = config.enableBlePeripheralMode,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWallet.kt
@@ -17,7 +17,6 @@
 package eu.europa.ec.eudi.wallet
 
 import android.content.Context
-import androidx.annotation.RawRes
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.engagement.BleRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
@@ -71,7 +70,6 @@ import org.multipaz.securearea.SecureAreaRepository
 import org.multipaz.storage.Storage
 import org.multipaz.storage.android.AndroidStorage
 import java.io.File
-import java.security.cert.X509Certificate
 import org.multipaz.util.Logger as IdentityLogger
 
 /**
@@ -100,48 +98,6 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
     val walletProvider: WalletAttestationsProvider?
     val walletKeyManager: WalletKeyManager
-
-    /**
-     * Sets the reader trust store with the given [ReaderTrustStore].
-     *
-     * @param readerTrustStore the reader trust store
-     * @return this [EudiWallet] instance
-     */
-    @Deprecated(
-        "Reader trust is now configured at build time via " +
-            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
-        replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.WARNING,
-    )
-    fun setReaderTrustStore(readerTrustStore: ReaderTrustStore): EudiWallet
-
-    /**
-     * Sets the reader trust store with the given list of [X509Certificate].
-     *
-     * @param trustedReaderCertificates the list of reader certificates
-     * @return this [EudiWallet] instance
-     */
-    @Deprecated(
-        "Reader trust is now configured at build time via " +
-            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
-        replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.WARNING,
-    )
-    fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>): EudiWallet
-
-    /**
-     * Sets the reader trust store with the given list of raw resource IDs.
-     *
-     * @param rawRes the list of raw resource IDs
-     * @return this [EudiWallet] instance
-     */
-    @Deprecated(
-        "Reader trust is now configured at build time via " +
-            "EudiWalletConfig.configureReaderAuthentication { }. This method is a no-op.",
-        replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.WARNING,
-    )
-    fun setTrustedReaderCertificates(@RawRes vararg rawRes: Int): EudiWallet
 
     /**
      * Creates an instance of [OpenId4VciManager] for the wallet to interact with the OpenID for Verifiable Credential Issuance service.
@@ -268,22 +224,6 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
          */
         fun withDocumentManager(documentManager: DocumentManager) =
             apply { this.documentManager = documentManager }
-
-        /**
-         * Configure with the given [ReaderTrustStore] to use for performing reader authentication.
-         *
-         * @param readerTrustStore the reader trust store
-         * @return this [Builder] instance
-         */
-        @Deprecated(
-            "Reader trust is now configured via " +
-                "EudiWalletConfig.configureReaderAuthentication { trustSource(...) }. " +
-                "This method is a no-op.",
-            replaceWith = ReplaceWith("this"),
-            level = DeprecationLevel.WARNING,
-        )
-        fun withReaderTrustStore(readerTrustStore: ReaderTrustStore) =
-            apply { /* no-op: trust store is configured via configureReaderAuthentication */ }
 
         /**
          * Configure with the given [PresentationManager] to use for both proximity and remote presentation.
@@ -462,7 +402,7 @@ interface EudiWallet : DocumentManager, PresentationManager, DocumentStatusResol
 
             // --- Build ReaderAuthPolicy (single policy for both transports) ---
             val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthenticationConfigBuilder()
-                .apply(config.readerAuthBlock ?: {})
+                .apply(config.readerAuthenticationBlock ?: {})
                 .build(etsiSource = etsiSource, logger = loggerToUse)
 
             // Derive trust store for components not yet migrated to ReaderAuthPolicy

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -585,7 +585,7 @@ class EudiWalletConfig {
      * [EudiWallet.Builder.build()][eu.europa.ec.eudi.wallet.EudiWallet] time to produce
      * the [ReaderAuthPolicy] with embedded trust material.
      */
-    internal var readerAuthBlock: (ReaderAuthenticationConfigBuilder.() -> Unit)? = null
+    internal var readerAuthenticationBlock: (ReaderAuthenticationConfigBuilder.() -> Unit)? = null
         private set
 
     /**
@@ -637,7 +637,7 @@ class EudiWalletConfig {
     fun configureReaderAuthentication(
         block: ReaderAuthenticationConfigBuilder.() -> Unit,
     ) = apply {
-        this.readerAuthBlock = block
+        this.readerAuthenticationBlock = block
     }
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletConfig.kt
@@ -41,6 +41,7 @@ import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfig
 import eu.europa.ec.eudi.wallet.trust.EtsiTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfig
 import eu.europa.ec.eudi.wallet.trust.IssuerTrustConfigBuilder
+import eu.europa.ec.eudi.wallet.trust.ReaderAuthenticationConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.ReaderTrustConfigBuilder
 import eu.europa.ec.eudi.wallet.trust.StatusListTrustConfig
 import eu.europa.ec.eudi.wallet.trust.asReaderTrustStore
@@ -363,6 +364,10 @@ class EudiWalletConfig {
      * @return the [EudiWalletConfig] instance
      * @see RevocationPolicy
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { trustedCertificates(...) } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { trustedCertificates(readerTrustedCertificates) }"),
+    )
     @JvmOverloads
     fun configureReaderTrustStore(
         readerTrustedCertificates: List<X509Certificate>,
@@ -392,6 +397,10 @@ class EudiWalletConfig {
      * @return the [EudiWalletConfig] instance
      * @see RevocationPolicy
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { trustedCertificates(...) } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { trustedCertificates(*readerTrustedCertificates) }"),
+    )
     fun configureReaderTrustStore(
         vararg readerTrustedCertificates: X509Certificate,
         revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail,
@@ -422,6 +431,10 @@ class EudiWalletConfig {
      * @return the [EudiWalletConfig] instance
      * @see RevocationPolicy
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { trustedCertificates(context, ...) } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { trustedCertificates(context, *certificateRes) }"),
+    )
     fun configureReaderTrustStore(
         context: Context,
         @RawRes vararg certificateRes: Int,
@@ -441,6 +454,10 @@ class EudiWalletConfig {
      * @param readerTrustStore the custom reader trust store implementation
      * @return the [EudiWalletConfig] instance
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { trustStore(readerTrustStore) } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { trustStore(readerTrustStore) }"),
+    )
     fun configureReaderTrustStore(readerTrustStore: ReaderTrustStore) = apply {
         this.readerTrustStore = readerTrustStore
     }
@@ -462,6 +479,10 @@ class EudiWalletConfig {
      * @param isChainTrusted the ETSI chain trust validator
      * @return the [EudiWalletConfig] instance
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { trustStore(isChainTrusted) } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { trustStore(isChainTrusted) }"),
+    )
     fun configureReaderTrustStore(
         isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>,
     ) = apply {
@@ -496,6 +517,10 @@ class EudiWalletConfig {
      * @see ReaderTrustConfigBuilder
      * @see ReaderAuthPolicy
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { ... } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { alwaysRequire() }"),
+    )
     fun configureReaderTrustStore(
         block: ReaderTrustConfigBuilder.() -> Unit,
     ) = apply {
@@ -520,9 +545,13 @@ class EudiWalletConfig {
      * The default is [ReaderAuthPolicy.EnforceIfPresent].
      *
      * @see ReaderAuthPolicy
-     * @see configureReaderTrustStore
+     * @see configureReaderAuthentication
      */
-    var readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent
+    @Deprecated(
+        message = "Use configureReaderAuthentication { ... } instead. " +
+            "The policy is now determined by the DSL builder.",
+    )
+    var readerAuthPolicy: ReaderAuthPolicy? = null
         private set
 
     /**
@@ -541,10 +570,74 @@ class EudiWalletConfig {
      * @return the [EudiWalletConfig] instance
      *
      * @see ReaderAuthPolicy
-     * @see configureReaderTrustStore
+     * @see configureReaderAuthentication
      */
+    @Deprecated(
+        message = "Use configureReaderAuthentication { ... } instead.",
+        replaceWith = ReplaceWith("configureReaderAuthentication { /* set enforcement via doNotEnforce(), enforceIfPresent(), or alwaysRequire() */ }"),
+    )
     fun configureReaderAuthPolicy(readerAuthPolicy: ReaderAuthPolicy) = apply {
         this.readerAuthPolicy = readerAuthPolicy
+    }
+
+    /**
+     * The stored reader authentication DSL block. When non-null, it is executed at
+     * [EudiWallet.Builder.build()][eu.europa.ec.eudi.wallet.EudiWallet] time to produce
+     * the [ReaderAuthPolicy] with embedded trust material.
+     */
+    internal var readerAuthBlock: (ReaderAuthenticationConfigBuilder.() -> Unit)? = null
+        private set
+
+    /**
+     * Configure reader authentication using the unified DSL.
+     *
+     * This replaces the scattered `configureReaderTrustStore` overloads and
+     * `configureReaderAuthPolicy` with a single entry point that bundles trust
+     * material and enforcement intent together.
+     *
+     * The block is stored at configuration time and executed at
+     * [EudiWallet.Builder.build()][eu.europa.ec.eudi.wallet.EudiWallet] time so that
+     * deferred trust sources (e.g. from [configureEtsiTrust]) are available.
+     *
+     * The default enforcement is `enforceIfPresent()`. When enforcement is set to
+     * `enforceIfPresent()` or `alwaysRequire()` but no trust material is configured
+     * (and no central ETSI trust source is available), an [IllegalArgumentException]
+     * is thrown at build time. Call `doNotEnforce()` to explicitly opt out.
+     *
+     * Example with static certificates:
+     * ```
+     * configureReaderAuthentication {
+     *     trustedCertificates(cert1, cert2)
+     *     revocationPolicy(RevocationPolicy.SoftFail)
+     *     enforceIfPresent()
+     * }
+     * ```
+     *
+     * Example with ETSI trust (from [configureEtsiTrust]):
+     * ```
+     * configureEtsiTrust { ... }
+     * configureReaderAuthentication {
+     *     alwaysRequire()
+     * }
+     * ```
+     *
+     * Example opting out of enforcement:
+     * ```
+     * configureReaderAuthentication {
+     *     trustedCertificates(cert1)
+     *     doNotEnforce()
+     * }
+     * ```
+     *
+     * @param block configuration block applied to [ReaderAuthenticationConfigBuilder]
+     * @return the [EudiWalletConfig] instance
+     * @see ReaderAuthenticationConfigBuilder
+     * @see ReaderAuthPolicy
+     */
+    fun configureReaderAuthentication(
+        block: ReaderAuthenticationConfigBuilder.() -> Unit,
+    ) = apply {
+        this.readerAuthBlock = block
     }
 
     /**

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
@@ -19,9 +19,7 @@ package eu.europa.ec.eudi.wallet
 import android.content.Context
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.wallet.document.DocumentManager
-import eu.europa.ec.eudi.wallet.internal.getCertificate
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.registration.CertificateTrust
 import eu.europa.ec.eudi.wallet.registration.issuer.DefaultIssuerRegistrationEvaluator
@@ -68,18 +66,20 @@ class EudiWalletImpl internal constructor(
 ) : EudiWallet, DocumentManager by documentManager, PresentationManager by presentationManager,
     DocumentStatusResolver by documentStatusResolver {
 
+    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
     override fun setReaderTrustStore(readerTrustStore: ReaderTrustStore) = apply {
-        (this as PresentationManager).readerTrustStore = readerTrustStore
-        if (transferManager is ReaderTrustStoreAware) {
-            transferManager.readerTrustStore = readerTrustStore
-        }
+        // no-op: trust store is embedded in ReaderAuthPolicy at build time
     }
 
-    override fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>) =
-        setReaderTrustStore(ReaderTrustStore.getDefault(trustedReaderCertificates, config.revocationPolicy))
+    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
+    override fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>) = apply {
+        // no-op: trust store is embedded in ReaderAuthPolicy at build time
+    }
 
-    override fun setTrustedReaderCertificates(vararg rawRes: Int) =
-        setReaderTrustStore(ReaderTrustStore.getDefault(rawRes.map { context.getCertificate(it) }, config.revocationPolicy))
+    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
+    override fun setTrustedReaderCertificates(vararg rawRes: Int) = apply {
+        // no-op: trust store is embedded in ReaderAuthPolicy at build time
+    }
 
     /**
      * Creates an instance of [OpenId4VciManager] for interacting with the OpenID for Verifiable Credential Issuance protocol.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/EudiWalletImpl.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.wallet
 
 import android.content.Context
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.registration.CertificateTrust
@@ -34,7 +33,6 @@ import eu.europa.ec.eudi.wallet.trust.pidClassification
 import eu.europa.ec.eudi.wallet.transactionLogging.TransactionLogger
 import io.ktor.client.HttpClient
 import org.multipaz.storage.Storage
-import java.security.cert.X509Certificate
 
 /**
  * Implementation of [EudiWallet]
@@ -65,21 +63,6 @@ class EudiWalletImpl internal constructor(
     internal val issuerRegistrationStatusTrust: CertificateTrust? = null,
 ) : EudiWallet, DocumentManager by documentManager, PresentationManager by presentationManager,
     DocumentStatusResolver by documentStatusResolver {
-
-    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
-    override fun setReaderTrustStore(readerTrustStore: ReaderTrustStore) = apply {
-        // no-op: trust store is embedded in ReaderAuthPolicy at build time
-    }
-
-    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
-    override fun setTrustedReaderCertificates(trustedReaderCertificates: List<X509Certificate>) = apply {
-        // no-op: trust store is embedded in ReaderAuthPolicy at build time
-    }
-
-    @Deprecated("Reader trust is now configured at build time via configureReaderAuthentication { }")
-    override fun setTrustedReaderCertificates(vararg rawRes: Int) = apply {
-        // no-op: trust store is embedded in ReaderAuthPolicy at build time
-    }
 
     /**
      * Creates an instance of [OpenId4VciManager] for interacting with the OpenID for Verifiable Credential Issuance protocol.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/DCAPIManager.kt
@@ -22,8 +22,6 @@ import android.content.Intent
 import androidx.credentials.exceptions.GetCredentialCustomException
 import androidx.credentials.provider.PendingIntentHandler
 import eu.europa.ec.eudi.iso18013.transfer.TransferEvent
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.Response
@@ -58,15 +56,7 @@ class DCAPIManager(
     private val supportedProtocols: List<DCAPIProtocol>,
     var logger: Logger? = null,
     var listenersExecutor: Executor? = null,
-) : TransferEvent.Listenable, ReaderTrustStoreAware {
-
-    override var readerTrustStore: ReaderTrustStore?
-        get() = (isoMdocRequestProcessor as? ReaderTrustStoreAware)?.readerTrustStore
-            ?: (openId4VpRequestProcessor as? ReaderTrustStoreAware)?.readerTrustStore
-        set(value) {
-            (isoMdocRequestProcessor as? ReaderTrustStoreAware)?.readerTrustStore = value
-            (openId4VpRequestProcessor as? ReaderTrustStoreAware)?.readerTrustStore = value
-        }
+) : TransferEvent.Listenable {
 
     private val transferEventListeners: MutableList<TransferEvent.Listener> = mutableListOf()
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/process/isomdoc/IsoMdocDCAPIRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/process/isomdoc/IsoMdocDCAPIRequestProcessor.kt
@@ -24,8 +24,6 @@ import eu.europa.ec.eudi.wallet.dcapi.internal.*
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.credentials.GetDigitalCredentialOption
 import androidx.credentials.provider.ProviderGetCredentialRequest
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.WrpRegistrationValidator
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
@@ -59,14 +57,13 @@ import org.multipaz.mdoc.zkp.ZkSystemRepository
  */
 class IsoMdocDCAPIRequestProcessor(
     private val documentManager: DocumentManager,
-    override var readerTrustStore: ReaderTrustStore?,
-    private val readerAuthPolicy: ReaderAuthPolicy = ReaderAuthPolicy.EnforceIfPresent,
+    private val readerAuthPolicy: ReaderAuthPolicy,
     private val privilegedAllowlist: String,
     private var zkSystemRepository: ZkSystemRepository?,
     private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.Strict,
     private val wrpRegistrationValidator: WrpRegistrationValidator? = null,
     private var logger: Logger? = null,
-) : RequestProcessor, ReaderTrustStoreAware {
+) : RequestProcessor {
 
     @OptIn(ExperimentalDigitalCredentialApi::class)
     override suspend fun process(request: Request): RequestProcessor.ProcessedRequest {
@@ -77,7 +74,6 @@ class IsoMdocDCAPIRequestProcessor(
         val (deviceRequest, origin) = credRequest.toDeviceRequest()
         val processed = DeviceRequestProcessor(
             documentManager = documentManager,
-            readerTrustStore = readerTrustStore,
             readerAuthPolicy = readerAuthPolicy,
             zkSystemRepository = zkSystemRepository,
             zkResponsePolicy = zkResponsePolicy,

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/process/openid4vp/OpenId4VpDCAPIRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/dcapi/process/openid4vp/OpenId4VpDCAPIRequestProcessor.kt
@@ -22,8 +22,6 @@ import eu.europa.ec.eudi.wallet.dcapi.internal.*
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.credentials.GetDigitalCredentialOption
 import androidx.credentials.provider.ProviderGetCredentialRequest
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.openid4vp.OpenId4Vp
@@ -69,13 +67,7 @@ class OpenId4VpDCAPIRequestProcessor(
     private val supportedProtocols: List<DCAPIProtocol>,
     private var logger: Logger? = null,
     private val registrationCertificatePolicy: RegistrationCertificatePolicy? = null
-) : RequestProcessor, ReaderTrustStoreAware {
-
-    override var readerTrustStore: ReaderTrustStore?
-        get() = dcqlRequestProcessor.readerTrustStore
-        set(value) {
-            dcqlRequestProcessor.readerTrustStore = value
-        }
+) : RequestProcessor {
 
     /**
      * Holds the registration certificate evaluation the OpenID4VP library policy produces while a

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/presentation/PresentationManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/presentation/PresentationManager.kt
@@ -39,12 +39,12 @@ import eu.europa.ec.eudi.wallet.presentation.SessionTerminationFlag.Companion.SE
  * the wallet can generate the response with [eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor.ProcessedRequest.Success.generateResponse]
  * and send it back to the verifier by calling [sendResponse] method.
  *
- * It also extends [ReaderTrustStoreAware] that allows to set the [ReaderTrustStore] that is used
- * to verify the authenticity of the reader.
- *
  * It provides also functionality to start the NFC engagement by calling [enableNFCEngagement]
  * method and stop it by calling [disableNFCEngagement] method.
  *
+ * **Note:** [ReaderTrustStoreAware] is deprecated. Reader trust is now configured at build time
+ * via [eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy] through
+ * [eu.europa.ec.eudi.wallet.EudiWalletConfig.configureReaderAuthentication].
  */
 interface PresentationManager : TransferEvent.Listenable, ReaderTrustStoreAware {
 

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/presentation/PresentationManagerImpl.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/presentation/PresentationManagerImpl.kt
@@ -24,7 +24,6 @@ import eu.europa.ec.eudi.iso18013.transfer.TransferEvent
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Response
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceResponse
 import eu.europa.ec.eudi.wallet.dcapi.DCAPIManager
@@ -40,7 +39,6 @@ import org.jetbrains.annotations.VisibleForTesting
  * Implementation of the [PresentationManager] interface based on the [TransferManager],
  * [OpenId4VpManager], [DCAPIManager] implementations.
  * @property nfcEngagementServiceClass the NFC engagement service class
- * @property readerTrustStore the reader trust store
  */
 class PresentationManagerImpl @JvmOverloads constructor(
     @VisibleForTesting internal val transferManager: TransferManager,
@@ -49,17 +47,14 @@ class PresentationManagerImpl @JvmOverloads constructor(
     override val nfcEngagementServiceClass: Class<out NfcEngagementService>? = null,
 ) : PresentationManager {
 
-    private var _readerTrustStore: ReaderTrustStore? = null
+    @Deprecated(
+        "Reader trust is now configured at build time via ReaderAuthPolicy. " +
+            "This setter is a no-op.",
+        level = DeprecationLevel.WARNING,
+    )
     override var readerTrustStore: ReaderTrustStore?
-        get() = _readerTrustStore
-        set(value) {
-            _readerTrustStore = value
-            if (transferManager is ReaderTrustStoreAware) {
-                transferManager.readerTrustStore = value
-            }
-            openId4vpManager?.readerTrustStore = value
-            dcapiManager?.readerTrustStore = value
-        }
+        get() = null
+        set(_) { /* no-op: trust store is embedded in ReaderAuthPolicy at build time */ }
 
     override fun addTransferEventListener(listener: TransferEvent.Listener) = apply {
         transferManager.addTransferEventListener(listener)

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpManager.kt
@@ -19,8 +19,6 @@ package eu.europa.ec.eudi.wallet.transfer.openId4vp
 import android.net.Uri
 import com.nimbusds.jose.util.Base64URL
 import eu.europa.ec.eudi.iso18013.transfer.TransferEvent
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
 import eu.europa.ec.eudi.iso18013.transfer.response.Response
 import eu.europa.ec.eudi.openid4vp.AuthorizationRequestError
 import eu.europa.ec.eudi.openid4vp.Consensus
@@ -76,16 +74,7 @@ class OpenId4VpManager(
     var listenersExecutor: Executor? = null,
     val ktorHttpClientFactory: (() -> HttpClient)? = null,
     private val registrationCertificatePolicy: RegistrationCertificatePolicy? = null
-) : TransferEvent.Listenable, ReaderTrustStoreAware {
-
-    /**
-     * The trust store used for verifying reader certificates. Delegates to the request processor.
-     */
-    override var readerTrustStore: ReaderTrustStore?
-        get() = requestProcessor.readerTrustStore
-        set(value) {
-            requestProcessor.readerTrustStore = value
-        }
+) : TransferEvent.Listenable {
 
     /**
      * Lazy initialization of the OpenID4VP protocol handler with logging and content negotiation.

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpReaderTrust.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/OpenId4VpReaderTrust.kt
@@ -34,7 +34,7 @@ class OpenId4VpReaderTrustImpl(
         get() = _result
 
     override suspend fun isTrusted(chain: List<X509Certificate>): Boolean {
-        val validationResult = readerTrustStore?.validateCertificationTrustPath(chain) != false
+        val validationResult = readerTrustStore?.validateCertificationTrustPath(chain) == true
         _result = ReaderTrustResult.Processed(chain, validationResult)
         return validationResult
     }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessor.kt
@@ -17,7 +17,7 @@
 package eu.europa.ec.eudi.wallet.transfer.openId4vp.dcql
 
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
-import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreAware
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.openid4vp.Format
@@ -84,17 +84,9 @@ import org.multipaz.sdjwt.credential.SdJwtVcCredential
 class DcqlRequestProcessor(
     private val documentManager: DocumentManager,
     var openid4VpX509CertificateTrust: OpenId4VpReaderTrust,
+    private val readerAuthPolicy: ReaderAuthPolicy,
     private var logger: Logger? = null
-) : RequestProcessor, ReaderTrustStoreAware {
-
-    /**
-     * The trust store used for verifying reader certificates.
-     */
-    override var readerTrustStore: ReaderTrustStore?
-        get() = openid4VpX509CertificateTrust.readerTrustStore
-        set(value) {
-            openid4VpX509CertificateTrust.readerTrustStore = value
-        }
+) : RequestProcessor {
 
     private val credentialSetsMatcher = CredentialSetsMatcher()
 
@@ -168,6 +160,7 @@ class DcqlRequestProcessor(
                 requester = requester,
                 trustMetadata = trustMetadata,
                 msoMdocNonce = generateJarmNonce(),
+                readerAuthPolicy = readerAuthPolicy,
                 multipleByQueryId = multipleByQueryId,
                 wrpRegistration = wrpRegistration
             )
@@ -463,6 +456,7 @@ class DcqlRequestProcessor(
         operator fun invoke(
             documentManager: DocumentManager,
             readerTrustStore: ReaderTrustStore?,
+            readerAuthPolicy: ReaderAuthPolicy,
             logger: Logger? = null
         ): DcqlRequestProcessor {
             val openId4VpReaderTrust = OpenId4VpReaderTrustImpl(
@@ -471,6 +465,7 @@ class DcqlRequestProcessor(
             return DcqlRequestProcessor(
                 documentManager = documentManager,
                 openid4VpX509CertificateTrust = openId4VpReaderTrust,
+                readerAuthPolicy = readerAuthPolicy,
                 logger = logger
             )
         }

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/ProcessedDcqlRequest.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/ProcessedDcqlRequest.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.eudi.wallet.transfer.openId4vp.dcql
 
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.ResponseResult
 import eu.europa.ec.eudi.openid4vp.Consensus
@@ -69,6 +70,7 @@ class ProcessedDcqlRequest(
     requester: Requester,
     trustMetadata: TrustMetadata?,
     val msoMdocNonce: String,
+    private val readerAuthPolicy: ReaderAuthPolicy,
     private val multipleByQueryId: Map<QueryId, Boolean> = emptyMap(),
     wrpRegistration: RegistrationCertificateResult? = null
 ) : RequestProcessor.ProcessedRequest.Success(
@@ -133,6 +135,20 @@ class ProcessedDcqlRequest(
         validateSelection(selection, resolvedRequestObject.query)?.let { error ->
             return ResponseResult.Failure(
                 IllegalStateException("Selection does not satisfy verifier request: $error"),
+            )
+        }
+
+        // Reader authentication policy enforcement
+        val isReaderTrustVerified = trustMetadata != null
+        val readerAuthPresent = requester.certChain != null
+        val rejectByPolicy = when (readerAuthPolicy) {
+            ReaderAuthPolicy.DoNotEnforce -> false
+            is ReaderAuthPolicy.EnforceIfPresent -> readerAuthPresent && !isReaderTrustVerified
+            is ReaderAuthPolicy.AlwaysRequire -> !isReaderTrustVerified
+        }
+        if (rejectByPolicy) {
+            return ResponseResult.Failure(
+                SecurityException("Reader authentication policy rejected the request")
             )
         }
 
@@ -222,6 +238,7 @@ class ProcessedDcqlRequest(
             requester = requester,
             trustMetadata = trustMetadata,
             msoMdocNonce = msoMdocNonce,
+            readerAuthPolicy = readerAuthPolicy,
             multipleByQueryId = multipleByQueryId,
             wrpRegistration = wrpRegistration as? RegistrationCertificateResult
         )

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderAuthenticationConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderAuthenticationConfigBuilder.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.wallet.trust
+
+import android.content.Context
+import androidx.annotation.RawRes
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForEUDIW
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStoreImpl
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.RevocationPolicy
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
+import eu.europa.ec.eudi.wallet.internal.getCertificate
+import eu.europa.ec.eudi.wallet.logging.Logger
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/**
+ * DSL builder for unified reader authentication configuration.
+ *
+ * Replaces the scattered `configureReaderTrustStore` overloads and
+ * `configureReaderAuthPolicy` with a single entry point that bundles trust
+ * material and enforcement intent together.
+ *
+ * The builder is stored at configuration time and executed at
+ * [EudiWallet.Builder.build()][eu.europa.ec.eudi.wallet.EudiWallet] time,
+ * so that deferred trust sources (e.g. ETSI) are available.
+ *
+ * Example:
+ * ```
+ * configureReaderAuthentication {
+ *     trustedCertificates(cert1, cert2)
+ *     revocationPolicy(RevocationPolicy.SoftFail)
+ *     enforceIfPresent()
+ * }
+ * ```
+ *
+ * @see eu.europa.ec.eudi.wallet.EudiWalletConfig.configureReaderAuthentication
+ */
+class ReaderAuthenticationConfigBuilder {
+
+    private enum class Enforcement { DoNotEnforce, EnforceIfPresent, AlwaysRequire }
+
+    private var enforcement = Enforcement.EnforceIfPresent
+
+    private var certificates: List<X509Certificate>? = null
+    private var customTrustStore: ReaderTrustStore? = null
+    private var etsiChainTrust: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>? = null
+    private var revocationPolicy: RevocationPolicy = RevocationPolicy.HardFail
+
+    // --- Trust material setters ---
+
+    fun trustedCertificates(certificates: List<X509Certificate>) {
+        this.certificates = certificates
+    }
+
+    fun trustedCertificates(vararg certificates: X509Certificate) {
+        this.certificates = certificates.toList()
+    }
+
+    fun trustedCertificates(context: Context, @RawRes vararg certificateRes: Int) {
+        this.certificates = certificateRes.map { context.getCertificate(it) }
+    }
+
+    fun trustSource(readerTrustStore: ReaderTrustStore) {
+        this.customTrustStore = readerTrustStore
+    }
+
+    fun trustSource(isChainTrusted: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>) {
+        this.etsiChainTrust = isChainTrusted
+    }
+
+    // --- Enforcement setters ---
+
+    fun doNotEnforce() {
+        enforcement = Enforcement.DoNotEnforce
+    }
+
+    fun enforceIfPresent() {
+        enforcement = Enforcement.EnforceIfPresent
+    }
+
+    fun alwaysRequire() {
+        enforcement = Enforcement.AlwaysRequire
+    }
+
+    // --- Revocation setter ---
+
+    fun revocationPolicy(policy: RevocationPolicy) {
+        this.revocationPolicy = policy
+    }
+
+    /**
+     * Builds the [ReaderAuthPolicy] from the configured trust sources and enforcement.
+     *
+     * Trust source resolution priority:
+     * 1. Custom [ReaderTrustStore] via [trustSource]
+     * 2. Explicit ETSI chain trust via [trustSource] (IsChainTrustedForEUDIW overload)
+     * 3. Static certificates via [trustedCertificates]
+     * 4. Central ETSI trust source from [configureEtsiTrust][eu.europa.ec.eudi.wallet.EudiWalletConfig.configureEtsiTrust]
+     *
+     * @param etsiSource the centrally configured ETSI trust source (may be null)
+     * @param logger the wallet logger for diagnostic output
+     * @return the resolved [ReaderAuthPolicy]
+     * @throws IllegalArgumentException if [enforceIfPresent] or [alwaysRequire] is set
+     *   but no trust source is available
+     */
+    internal fun build(
+        etsiSource: IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>?,
+        logger: Logger,
+    ): ReaderAuthPolicy {
+        val trustStore: ReaderTrustStore? = when {
+            customTrustStore != null -> customTrustStore
+            etsiChainTrust != null -> etsiChainTrust!!.asReaderTrustStore()
+            certificates != null -> ReaderTrustStoreImpl(
+                certificates!!,
+                profileValidation = { _, _ -> true },
+                revocationPolicy = revocationPolicy,
+            )
+            etsiSource != null -> etsiSource.asReaderTrustStore()
+            else -> null
+        }?.also { if (it is EtsiReaderTrustStore) it.logger = logger }
+
+        return when (enforcement) {
+            Enforcement.DoNotEnforce -> ReaderAuthPolicy.DoNotEnforce
+            Enforcement.EnforceIfPresent -> {
+                requireNotNull(trustStore) {
+                    "enforceIfPresent() requires trust sources. " +
+                        "Call trustedCertificates() or trustSource(), or use doNotEnforce() to opt out."
+                }
+                ReaderAuthPolicy.EnforceIfPresent(trustStore)
+            }
+            Enforcement.AlwaysRequire -> {
+                requireNotNull(trustStore) {
+                    "alwaysRequire() requires trust sources. " +
+                        "Call trustedCertificates() or trustSource()."
+                }
+                ReaderAuthPolicy.AlwaysRequire(trustStore)
+            }
+        }
+    }
+}

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderTrustConfigBuilder.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/trust/ReaderTrustConfigBuilder.kt
@@ -29,6 +29,10 @@ import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
  * }
  * ```
  */
+@Deprecated(
+    message = "Use configureReaderAuthentication { ... } instead.",
+    replaceWith = ReplaceWith("ReaderAuthenticationConfigBuilder"),
+)
 class ReaderTrustConfigBuilder {
 
     internal var readerAuthPolicy: ReaderAuthPolicy? = null

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/EudiWalletBuilderTest.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.eudi.wallet
 import android.content.Context
 import eu.europa.ec.eudi.iso18013.transfer.TransferManager
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.issue.openid4vci.reissue.DocumentManagerWithMetadataCleanup
 import eu.europa.ec.eudi.wallet.logging.Logger
@@ -62,6 +63,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns mockk(relaxed = true)
@@ -76,7 +78,7 @@ class EudiWalletBuilderTest {
         // Verify
         assertIs<EudiWalletImpl>(wallet)
         verify(exactly = 1) { builder.getDefaultDocumentManager(null, null) }
-        verify(exactly = 1) { builder.getTransferManager(any(), null) }
+        verify(exactly = 1) { builder.getTransferManager(any(), any<ReaderAuthPolicy>()) }
         verify(exactly = 1) { builder.getDocumentStatusResolver(any()) }
     }
 
@@ -94,6 +96,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customSecureArea: SecureArea = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -130,6 +133,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customStorageEngine: Storage = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -165,6 +169,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customDocumentManager: DocumentManager = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -181,11 +186,11 @@ class EudiWalletBuilderTest {
         // documentManager is wrapped with DocumentManagerWithMetadataCleanup for metadata cleanup
         assertIs<DocumentManagerWithMetadataCleanup>(wallet.documentManager)
         verify(exactly = 0) { builder.getDefaultDocumentManager(any(), any()) }
-        verify(exactly = 1) { builder.getTransferManager(any(), null) }
+        verify(exactly = 1) { builder.getTransferManager(any(), any<ReaderAuthPolicy>()) }
     }
 
     @Test
-    fun `withReaderTrustStore should use custom reader trust store`() {
+    fun `configureReaderAuthentication should produce correct policy`() {
         // Setup
         val context: Context = mockk {
             every { applicationContext } returns this
@@ -197,17 +202,22 @@ class EudiWalletBuilderTest {
             every { strongBoxSupported } returns true
         }
 
-        val config = EudiWalletConfig()
         val customReaderTrustStore: ReaderTrustStore = mockk()
+        val config = EudiWalletConfig()
+                .configureReaderAuthentication {
+                    trustSource(customReaderTrustStore)
+                    enforceIfPresent()
+                }
         val documentManager: DocumentManager = mockk(relaxed = true)
         val transferManager: TransferManager = mockk(relaxed = true)
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
             every { getDefaultDocumentManager(any(), any()) } returns documentManager
-            every { getTransferManager(any(), any()) } answers {
-                // Verify reader trust store is passed to transfer manager
-                val readerTrustStore = secondArg<ReaderTrustStore?>()
-                assertEquals(customReaderTrustStore, readerTrustStore)
+            every { getTransferManager(any(), any(), any()) } answers {
+                // Verify reader auth policy carries the custom trust store
+                val policy = secondArg<ReaderAuthPolicy>()
+                assertIs<ReaderAuthPolicy.EnforceIfPresent>(policy)
+                assertEquals(customReaderTrustStore, policy.readerTrustStore)
                 transferManager
             }
             every { getDocumentStatusResolver(any()) } returns mockk(relaxed = true)
@@ -215,11 +225,11 @@ class EudiWalletBuilderTest {
         }
 
         // Execute
-        val wallet = builder.withReaderTrustStore(customReaderTrustStore).build()
+        val wallet = builder.build()
 
         // Verify
         assertIs<EudiWalletImpl>(wallet)
-        verify(exactly = 1) { builder.getTransferManager(any(), customReaderTrustStore, any()) }
+        verify(exactly = 1) { builder.getTransferManager(any(), any<ReaderAuthPolicy>(), any()) }
     }
 
     @Test
@@ -236,6 +246,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customPresentationManager: PresentationManager = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -243,6 +254,7 @@ class EudiWalletBuilderTest {
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
             every {
                 getDefaultPresentationManager(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -259,7 +271,7 @@ class EudiWalletBuilderTest {
         // Verify
         assertIs<EudiWalletImpl>(wallet)
         assertEquals(customPresentationManager, wallet.presentationManager)
-        verify(exactly = 0) { builder.getDefaultPresentationManager(any(), any(), any(), any()) }
+        verify(exactly = 0) { builder.getDefaultPresentationManager(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -276,6 +288,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customLogger: Logger = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -307,6 +320,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customHttpClientFactory: () -> HttpClient = { mockk() }
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -341,6 +355,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customTransactionLogger: TransactionLogger = mockk()
         val documentManager: DocumentManager = mockk(relaxed = true)
         val defaultPresentationManager: PresentationManagerImpl = mockk(relaxed = true)
@@ -350,6 +365,7 @@ class EudiWalletBuilderTest {
             every { getTransferManager(any(), any()) } returns mockk(relaxed = true)
             every {
                 getDefaultPresentationManager(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -391,6 +407,7 @@ class EudiWalletBuilderTest {
         }
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
         val customDocumentStatusResolver: DocumentStatusResolver = mockk()
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {
@@ -430,6 +447,7 @@ class EudiWalletBuilderTest {
             .build()
 
         val config = EudiWalletConfig()
+                .configureReaderAuthentication { doNotEnforce() }
             .configureOpenId4Vp(openId4VpConfig)
 
         val builder = spyk(EudiWallet.Builder(context, config, null)) {

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorHolderBindingTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorHolderBindingTest.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.openid4vp.dcql.Credentials
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.dcql.DCQLMetaSdJwtVcExtensions
 import eu.europa.ec.eudi.openid4vp.dcql.QueryId
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
@@ -252,7 +253,7 @@ class DcqlRequestProcessorHolderBindingTest {
             every { readerTrustStore } returns null
             every { readerTrustStore = any() } returns Unit
         }
-        return DcqlRequestProcessor(documentManager, trust)
+        return DcqlRequestProcessor(documentManager, trust, ReaderAuthPolicy.DoNotEnforce)
     }
 
     private fun buildOpenId4VpRequest(dcql: DCQL): OpenId4VpRequest {

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/DcqlRequestProcessorTest.kt
@@ -30,6 +30,7 @@ import eu.europa.ec.eudi.openid4vp.dcql.DCQLMetaMsoMdocExtensions
 import eu.europa.ec.eudi.openid4vp.dcql.DCQLMetaSdJwtVcExtensions
 import eu.europa.ec.eudi.openid4vp.dcql.MsoMdocDocType
 import eu.europa.ec.eudi.openid4vp.dcql.QueryId
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.DocumentFormat
@@ -860,7 +861,7 @@ class DcqlRequestProcessorTest {
             every { readerTrustStore } returns null
             every { readerTrustStore = any() } returns Unit
         }
-        return DcqlRequestProcessor(documentManager, trust)
+        return DcqlRequestProcessor(documentManager, trust, ReaderAuthPolicy.DoNotEnforce)
     }
 
     /**
@@ -946,7 +947,7 @@ class DcqlRequestProcessorTest {
             every { readerTrustStore } returns null
             every { readerTrustStore = any() } returns Unit
         }
-        return DcqlRequestProcessor(documentManager, trust)
+        return DcqlRequestProcessor(documentManager, trust, ReaderAuthPolicy.DoNotEnforce)
     }
 
     /**
@@ -976,7 +977,7 @@ class DcqlRequestProcessorTest {
             every { readerTrustStore } returns null
             every { readerTrustStore = any() } returns Unit
         }
-        return DcqlRequestProcessor(documentManager, trust)
+        return DcqlRequestProcessor(documentManager, trust, ReaderAuthPolicy.DoNotEnforce)
     }
 
     /**

--- a/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/ProcessedDcqlRequestTest.kt
+++ b/wallet-core/src/test/java/eu/europa/ec/eudi/wallet/transfer/openId4vp/dcql/ProcessedDcqlRequestTest.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.wallet.transfer.openId4vp.dcql
 
+import eu.europa.ec.eudi.iso18013.transfer.response.ReaderAuthPolicy
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificate
 import eu.europa.ec.eudi.wallet.registration.RegistrationCertificateResult
 import io.mockk.mockk
@@ -36,6 +37,7 @@ class ProcessedDcqlRequestTest {
             requester = mockk(relaxed = true),
             trustMetadata = null,
             msoMdocNonce = "nonce",
+            readerAuthPolicy = ReaderAuthPolicy.DoNotEnforce,
             wrpRegistration = registration,
         )
 


### PR DESCRIPTION
- Replace all configureReaderTrustStore overloads and configureReaderAuthPolicy with a single configureReaderAuthentication { } DSL that bundles trust sources and enforcement intent together
- Embed ReaderTrustStore into ReaderAuthPolicy sealed variants
- Add reader authentication enforcement to the OpenID4VP/DCQL path (previously only proximity enforced)
- Fix fail-open bug in OpenId4VpReaderTrustImpl.isTrusted() (!= false → == true)
- Remove ReaderTrustStoreAware from all internal components

Breaking Changes

ReaderAuthPolicy (transfer-manager)

- DoNotEnforce changed from data object to data object (no embedded store)
- EnforceIfPresent changed from data object to data class(val readerTrustStore: ReaderTrustStore), now requires a trust store
- AlwaysRequire changed from data object to data class(val readerTrustStore: ReaderTrustStore), now requires a trust store

TransferManager (transfer-manager)

- getDefault() and Builder: removed readerTrustStore parameter, trust store is now carried by ReaderAuthPolicy
- TransferManagerImpl no longer implements ReaderTrustStoreAware

DeviceRequestProcessor (transfer-manager)

- Removed readerTrustStore constructor parameter, trust store is derived from readerAuthPolicy.readerTrustStore
- No longer implements ReaderTrustStoreAware

EudiWalletConfig (wallet-core)

- configureReaderTrustStore(...), all 6 overloads removed
- configureReaderAuthPolicy(ReaderAuthPolicy) — removed
- readerAuthPolicy property — removed
- Replaced by configureReaderAuthentication { } DSL

EudiWallet / EudiWalletImpl (wallet-core)

- setReaderTrustStore(ReaderTrustStore), deprecated no-op
- setTrustedReaderCertificates(List<X509Certificate>),deprecated no-op
- Builder.withReaderTrustStore(ReaderTrustStore), deprecated no-op

Internal components (wallet-core)

- ReaderTrustStoreAware removed from: OpenId4VpManager, DcqlRequestProcessor, DCAPIManager, OpenId4VpDCAPIRequestProcessor
- PresentationManagerImpl.readerTrustStore — deprecated no-op setter/getter
- ReaderTrustConfigBuilder — deprecated at class level

New behavior

- OpenId4VpReaderTrustImpl.isTrusted() now fails closed (returns false when trust store is null)
- OpenID4VP requests are now subject to ReaderAuthPolicy enforcement (same as proximity)
- configureReaderAuthentication { } with default enforcement (enforceIfPresent) but no trust sources throws IllegalArgumentException at build time, callers must explicitly set doNotEnforce() to opt out

Migration

// Before
EudiWalletConfig()
    .configureReaderTrustStore(listOf(cert1, cert2))
    .configureReaderAuthPolicy(ReaderAuthPolicy.EnforceIfPresent)

// After
EudiWalletConfig()
    .configureReaderAuthentication {
        trustedCertificates(cert1, cert2)
        enforceIfPresent()  // default can be omitted
    }

When using ETSI trusted lists via configureEtsiTrust { }, the trust source is automatically resolved at build time, no explicit trustSource() call needed:

configureEtsiTrust { loteLocations(...) }
configureReaderAuthentication {
    alwaysRequire()
    revocationPolicy(RevocationPolicy.SoftFail)
}